### PR TITLE
Template numerical precision for SASOs

### DIFF
--- a/.github/workflows/core-linux.yaml
+++ b/.github/workflows/core-linux.yaml
@@ -60,4 +60,4 @@ jobs:
             -DCMAKE_BINARY_DIR=`pwd` \
             `pwd`/../RandBLAS
           make -j2 install
-          ctest --verbose
+          ctest --output-on-failure

--- a/.github/workflows/core-linux.yaml
+++ b/.github/workflows/core-linux.yaml
@@ -60,4 +60,4 @@ jobs:
             -DCMAKE_BINARY_DIR=`pwd` \
             `pwd`/../RandBLAS
           make -j2 install
-          ctest --output-on-failure
+          ctest --verbose

--- a/CMake/build_options.cmake
+++ b/CMake/build_options.cmake
@@ -1,4 +1,4 @@
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 option(BUILD_SHARED_LIBS OFF "Configure to build shared or static libraries")

--- a/include/RandBLAS/sasos.hh
+++ b/include/RandBLAS/sasos.hh
@@ -12,12 +12,14 @@ struct SASO {
     int64_t n_rows;
     int64_t n_cols;
     int64_t vec_nnz;
-    int64_t *rows;
-    int64_t *cols;
-    double *vals;
+    uint64_t key = 0;
+    uint64_t ctr = 0;
+    int64_t *rows = NULL;
+    int64_t *cols = NULL;
+    double *vals = NULL;
 };
 
-void fill_colwise(SASO sas, uint64_t seed_key, uint64_t seed_ctr);
+void fill_colwise(SASO sas);
 
 void sketch_cscrow(SASO sas, int64_t n, double *a, double *a_hat, int threads);
 

--- a/include/RandBLAS/sasos.hh
+++ b/include/RandBLAS/sasos.hh
@@ -8,6 +8,7 @@
 
 namespace RandBLAS::sasos {
 
+template <typename T>
 struct SASO {
     int64_t n_rows;
     int64_t n_cols;
@@ -16,16 +17,20 @@ struct SASO {
     uint64_t ctr = 0;
     int64_t *rows = NULL;
     int64_t *cols = NULL;
-    double *vals = NULL;
+    T *vals = NULL;
 };
 
-void fill_colwise(SASO sas);
+template <typename T>
+void fill_colwise(SASO<T> &sas);
 
-void sketch_cscrow(SASO sas, int64_t n, double *a, double *a_hat, int threads);
+template <typename T>
+void sketch_cscrow(SASO<T> &sas, int64_t n, T *a, T *a_hat, int threads);
 
-void sketch_csccol(SASO sas, int64_t m, double *a, double *a_hat, int threads);
+template <typename T>
+void sketch_csccol(SASO<T> &sas, int64_t m, T *a, T *a_hat, int threads);
 
-void print_saso(SASO sas);
+template <typename T>
+void print_saso(SASO<T> &sas);
 
 } // end namespace RandBLAS::sasos
 

--- a/src/sasos.cc
+++ b/src/sasos.cc
@@ -13,7 +13,9 @@
 
 namespace RandBLAS::sasos {
 
-void fill_colwise(SASO sas, uint64_t seed_key, uint64_t seed_ctr) {
+void fill_colwise(SASO sas) {
+    uint64_t seed_ctr = sas.ctr;
+    uint64_t seed_key = sas.key;
     // Use Fisher-Yates
 
     // Load shorter names into the workspace

--- a/src/sasos.cc
+++ b/src/sasos.cc
@@ -110,9 +110,9 @@ template <typename T>
 void sketch_cscrow(SASO<T>& sas, int64_t n, T *a, T *a_hat, int threads){
 
 	// Identify the range of rows to be processed by each thread.
-    int avg = sas.n_rows / threads;
+    int64_t avg = sas.n_rows / threads;
     if (avg == 0) avg = 1; // this is unusual, but can happen in small experiments.
-	int blocks[threads + 1];
+	int64_t blocks[threads + 1];
 	blocks[0] = 0;
     for(int i = 1; i < threads + 1; ++i)
 		blocks[i] = blocks[i - 1] + avg;
@@ -123,16 +123,16 @@ void sketch_cscrow(SASO<T>& sas, int64_t n, T *a, T *a_hat, int threads){
 	{
 		int my_id = omp_get_thread_num();
 		#pragma omp for schedule(static)
-		for(int outer = 0; outer < threads; ++outer)
+		for(int64_t outer = 0; outer < threads; ++outer)
         {
-			for(int c = 0; c < sas.n_cols; ++c)
+			for(int64_t c = 0; c < sas.n_cols; ++c)
             {
 				T *a_row = &a[c * n];
-				int offset = c * sas.vec_nnz;
-                for (int r = 0; r < sas.vec_nnz; ++r)
+				int64_t offset = c * sas.vec_nnz;
+                for (int64_t r = 0; r < sas.vec_nnz; ++r)
                 {
-					int inner = offset + r;
-					int row = sas.rows[inner];
+					int64_t inner = offset + r;
+					int64_t row = sas.rows[inner];
 					if(row >= blocks[my_id] && row < blocks[my_id + 1])
                     {
 						T scale = sas.vals[inner];
@@ -153,7 +153,7 @@ void sketch_csccol(SASO<T>& sas, int64_t n, T *a, T *a_hat, int threads){
 		#pragma omp for schedule(static)
 		for(int64_t k = 0; k < n; k++){
 			T *a_col = &a[m * k];
-			for(int c = 0; c < m; c++){
+			for(int64_t c = 0; c < m; c++){
 				T scale = a_col[c];
 				for (int64_t r = c * sas.vec_nnz; r < (c + 1) * sas.vec_nnz; r++){
                     int64_t row = sas.rows[r];

--- a/src/sasos.cc
+++ b/src/sasos.cc
@@ -13,7 +13,8 @@
 
 namespace RandBLAS::sasos {
 
-void fill_colwise(SASO sas) {
+template <typename T>
+void fill_colwise(SASO<T>& sas) {
     uint64_t seed_ctr = sas.ctr;
     uint64_t seed_key = sas.key;
     // Use Fisher-Yates
@@ -22,7 +23,7 @@ void fill_colwise(SASO sas) {
     int64_t k = sas.vec_nnz;
     int64_t n_rows = sas.n_rows;
     int64_t n_cols = sas.n_cols; 
-    double *vals = sas.vals; // point to array of length nnz 
+    T *vals = sas.vals; // point to array of length nnz 
     int64_t *cols = sas.cols; // point to array of length nnz.
     int64_t *rows = sas.rows; // point to array of length nnz.
 
@@ -81,7 +82,8 @@ void fill_colwise(SASO sas) {
     return;
 }
 
-void print_saso(SASO sas)
+template <typename T>
+void print_saso(SASO<T>& sas)
 {
     std::cout << "SASO information" << std::endl;
     std::cout << "\tn_rows = " << sas.n_rows << std::endl;
@@ -104,7 +106,8 @@ void print_saso(SASO sas)
     std::cout << std::endl;
 }
 
-void sketch_cscrow(SASO sas, int64_t n, double *a, double *a_hat, int threads){
+template <typename T>
+void sketch_cscrow(SASO<T>& sas, int64_t n, T *a, T *a_hat, int threads){
 
 	// Identify the range of rows to be processed by each thread.
     int avg = sas.n_rows / threads;
@@ -124,7 +127,7 @@ void sketch_cscrow(SASO sas, int64_t n, double *a, double *a_hat, int threads){
         {
 			for(int c = 0; c < sas.n_cols; ++c)
             {
-				double *a_row = &a[c * n];
+				T *a_row = &a[c * n];
 				int offset = c * sas.vec_nnz;
                 for (int r = 0; r < sas.vec_nnz; ++r)
                 {
@@ -132,8 +135,8 @@ void sketch_cscrow(SASO sas, int64_t n, double *a, double *a_hat, int threads){
 					int row = sas.rows[inner];
 					if(row >= blocks[my_id] && row < blocks[my_id + 1])
                     {
-						double scale = sas.vals[inner];
-                        blas::axpy(n, scale, a_row, 1, &a_hat[row * n], 1);
+						T scale = sas.vals[inner];
+                        blas::axpy<T>(n, scale, a_row, 1, &a_hat[row * n], 1);
 					}	
 				} // end processing of column c
 			}
@@ -141,16 +144,17 @@ void sketch_cscrow(SASO sas, int64_t n, double *a, double *a_hat, int threads){
 	}
 }
 
-void sketch_csccol(SASO sas, int64_t n, double *a, double *a_hat, int threads){
+template <typename T>
+void sketch_csccol(SASO<T>& sas, int64_t n, T *a, T *a_hat, int threads){
     int64_t m = sas.n_cols;
     omp_set_num_threads(threads);
 	#pragma omp parallel default(shared)
 	{
 		#pragma omp for schedule(static)
 		for(int64_t k = 0; k < n; k++){
-			double *a_col = &a[m * k];
+			T *a_col = &a[m * k];
 			for(int c = 0; c < m; c++){
-				double scale = a_col[c];
+				T scale = a_col[c];
 				for (int64_t r = c * sas.vec_nnz; r < (c + 1) * sas.vec_nnz; r++){
                     int64_t row = sas.rows[r];
 					a_hat[k * sas.n_rows + row] += (sas.vals[r] * scale);
@@ -159,5 +163,16 @@ void sketch_csccol(SASO sas, int64_t n, double *a, double *a_hat, int threads){
 		}
 	}
 }
+
+template void fill_colwise<float>(SASO<float> &sas);
+template void print_saso<float>(SASO<float> &sas);
+template void sketch_cscrow<float>(SASO<float> &sas, int64_t n, float *a, float *a_hat, int threads);
+template void sketch_csccol<float>(SASO<float> &sas, int64_t n, float *a, float *a_hat, int threads);
+
+
+template void fill_colwise<double>(SASO<double> &sas);
+template void print_saso<double>(SASO<double> &sas);
+template void sketch_cscrow<double>(SASO<double> &sas, int64_t n, double *a, double *a_hat, int threads);
+template void sketch_csccol<double>(SASO<double> &sas, int64_t n, double *a, double *a_hat, int threads);
 
 } // end namespace RandBLAS::sasos

--- a/test/src/test_sasos.cc
+++ b/test/src/test_sasos.cc
@@ -210,6 +210,8 @@ class TestApplyCsc : public ::testing::Test
         T *a_hat_expect = new T[d * n];
         T *S = new T[d * m]{}; // zero-initialize.
         sas_to_dense_colmajor<T>(sas, S);
+        RandBLAS::sasos::print_saso(sas);
+        //RandBLAS::util::print_colmaj(d, m, S, "Sketching operator:");
         int64_t lds = d;
         int64_t lda = m; 
         int64_t ldahat = d;

--- a/test/src/test_sasos.cc
+++ b/test/src/test_sasos.cc
@@ -2,8 +2,8 @@
 #include <gtest/gtest.h>
 #include <math.h>
 
-#define RELDTOL 1e-10;
-#define ABSDTOL 1e-12;
+#define RELTOL_POWER 0.7
+#define ABSTOL_POWER 0.75
 
 
 class TestSASOConstruction : public ::testing::Test
@@ -161,16 +161,17 @@ class TestApplyCsc : public ::testing::Test
             0.0, a_hat_expect, ldahat);
 
         // check the result
-        double reldtol = RELDTOL;
+        T reltol = std::pow(std::numeric_limits<T>::epsilon(), RELTOL_POWER);
+        T abstol = std::pow(std::numeric_limits<T>::epsilon(), ABSTOL_POWER);
         for (int64_t i = 0; i < d; ++i)
         {
             for (int64_t j = 0; j < n; ++j)
             {
                 int64_t ell = i*n + j;
-                double expect = (double) a_hat_expect[ell];
-                double actual = (double) a_hat[ell];
-                double atol = reldtol * std::min(abs(actual), abs(expect));
-                if (atol == 0.0) atol = ABSDTOL;
+                T expect = a_hat_expect[ell];
+                T actual = a_hat[ell];
+                T atol = reltol * std::min(abs(actual), abs(expect));
+                if (atol == 0.0) atol = abstol;
                 ASSERT_NEAR(actual, expect, atol);
             }    
         }
@@ -219,16 +220,17 @@ class TestApplyCsc : public ::testing::Test
             0.0, a_hat_expect, ldahat);
 
         // check the result
-        double reldtol = RELDTOL;
+        T reltol = std::pow(std::numeric_limits<T>::epsilon(), RELTOL_POWER);
+        T abstol = std::pow(std::numeric_limits<T>::epsilon(), ABSTOL_POWER);
         for (int64_t i = 0; i < d; ++i)
         {
             for (int64_t j = 0; j < n; ++j)
             {
                 int64_t ell = i + j*d;
-                double expect = (double) a_hat_expect[ell];
-                double actual = (double) a_hat[ell];
-                double atol = reldtol * std::min(abs(actual), abs(expect));
-                if (atol == 0.0) atol = ABSDTOL;
+                T expect = a_hat_expect[ell];
+                T actual = a_hat[ell];
+                T atol = reltol * std::min(abs(actual), abs(expect));
+                if (atol == 0.0) atol = abstol;
                 ASSERT_NEAR(actual, expect, atol);
             }    
         }

--- a/test/src/test_sasos.cc
+++ b/test/src/test_sasos.cc
@@ -210,7 +210,7 @@ class TestApplyCsc : public ::testing::Test
         T *a_hat_expect = new T[d * n];
         T *S = new T[d * m]{}; // zero-initialize.
         sas_to_dense_colmajor<T>(sas, S);
-        RandBLAS::sasos::print_saso(sas);
+        //RandBLAS::sasos::print_saso(sas);
         //RandBLAS::util::print_colmaj(d, m, S, "Sketching operator:");
         int64_t lds = d;
         int64_t lda = m; 
@@ -233,7 +233,7 @@ class TestApplyCsc : public ::testing::Test
                 T actual = a_hat[ell];
                 T atol = reltol * std::min(abs(actual), abs(expect));
                 if (atol == 0.0) atol = abstol;
-                ASSERT_NEAR(actual, expect, atol);
+                EXPECT_NEAR(actual, expect, atol) << {i, j};
             }    
         }
     }

--- a/test/src/test_sasos.cc
+++ b/test/src/test_sasos.cc
@@ -228,12 +228,13 @@ class TestApplyCsc : public ::testing::Test
         {
             for (int64_t j = 0; j < n; ++j)
             {
+                // std::pair<int64_t, int64_t> p = {i, j};
                 int64_t ell = i + j*d;
                 T expect = a_hat_expect[ell];
                 T actual = a_hat[ell];
                 T atol = reltol * std::min(abs(actual), abs(expect));
                 if (atol == 0.0) atol = abstol;
-                EXPECT_NEAR(actual, expect, atol) << {i, j};
+                EXPECT_NEAR(actual, expect, atol) << "\t" << i << ", " << j;
             }    
         }
     }

--- a/test/src/test_sasos.cc
+++ b/test/src/test_sasos.cc
@@ -149,7 +149,7 @@ class TestApplyCsc : public ::testing::Test
 
         // compute expected result
         T *a_hat_expect = new T[d * n];
-        T *S = new T[d * m];
+        T *S = new T[d * m]{}; // zero-initialize.
         sas_to_dense_rowmajor<T>(sas, S);
         int64_t lds = m;
         int64_t lda = n; 
@@ -208,7 +208,7 @@ class TestApplyCsc : public ::testing::Test
 
         // compute expected result
         T *a_hat_expect = new T[d * n];
-        T *S = new T[d * m];
+        T *S = new T[d * m]{}; // zero-initialize.
         sas_to_dense_colmajor<T>(sas, S);
         int64_t lds = d;
         int64_t lda = m; 

--- a/test/src/test_sasos.cc
+++ b/test/src/test_sasos.cc
@@ -156,7 +156,7 @@ class TestApplyCsc : public ::testing::Test
         RandBLAS::sasos::sketch_cscrow<T>(sas, n, a, a_hat, threads);
 
         // compute expected result
-        T *a_hat_expect = new T[d * n];
+        T *a_hat_expect = new T[d * n]{}; // zero-initialize.
         T *S = new T[d * m];
         sas_to_dense_rowmajor<T>(sas, S);
         int64_t lds = m;
@@ -207,11 +207,7 @@ class TestApplyCsc : public ::testing::Test
         RandBLAS::sasos::fill_colwise<T>(sas);
         
         // compute S*A. 
-        T *a_hat = new T[d * n];
-        for (int64_t i = 0; i < d * n; ++i)
-        {
-            a_hat[i] = 0.0;
-        }
+        T *a_hat = new T[d * n]{}; // zero-initialize.
         RandBLAS::sasos::sketch_csccol<T>(sas, n, a, a_hat, threads);
 
         // compute expected result

--- a/test/src/test_sasos.cc
+++ b/test/src/test_sasos.cc
@@ -28,7 +28,9 @@ class TestSASOConstruction : public ::testing::Test
         sas.rows = new int64_t[sas.vec_nnz * m];
         sas.cols = new int64_t[sas.vec_nnz * m];
         sas.vals = new double[sas.vec_nnz * m];
-        RandBLAS::sasos::fill_colwise(sas, keys[key_index], 0);
+        sas.key = keys[key_index];
+        sas.ctr = 0;
+        RandBLAS::sasos::fill_colwise(sas);
 
         // check that each block of sas.vec_nnz entries of sas.rows is
         // sampled without replacement from 0,...,n_rows - 1.
@@ -78,7 +80,7 @@ TEST_F(TestSASOConstruction, Dim7by20nnz7)
 
 
 
-void sast_to_dense_rowmajor(RandBLAS::sasos::SASO sas, double *mat)
+void sas_to_dense_rowmajor(RandBLAS::sasos::SASO sas, double *mat)
 {
     int64_t nnz = sas.n_cols * sas.vec_nnz;
     for (int64_t i = 0; i < nnz; ++i)
@@ -90,7 +92,7 @@ void sast_to_dense_rowmajor(RandBLAS::sasos::SASO sas, double *mat)
     }
 }
 
-void sast_to_dense_colmajor(RandBLAS::sasos::SASO sas, double *mat)
+void sas_to_dense_colmajor(RandBLAS::sasos::SASO sas, double *mat)
 {
     int64_t nnz = sas.n_cols * sas.vec_nnz;
     for (int64_t i = 0; i < nnz; ++i)
@@ -134,7 +136,9 @@ class TestApplyCsc : public ::testing::Test
         sas.rows = new int64_t[sas.vec_nnz * m];
         sas.cols = new int64_t[sas.vec_nnz * m];
         sas.vals = new double[sas.vec_nnz * m];
-        RandBLAS::sasos::fill_colwise(sas, keys[key_index], 0);
+        sas.ctr = 0;
+        sas.key = keys[key_index];
+        RandBLAS::sasos::fill_colwise(sas);
         
         // compute S*A. 
         double *a_hat = new double[d * n];
@@ -147,7 +151,7 @@ class TestApplyCsc : public ::testing::Test
         // compute expected result
         double *a_hat_expect = new double[d * n];
         double *S = new double[d * m];
-        sast_to_dense_rowmajor(sas, S);
+        sas_to_dense_rowmajor(sas, S);
         int lds = (int) m;
         int lda = (int) n; 
         int ldahat = (int) n;
@@ -189,7 +193,9 @@ class TestApplyCsc : public ::testing::Test
         sas.rows = new int64_t[sas.vec_nnz * m];
         sas.cols = new int64_t[sas.vec_nnz * m];
         sas.vals = new double[sas.vec_nnz * m];
-        RandBLAS::sasos::fill_colwise(sas, keys[key_index], 0);
+        sas.ctr = 0;
+        sas.key = keys[key_index];
+        RandBLAS::sasos::fill_colwise(sas);
         
         // compute S*A. 
         double *a_hat = new double[d * n];
@@ -202,7 +208,7 @@ class TestApplyCsc : public ::testing::Test
         // compute expected result
         double *a_hat_expect = new double[d * n];
         double *S = new double[d * m];
-        sast_to_dense_colmajor(sas, S);
+        sas_to_dense_colmajor(sas, S);
         int lds = (int) d;
         int lda = (int) m; 
         int ldahat = (int) d;

--- a/test/src/test_sasos.cc
+++ b/test/src/test_sasos.cc
@@ -151,9 +151,9 @@ class TestApplyCsc : public ::testing::Test
         T *a_hat_expect = new T[d * n];
         T *S = new T[d * m];
         sas_to_dense_rowmajor<T>(sas, S);
-        int lds = (int) m;
-        int lda = (int) n; 
-        int ldahat = (int) n;
+        int64_t lds = m;
+        int64_t lda = n; 
+        int64_t ldahat = n;
         blas::gemm<T>(
             blas::Layout::RowMajor, blas::Op::NoTrans, blas::Op::NoTrans,
             d, n, m,
@@ -210,9 +210,9 @@ class TestApplyCsc : public ::testing::Test
         T *a_hat_expect = new T[d * n];
         T *S = new T[d * m];
         sas_to_dense_colmajor<T>(sas, S);
-        int lds = (int) d;
-        int lda = (int) m; 
-        int ldahat = (int) d;
+        int64_t lds = d;
+        int64_t lda = m; 
+        int64_t ldahat = d;
         blas::gemm<T>(
             blas::Layout::ColMajor, blas::Op::NoTrans, blas::Op::NoTrans,
             d, n, m,

--- a/test/src/test_sasos.cc
+++ b/test/src/test_sasos.cc
@@ -207,7 +207,7 @@ class TestApplyCsc : public ::testing::Test
         RandBLAS::sasos::sketch_csccol<T>(sas, n, a, a_hat, threads);
 
         // compute expected result
-        T *a_hat_expect = new T[d * n];
+        T *a_hat_expect = new T[d * n]{}; // zero-initialize
         T *S = new T[d * m]{}; // zero-initialize.
         sas_to_dense_colmajor<T>(sas, S);
         //RandBLAS::sasos::print_saso(sas);


### PR DESCRIPTION
This also makes C++17 the explicit standard and moves RNG counters and keys into SASO structs.