### PR TITLE
No unsigned indexing

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -79,7 +79,15 @@ make -j install  # might need "sudo make -j install"
 ctest  # run unit tests (only if GTest was found by CMake)
 ```
 
-Here are the conceptual meanings in the recipe's build flags:
+If you're running macOS, then it may be necessary to specify
+an additional flag to CMake
+```shell
+     -DCMAKE_CXX_FLAGS="-D __APPLE__"
+```
+This flag is needed to avoid compiler errors with the "sincosf" and "sincos"
+functions in "dense_op.cc".
+
+Here are the conceptual meanings of the recipe's other build flags:
 
 * `-Dblaspp_DIR=X` means `X` is the directory containing the file `blasppConfig.cmake`.
    

--- a/include/RandBLAS/sjlts.hh
+++ b/include/RandBLAS/sjlts.hh
@@ -12,17 +12,17 @@ enum sjlt_orientation {ColumnWise, RowWise};
 
 struct SJLT {
     sjlt_orientation ori;
-    uint64_t n_rows;
-    uint64_t n_cols;
-    uint64_t vec_nnz;
-    uint64_t *rows;
-    uint64_t *cols;
+    int64_t n_rows;
+    int64_t n_cols;
+    int64_t vec_nnz;
+    int64_t *rows;
+    int64_t *cols;
     double *vals;
 };
 
 void fill_colwise(SJLT sjl, uint64_t seed_key, uint64_t seed_ctr);
 
-void sketch_cscrow(SJLT sjl, uint64_t n, double *a, double *a_hat, int threads);
+void sketch_cscrow(SJLT sjl, int64_t n, double *a, double *a_hat, int threads);
 
 void sketch_csccol(SJLT sjl, int64_t m, int64_t n, double *a, double *a_hat);
 

--- a/include/RandBLAS/util.hh
+++ b/include/RandBLAS/util.hh
@@ -20,7 +20,7 @@ void genmat(
 //void print_colmaj(uint64_t n_rows, uint64_t n_cols, double *a, char label[]);
 
 template <typename T>
-void print_colmaj(uint64_t n_rows, uint64_t n_cols, T *a, char label[]);
+void print_colmaj(int64_t n_rows, int64_t n_cols, T *a, char label[]);
 
 } // end namespace RandBLAS::util
 

--- a/src/dense_op.cc
+++ b/src/dense_op.cc
@@ -7,8 +7,13 @@
 #include <math.h>
 #include <typeinfo>
 
-// The following functions are in some standard math libraries,
-// but are missing from Apple's.
+#if !defined(R123_NO_SINCOS) && defined(__APPLE__)
+/* MacOS X 10.10.5 (2015) doesn't have sincosf */
+// use "-D __APPLE__" as a compiler flag to make sure this is hit.
+#define R123_NO_SINCOS 1
+#endif
+
+#if R123_NO_SINCOS /* enable this if sincos and sincosf are not in the math library */
 static inline void sincosf(float x, float *s, float *c) {
     *s = sinf(x);
     *c = cosf(x);
@@ -18,6 +23,7 @@ static inline void sincos(double x, double *s, double *c) {
     *s = sin(x);
     *c = cos(x);
 }
+#endif /* sincos is not in the math library */
 
 
 // The following two functions are part of NVIDIA device side math library.

--- a/src/dense_op.cc
+++ b/src/dense_op.cc
@@ -7,10 +7,24 @@
 #include <math.h>
 #include <typeinfo>
 
+// The following functions are in some standard math libraries,
+// but are missing from Apple's.
+static inline void sincosf(float x, float *s, float *c) {
+    *s = sinf(x);
+    *c = cosf(x);
+}
+
+static inline void sincos(double x, double *s, double *c) {
+    *s = sin(x);
+    *c = cos(x);
+}
+
+
 // The following two functions are part of NVIDIA device side math library.
 // Random123 relies on them in both host and device sources.  We can work
 // around this by defining them when not compiling device code.
 #if !defined(__CUDACC__)
+
 static inline void sincospif(float x, float *s, float *c) {
     const float PIf = 3.1415926535897932f;
     sincosf(PIf*x, s, c);

--- a/src/sjlts.cc
+++ b/src/sjlts.cc
@@ -15,20 +15,20 @@ void fill_colwise(SJLT sjl, uint64_t seed_key, uint64_t seed_ctr) {
     // Use Fisher-Yates
 
     // Load shorter names into the workspace
-    uint64_t k = sjl.vec_nnz;
-    uint64_t n_rows = sjl.n_rows;
-    uint64_t n_cols = sjl.n_cols; 
+    int64_t k = sjl.vec_nnz;
+    int64_t n_rows = sjl.n_rows;
+    int64_t n_cols = sjl.n_cols; 
     double *vals = sjl.vals; // point to array of length nnz 
-    uint64_t *cols = sjl.cols; // point to array of length nnz.
-    uint64_t *rows = sjl.rows; // point to array of length nnz.
+    int64_t *cols = sjl.cols; // point to array of length nnz.
+    int64_t *rows = sjl.rows; // point to array of length nnz.
 
     // Define variables needed in the main loop
-    uint64_t i, j, ell, swap, offset;
-    uint64_t row_work[n_rows];
+    int64_t i, j, ell, swap, offset;
+    int64_t row_work[n_rows];
     for (j = 0; j < n_rows; ++j) {
         row_work[j] = j;
     }
-    uint64_t pivots[k];
+    int64_t pivots[k];
     typedef r123::Threefry2x64 CBRNG;
 	CBRNG::key_type key = {{seed_key}};
 	CBRNG::ctr_type ctr = {{seed_ctr, 0}};
@@ -82,7 +82,7 @@ void print_sjlt(SJLT sjl)
     std::cout << "SJLT information" << std::endl;
     std::cout << "\tn_rows = " << sjl.n_rows << std::endl;
     std::cout << "\tn_cols = " << sjl.n_cols << std::endl;
-    uint64_t nnz;
+    int64_t nnz;
     if (sjl.ori == ColumnWise)
     {
         std::cout << "\torientation: ColumnWise" << std::endl;
@@ -94,24 +94,24 @@ void print_sjlt(SJLT sjl)
         nnz = sjl.vec_nnz *  sjl.n_rows;
     }
     std::cout << "\tvector of row indices\n\t\t";
-    for (uint64_t i = 0; i < nnz; ++i) {
+    for (int64_t i = 0; i < nnz; ++i) {
         std::cout << sjl.rows[i] << ", ";
     }
     std::cout << std::endl;
     std::cout << "\tvector of column indices\n\t\t";
-    for (uint64_t i = 0; i < nnz; ++i) {
+    for (int64_t i = 0; i < nnz; ++i) {
         std::cout << sjl.cols[i] << ", ";
     }
     std::cout << std::endl;
     std::cout << "\tvector of values\n\t\t";
-    for (uint64_t i = 0; i < nnz; ++i) {
+    for (int64_t i = 0; i < nnz; ++i) {
         std::cout << sjl.vals[i] << ", ";
     }
     std::cout << std::endl;
 }
 
 
-void sketch_cscrow(SJLT sjl, uint64_t n, double *a, double *a_hat, int threads){
+void sketch_cscrow(SJLT sjl, int64_t n, double *a, double *a_hat, int threads){
 
 	// Identify the range of rows to be processed by each thread.
     int avg = sjl.n_rows / threads;

--- a/src/util.cc
+++ b/src/util.cc
@@ -29,9 +29,9 @@ void genmat(
 }
 
 template <typename T>
-void print_colmaj(uint64_t n_rows, uint64_t n_cols, T *a, char label[])
+void print_colmaj(int64_t n_rows, int64_t n_cols, T *a, char label[])
 {
-	uint64_t i, j;
+	int64_t i, j;
     T val;
 	std::cout << "\n" << label << std::endl;
     for (i = 0; i < n_rows; ++i) {
@@ -62,8 +62,8 @@ void print_colmaj(uint64_t n_rows, uint64_t n_cols, T *a, char label[])
 }
 
 
-template void print_colmaj<float>(uint64_t n_rows, uint64_t n_cols, float *a, char label[]);
-template void print_colmaj<double>(uint64_t n_rows, uint64_t n_cols, double *a, char label[]);
+template void print_colmaj<float>(int64_t n_rows, int64_t n_cols, float *a, char label[]);
+template void print_colmaj<double>(int64_t n_rows, int64_t n_cols, double *a, char label[]);
 
 template void genmat<float>(int64_t n_rows, int64_t n_cols, float* mat, uint64_t seed);
 template void genmat<double>(int64_t n_rows, int64_t n_cols, double* mat, uint64_t seed);

--- a/test/src/test_sjlts.cc
+++ b/test/src/test_sjlts.cc
@@ -10,8 +10,8 @@ class TestSJLTConstruction : public ::testing::Test
 {
     // only tests column-sparse SJLTs for now.
     protected:
-        uint64_t d = 7;
-        uint64_t m = 20;
+        int64_t d = 7;
+        int64_t m = 20;
         std::vector<uint64_t> keys = {42, 0, 1};
         std::vector<uint64_t> vec_nnzs = {1, 2, 3, 7};     
     
@@ -19,29 +19,29 @@ class TestSJLTConstruction : public ::testing::Test
 
     virtual void TearDown() {};
 
-    virtual void proper_construction(uint64_t key_index, uint64_t nnz_index)
+    virtual void proper_construction(int64_t key_index, int64_t nnz_index)
     {
         struct RandBLAS::sjlts::SJLT sjl;
         sjl.ori = RandBLAS::sjlts::ColumnWise;
         sjl.n_rows = d; // > n
         sjl.n_cols = m;
         sjl.vec_nnz = vec_nnzs[nnz_index]; // <= n_rows
-        sjl.rows = new uint64_t[sjl.vec_nnz * m];
-        sjl.cols = new uint64_t[sjl.vec_nnz * m];
+        sjl.rows = new int64_t[sjl.vec_nnz * m];
+        sjl.cols = new int64_t[sjl.vec_nnz * m];
         sjl.vals = new double[sjl.vec_nnz * m];
         RandBLAS::sjlts::fill_colwise(sjl, keys[key_index], 0);
 
         // check that each block of sjl.vec_nnz entries of sjl.rows is
         // sampled without replacement from 0,...,n_rows - 1.
-        std::set<uint64_t> s;
-        uint64_t offset = 0;
-        for (uint64_t i = 0; i < sjl.n_cols; ++i)
+        std::set<int64_t> s;
+        int64_t offset = 0;
+        for (int64_t i = 0; i < sjl.n_cols; ++i)
         {
             offset = sjl.vec_nnz * i;
             s.clear();
-            for (uint64_t j = 0; j < sjl.vec_nnz; ++j)
+            for (int64_t j = 0; j < sjl.vec_nnz; ++j)
             {
-                uint64_t row = sjl.rows[offset + j];
+                int64_t row = sjl.rows[offset + j];
                 ASSERT_EQ(s.count(row), 0);
                 s.insert(row);
             }
@@ -81,11 +81,11 @@ TEST_F(TestSJLTConstruction, Dim7by20nnz7)
 
 void sjlt_to_dense_rowmajor(RandBLAS::sjlts::SJLT sjl, double *mat)
 {
-    uint64_t nnz = sjl.n_cols * sjl.vec_nnz;
-    for (uint64_t i = 0; i < nnz; ++i)
+    int64_t nnz = sjl.n_cols * sjl.vec_nnz;
+    for (int64_t i = 0; i < nnz; ++i)
     {
-        uint64_t row = sjl.rows[i];
-        uint64_t col = sjl.cols[i];
+        int64_t row = sjl.rows[i];
+        int64_t col = sjl.cols[i];
         double val = sjl.vals[i];
         mat[row * sjl.n_cols + col] = val;
     }
@@ -97,9 +97,9 @@ class TestApplyCscRowMaj : public ::testing::Test
 {
     // only tests column-sparse SJLTs for now.
     protected:
-        uint64_t d = 19;
-        uint64_t m = 201;
-        uint64_t n = 12;
+        int64_t d = 19;
+        int64_t m = 201;
+        int64_t n = 12;
         std::vector<uint64_t> keys = {42, 0, 1};
         std::vector<uint64_t> vec_nnzs = {1, 2, 3, 7, 19};     
     
@@ -107,7 +107,7 @@ class TestApplyCscRowMaj : public ::testing::Test
 
     virtual void TearDown() {};
 
-    virtual void apply(uint64_t key_index, uint64_t nnz_index, int threads)
+    virtual void apply(int64_t key_index, int64_t nnz_index, int threads)
     {
         uint64_t a_seed = 99;
 
@@ -121,14 +121,14 @@ class TestApplyCscRowMaj : public ::testing::Test
         sjl.n_rows = d; // > n
         sjl.n_cols = m;
         sjl.vec_nnz = vec_nnzs[nnz_index]; // <= n_rows
-        sjl.rows = new uint64_t[sjl.vec_nnz * m];
-        sjl.cols = new uint64_t[sjl.vec_nnz * m];
+        sjl.rows = new int64_t[sjl.vec_nnz * m];
+        sjl.cols = new int64_t[sjl.vec_nnz * m];
         sjl.vals = new double[sjl.vec_nnz * m];
         RandBLAS::sjlts::fill_colwise(sjl, keys[key_index], 0);
         
         // compute S*A. 
         double *a_hat = new double[d * n];
-        for (uint64_t i = 0; i < d * n; ++i)
+        for (int64_t i = 0; i < d * n; ++i)
         {
             a_hat[i] = 0.0;
         }
@@ -149,11 +149,11 @@ class TestApplyCscRowMaj : public ::testing::Test
 
         // check the result
         double reldtol = RELDTOL;
-        for (uint64_t i = 0; i < d; ++i)
+        for (int64_t i = 0; i < d; ++i)
         {
-            for (uint64_t j = 0; j < n; ++j)
+            for (int64_t j = 0; j < n; ++j)
             {
-                uint64_t ell = i*n + j;
+                int64_t ell = i*n + j;
                 double expect = a_hat_expect[ell];
                 double actual = a_hat[ell];
                 double atol = reldtol * std::min(abs(actual), abs(expect));
@@ -167,9 +167,9 @@ class TestApplyCscRowMaj : public ::testing::Test
 
 TEST_F(TestApplyCscRowMaj, OneThread)
 {
-    for (uint64_t k_idx : {0, 1, 2})
+    for (int64_t k_idx : {0, 1, 2})
     {
-        for (uint64_t nz_idx: {4, 1, 2, 3, 0})
+        for (int64_t nz_idx: {4, 1, 2, 3, 0})
         {
             apply(k_idx, nz_idx, 1);
         }
@@ -178,9 +178,9 @@ TEST_F(TestApplyCscRowMaj, OneThread)
 
 TEST_F(TestApplyCscRowMaj, TwoThreads)
 {
-    for (uint64_t k_idx : {0, 1, 2})
+    for (int64_t k_idx : {0, 1, 2})
     {
-        for (uint64_t nz_idx: {4, 1, 2, 3, 0})
+        for (int64_t nz_idx: {4, 1, 2, 3, 0})
         {
             apply(k_idx, nz_idx, 2);
         }


### PR DESCRIPTION
Remove unsigned row and column index arrays in SJLTs, and in function signatures for dense operators.

Merging this will probably break RandLAPACK code, so I won't do so until a similar PR is staged for RandLAPACK.