### PR TITLE
improve semantic versioning

### DIFF
--- a/CMake/version.cmake
+++ b/CMake/version.cmake
@@ -2,7 +2,8 @@ set(tmp)
 find_package(Git QUIET)
 if(GIT_FOUND)
     execute_process(COMMAND ${GIT_EXECUTABLE}
-        --git-dir=${CMAKE_SOURCE_DIR}/.git describe --tags
+        --git-dir=${CMAKE_SOURCE_DIR}/.git describe
+        --tags --match "[0-9]*.[0-9]*.[0-9]*"
         OUTPUT_VARIABLE tmp OUTPUT_STRIP_TRAILING_WHITESPACE
         ERROR_QUIET)
 endif()


### PR DESCRIPTION
Make git ignore tags that do not follow the semantic versioning format.

Note: a tag w/ semantic versioning format  should be added to the repo before/when this is merged. I suggest 0.1.0 pointing to the existing tag 19sept22