### PR TITLE
Complete implementation of LSKGES

### DIFF
--- a/RandBLAS/CMakeLists.txt
+++ b/RandBLAS/CMakeLists.txt
@@ -1,8 +1,5 @@
-set(RandBLAS_cxx_srcs
-    base.cc)
 
 set(RandBLAS_libs blaspp Random123)
-
 if (RandBLAS_HAS_OpenMP)
     list(APPEND RandBLAS_libs OpenMP::OpenMP_CXX)
 endif()
@@ -11,17 +8,17 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in config.h)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/config.h
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/RandBLAS)
 
-add_library(RandBLAS ${RandBLAS_cxx_srcs})
+add_library(RandBLAS INTERFACE)
 
-target_include_directories(RandBLAS PUBLIC
+target_include_directories(RandBLAS INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/..>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/RandBLAS>)
 
-target_link_libraries(RandBLAS PUBLIC ${RandBLAS_libs})
-target_compile_options(RandBLAS PUBLIC -Wall -Wextra)
+target_link_libraries(RandBLAS INTERFACE ${RandBLAS_libs})
+target_compile_options(RandBLAS INTERFACE -Wall -Wextra)
 
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
   DESTINATION include FILES_MATCHING PATTERN "*.hh")

--- a/RandBLAS/base.hh
+++ b/RandBLAS/base.hh
@@ -13,7 +13,6 @@
 #include <cstdint>
 #include <iostream>
 
-#define RandBLAS_HAS_OpenMP
 #if defined(RandBLAS_HAS_OpenMP)
 #include <omp.h>
 #endif

--- a/RandBLAS/dense.hh
+++ b/RandBLAS/dense.hh
@@ -3,6 +3,7 @@
 
 #include "RandBLAS/base.hh"
 #include "RandBLAS/exceptions.hh"
+#include "RandBLAS/random_gen.hh"
 
 #include <blas.hh>
 
@@ -55,11 +56,11 @@ namespace RandBLAS::dense {
 using namespace RandBLAS::base;
 
 enum class DenseDistName : char {
-    Gaussian = 'G',         
-    Uniform = 'U',          // uniform over the interval [-1, 1].
-    Rademacher = 'R',       // uniform over {+1, -1}.
-    Haar = 'H',             // uniform over row-orthonormal or column-orthonormal matrices.
-    DisjointIntervals = 'I' // might require additional metadata.
+    Gaussian = 'G',         ///< a Gaussian with mean 0 and standard deviation 1
+    Uniform = 'U',          ///< uniform over the interval [-1, 1].
+    Rademacher = 'R',       ///< uniform over {+1, -1}.
+    Haar = 'H',             ///< uniform over row-orthonormal or column-orthonormal matrices.
+    DisjointIntervals = 'I' ///< might require additional metadata.
 };
 
 struct DenseDist {
@@ -68,22 +69,29 @@ struct DenseDist {
     const int64_t n_cols;
 };
 
-template <typename T>
+template <typename T, typename RNG = r123::Philox4x32>
 struct DenseSkOp {
-    const DenseDist dist;
-    const RNGState seed_state;
-    RNGState next_state;
-    const bool own_memory = true;
+
+    using generator = RNG;
+    using state_type = RNGState<RNG>;
+    using buffer_type = T;
+
     /////////////////////////////////////////////////////////////////////
     //
     //      Properties specific to dense sketching operators
     //
     /////////////////////////////////////////////////////////////////////
 
-    T *buff = nullptr;
-    bool filled = false;
-    bool persistent = true;
-    const blas::Layout layout = blas::Layout::ColMajor;
+    const DenseDist dist;            ///< the name of the distribution and matrix size
+    const RNGState<RNG> seed_state;  ///< the initial CBRNG state
+    RNGState<RNG> next_state;        ///< the current CBRNG state
+    const bool own_memory = true;    ///< a flag that indicates who owns the memory
+
+    T *buff = nullptr;               ///< memory
+    bool filled = false;             ///< a flag that indicates if the memory was initialized
+    bool persistent = true;          ///< ???
+
+    const blas::Layout layout = blas::Layout::ColMajor; ///< matrix storage order
 
     /////////////////////////////////////////////////////////////////////
     //
@@ -94,7 +102,7 @@ struct DenseSkOp {
     //  Elementary constructor: needs an implementation
     DenseSkOp(
         DenseDist dist_,
-        const RNGState &state_,
+        RNGState<RNG> const& state_,
         T *buff_,
         bool filled_,
         bool persistent_,
@@ -110,30 +118,30 @@ struct DenseSkOp {
         bool filled,
         bool persistent,
         blas::Layout layout
-    ) : DenseSkOp(dist, RNGState{ctr_offset, key}, buff, filled, persistent, layout) {};
+    ) : DenseSkOp(dist, {ctr_offset, key}, buff, filled, persistent, layout) {};
 
     //  Convenience constructor (a wrapper)
     DenseSkOp(
         DenseDistName family,
         int64_t n_rows,
         int64_t n_cols,
-        uint32_t key,
         uint32_t ctr_offset,
+        uint32_t key,
         T *buff,
         bool filled,
         bool persistent,
         blas::Layout layout
-    ) : DenseSkOp(DenseDist{family, n_rows, n_cols}, RNGState{key, ctr_offset},
-        buff, filled, persistent, layout) {};
+    ) : DenseSkOp(DenseDist{family, n_rows, n_cols}, ctr_offset,
+                  key, buff, filled, persistent, layout) {};
 
     // Destructor
     ~DenseSkOp();
 };
 
-template <typename T>
-DenseSkOp<T>::DenseSkOp(
+template <typename T, typename RNG>
+DenseSkOp<T,RNG>::DenseSkOp(
     DenseDist dist_,
-    const RNGState &state_,
+    RNGState<RNG> const& state_,
     T *buff_,           
     bool filled_,       
     bool persistent_,   
@@ -141,7 +149,7 @@ DenseSkOp<T>::DenseSkOp(
 ) : // variable definitions
     dist(dist_),
     seed_state(state_),
-    next_state(),
+    next_state{},
     own_memory(!buff_),
     buff(buff_),
     filled(filled_),
@@ -165,8 +173,8 @@ DenseSkOp<T>::DenseSkOp(
     }
 }
 
-template <typename T>
-DenseSkOp<T>::~DenseSkOp() {
+template <typename T, typename RNG>
+DenseSkOp<T,RNG>::~DenseSkOp() {
     if (this->own_memory) {
         delete [] this->buff;
     }
@@ -177,126 +185,106 @@ DenseSkOp<T>::~DenseSkOp() {
 
 
 
-
-
-
-
-template <typename T, typename T_gen>
-static RNGState gen_unif(
+/** Fill a n_rows \times n_cols matrix with random values. If RandBLAS is
+ * compiled with OpenMP threading support enabled, the operation is
+ * parallelized using OMP_NUM_THREADS. The sequence of values genrated is not
+ * dependent on the number of OpenMP threads.
+ *
+ * @tparam T the data type of the matrix
+ * @tparam RNG a random123 CBRNG type
+ * @tparm OP an operator that transforms raw random values into matrix
+ *           elements. See r123ext::uneg11 and r123ext::boxmul.
+ *
+ * @param[in] n_rows the number of rows in the matrix
+ * @param[in] n_cols the number of columns in the matrix
+ * @param[in] mat a pointer to a contiguous region of memory with space for
+ *                n_rows \times n_cols elements of type T. This memory will be
+ *                filled with random values.
+ * @param[in] seed A CBRNG state
+ *
+ * @returns the updated CBRNG state
+ */
+template <typename T, typename RNG, typename OP>
+auto fill_rmat(
     int64_t n_rows,
     int64_t n_cols,
     T* mat,
-    const RNGState &state
+    const RNGState<RNG> & seed
 ) {
+    RNG rng;
+    auto [c, k] = seed;
+
     int64_t dim = n_rows * n_cols;
-    int64_t i;
-    Random123_RNGState<T_gen> impl_state(state);
-    T_gen gen;
-    typedef typename T_gen::ctr_type ctr_type;
-    ctr_type rout;
-    for (i = 0; i + 3 < dim; i += 4) {
-        rout = gen(impl_state.ctr, impl_state.key);
-        mat[i] = r123::uneg11<T>(rout.v[0]);
-        mat[i + 1] = r123::uneg11<T>(rout.v[1]);
-        mat[i + 2] = r123::uneg11<T>(rout.v[2]);
-        mat[i + 3] = r123::uneg11<T>(rout.v[3]);
-        impl_state.ctr.incr(4);
+    int64_t nit = dim / RNG::ctr_type::static_size;
+    int64_t nlast = dim % RNG::ctr_type::static_size;
+
+#if defined(RandBLAS_HAS_OpenMP)
+    #pragma omp parallel firstprivate(c, k)
+    {
+        // decompose the work into a set of approximately equal size chunks.
+        // if the number of iterations is not evenly divisible by the number
+        // of threads, the left over itertions are distributed one each among
+        // the first threads.
+        int ti = omp_get_thread_num();
+        int nt = omp_get_num_threads();
+
+        int64_t chs = nit / nt; // chunk size
+        int64_t nlg = nit % nt; // number of large chunks
+        int64_t i0 = chs * ti + (ti < nlg ? ti : nlg); // this threads start
+        int64_t i1 = i0 + chs + (ti < nlg ? 1 : 0);    // this threads end
+
+        // add the start index to the counter in order to make the sequence
+        // deterministic independent of the number of threads.
+        auto cc = c;
+        cc.incr(i0);
+#else
+        int64_t i0 = 0;
+        int64_t i1 = nit;
+#endif
+        for (int64_t i = i0; i < i1; ++i)
+        {
+            auto rv = OP::generate(rng, cc, k);
+
+            for (int j = 0; j < RNG::ctr_type::static_size; ++j)
+            {
+               mat[RNG::ctr_type::static_size * i + j] = rv[j];
+            }
+
+            cc.incr();
+        }
+#if defined(RandBLAS_HAS_OpenMP)
     }
-    rout = gen(impl_state.ctr, impl_state.key);
-    int32_t j = 0;
-    while (i < dim) {
-        mat[i] =  r123::uneg11<T>(rout.v[j]);
-        ++i;
-        ++j;
+    // puts the counter in the correct state when threads are used.
+    c.incr(nit);
+#endif
+
+    if (nlast)
+    {
+        auto rv = OP::generate(rng, c, k);
+
+        for (int64_t j = 0; j < nlast; ++j)
+        {
+            mat[RNG::ctr_type::static_size * nit + j] = rv[j];
+        }
+
+        c.incr();
     }
-    return impl_state;
+
+    return RNGState<RNG> {c, k};
 }
 
 
-
-template <typename T>
-RNGState gen_rmat_unif(
-    int64_t n_rows,
-    int64_t n_cols,
-    T* mat,
-    const RNGState &state
-) {
-    switch (state.rng_name) {
-        case RNGName::Philox:
-            return gen_unif<T, Philox>(n_rows, n_cols, mat, state);
-        case RNGName::Threefry:
-            return gen_unif<T, Threefry>(n_rows, n_cols, mat, state);
-        default:
-            throw std::runtime_error(std::string("Unrecognized generator."));
-    }
-}
-
-template <typename T, typename T_gen>
-static RNGState gen_norm(
-    int64_t n_rows,
-    int64_t n_cols,
-    T* mat,
-    const RNGState &state
-) {
-    T_gen gen;
-    Random123_RNGState<T_gen> impl_state(state);
-    int64_t dim = n_rows * n_cols;
-    int64_t i;
-    typedef typename T_gen::ctr_type ctr_type;
-    ctr_type rout;
-    r123::float2 pair_1, pair_2;
-    for (i = 0; i + 3 < dim; i += 4) {
-        rout = gen(impl_state.ctr, impl_state.key);
-        pair_1 = r123::boxmuller(rout.v[0], rout.v[1]);
-        pair_2 = r123::boxmuller(rout.v[2], rout.v[3]);
-        mat[i] = pair_1.x;
-        mat[i + 1] = pair_1.y;
-        mat[i + 2] = pair_2.x;
-        mat[i + 3] = pair_2.y;
-        impl_state.ctr.incr(4);
-    }
-    rout = gen(impl_state.ctr, impl_state.key);
-    pair_1 = r123::boxmuller(rout.v[0], rout.v[1]);
-    pair_2 = r123::boxmuller(rout.v[2], rout.v[3]);
-    T v[4] = {pair_1.x, pair_1.y, pair_2.x, pair_2.y};
-    int32_t j = 0;
-    while (i < dim) {
-        mat[i] =  v[j];
-        ++i;
-        ++j;
-    }
-    RNGState out_state(state);
-    return out_state;
-}
-
-template <typename T>
-static RNGState gen_rmat_norm(
-    int64_t n_rows,
-    int64_t n_cols,
-    T* mat,
-    const RNGState &state
-) {
-    switch (state.rng_name) {
-        case RNGName::Philox:
-            return gen_norm<T, Philox>(n_rows, n_cols, mat, state);
-        case RNGName::Threefry:
-            return gen_norm<T, Threefry>(n_rows, n_cols, mat, state);
-        default:
-            throw std::runtime_error(std::string("Unrecognized generator."));
-    }
-}
-
-template <typename T>
-RNGState fill_buff(
+template <typename T, typename RNG>
+auto fill_buff(
     T *buff,
-    DenseDist D,
-    const RNGState &state
+    const DenseDist &D,
+    RNGState<RNG> const& state
 ) {
-    switch (D.family) { // no break statements needed as-written
+    switch (D.family) {
         case DenseDistName::Gaussian:
-            return gen_rmat_norm<T>(D.n_rows, D.n_cols, buff, state);
+            return fill_rmat<T,RNG,r123ext::boxmul>(D.n_rows, D.n_cols, buff, state);
         case DenseDistName::Uniform:
-            return gen_rmat_unif<T>(D.n_rows, D.n_cols, buff, state);
+            return fill_rmat<T,RNG,r123ext::uneg11>(D.n_rows, D.n_cols, buff, state);
         case DenseDistName::Rademacher:
             throw std::runtime_error(std::string("Not implemented."));
         case DenseDistName::Haar:
@@ -308,23 +296,25 @@ RNGState fill_buff(
         default:
             throw std::runtime_error(std::string("Unrecognized distribution."));
     }
+
+    return state;
 }
 
-template <typename T>
-T* fill_skop_buff(
-    DenseSkOp<T> &S0
+template <typename SKOP>
+auto fill_skop_buff(
+    SKOP &S0
 ) {
-    T *S0_ptr = S0.buff;
+    auto S0_ptr = S0.buff;
     if (S0_ptr == nullptr) {
-        S0_ptr = new T[S0.dist.n_rows * S0.dist.n_cols];
-        S0.next_state = fill_buff<T>(S0_ptr, S0.dist, S0.seed_state);
+        S0_ptr = new typename SKOP::buffer_type [S0.dist.n_rows * S0.dist.n_cols];
+        S0.next_state = fill_buff(S0_ptr, S0.dist, S0.seed_state);
         if (S0.persistent) {
             S0.buff = S0_ptr;
             S0.filled = true;
         }
         return S0_ptr;
     } else if (!S0.filled) {
-        S0.next_state = fill_buff<T>(S0_ptr, S0.dist, S0.seed_state);
+        S0.next_state = fill_buff(S0_ptr, S0.dist, S0.seed_state);
         S0.filled = true;
         return S0_ptr;
     } else {
@@ -332,7 +322,7 @@ T* fill_skop_buff(
     }
 }
 
-template <typename T>
+template <typename T, typename RNG>
 void lskge3(
     blas::Layout layout,
     blas::Op transS,
@@ -341,7 +331,7 @@ void lskge3(
     int64_t n, // op(A) is m-by-n
     int64_t m, // op(S) is d-by-m
     T alpha,
-    DenseSkOp<T> &S0,
+    DenseSkOp<T,RNG> &S0,
     int64_t i_os,
     int64_t j_os,
     const T *A,
@@ -353,7 +343,7 @@ void lskge3(
     randblas_require(d <= m);
     randblas_require(S0.layout == layout);
 
-    T *S0_ptr = fill_skop_buff<T>(S0);
+    auto S0_ptr = fill_skop_buff(S0);
 
     // Dimensions of A, rather than op(A)
     int64_t rows_A, cols_A, rows_S, cols_S;
@@ -400,8 +390,6 @@ void lskge3(
     );
     return;
 }
-
-
 
 } // end namespace RandBLAS::dense
 

--- a/RandBLAS/dense.hh
+++ b/RandBLAS/dense.hh
@@ -147,7 +147,10 @@ DenseSkOp<T>::DenseSkOp(
     filled(filled_),
     persistent(persistent_),
     layout(layout_)
-{   // Initialization logic
+{   // sanity checks
+    randblas_require(this->dist.n_rows > 0);
+    randblas_require(this->dist.n_cols > 0);
+    // Initialization logic
     //
     //      own_memory is a bool that's true iff buff_ is nullptr.
     //

--- a/RandBLAS/dense.hh
+++ b/RandBLAS/dense.hh
@@ -341,7 +341,6 @@ void lskge3(
     T *B,
     int64_t ldb
 ){
-    randblas_require(d <= m);
     randblas_require(S0.layout == layout);
 
     auto S0_ptr = fill_skop_buff(S0);

--- a/RandBLAS/random_gen.hh
+++ b/RandBLAS/random_gen.hh
@@ -1,6 +1,8 @@
 #ifndef random_gen_hh
 #define random_gen_hh
 
+/// @file
+
 // this is for sincosf
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
@@ -9,12 +11,109 @@
 #include <math.h>
 #include <Random123/array.h>
 #include <Random123/philox.h>
-#include <Random123/uniform.hpp>
-#include <Random123/philox.h>
 #include <Random123/threefry.h>
+#include <Random123/aes.h>
+#include <Random123/ars.h>
 #include <Random123/boxmuller.hpp>
+#include <Random123/uniform.hpp>
 
-using Philox = r123::Philox4x32;
-using Threefry = r123::Threefry4x32;
+/// our extensions to random123
+namespace r123ext
+{
+/** Apply boxmuller transform to all elements of ri. The number of elements of r
+ * must be evenly divisible by 2. See also r123::uneg11all.
+ *
+ * @tparam CTR a random123 CBRNG ctr_type
+ * @tparam T the return element type. The default return type is dictated by
+ *           the RNG's ctr_type's value_type : float for 32 bit counter elements
+ *           and double for 64.
+ *
+ * @param[in] ri a sequence of N random values generated using random123 CBRNG
+ *               type RNG. The transform is applied pair wise to the sequence.
+ *
+ * @returns a std::array<T,N> of transformed floating point values.
+ */
+template <typename CTR, typename T = typename std::conditional
+    <sizeof(typename CTR::value_type) == sizeof(uint32_t), float, double>::type>
+auto boxmulall(
+    CTR const& ri
+) {
+    std::array<T, CTR::static_size> ro;
+    int nit = CTR::static_size / 2;
+    for (int i = 0; i < nit; ++i)
+    {
+        auto [v0, v1] = r123::boxmuller(ri[2*i], ri[2*i + 1]);
+        ro[2*i    ] = v0;
+        ro[2*i + 1] = v1;
+    }
+    return ro;
+}
+
+/** @defgroup generators
+ * Generators take CBRNG, counter,and key instances and return a sequence of
+ * random floating point numbers in a std::array. The length of the squence is
+ * the length of the counter and the precision is float for 32 bit counters and
+ * double for 64.
+ */
+/// @{
+
+/// Generate a sequence of random values and apply a Box-Muller transform.
+struct boxmul
+{
+    /** Generate a sequence of random values and apply a Box-Muller transform.
+     *
+     * @tparam RNG a random123 CBRNG type
+     *
+     * @param[in] a random123 CBRNG instance used to generate the sequence
+     * @param[in] the CBRNG counter
+     * @param[in] the CBRNG key
+     *
+     * @returns a std::array<N,T> where N is the CBRNG's ctr_type::static_size
+     *          and T is deduced from the RNG's counter element type : float
+     *          for 32 bit counter elements and double for 64. For example when
+     *          RNG is Philox4x32 the return is a std::array<float,4>.
+     */
+    template <typename RNG>
+    static
+    auto generate(
+        RNG &rng,
+        typename RNG::ctr_type const& c,
+        typename RNG::key_type const& k
+    ) {
+        return boxmulall(rng(c,k));
+    }
+};
+
+/// Generate a sequence of random values and transform to -1.0 to 1.0.
+struct uneg11
+{
+    /** Generate a sequence of random values and transform to -1.0 to 1.0.
+     *
+     * @tparam RNG a random123 CBRNG type
+     *
+     * @param[in] a random123 CBRNG instance used to generate the sequence
+     * @param[in] the CBRNG counter
+     * @param[in] the CBRNG key
+     *
+     * @returns a std::array<N,T> where N is the CBRNG's ctr_type::static_size
+     *          and T is deduced from the RNG's counter element type : float
+     *          for 32 bit counter elements and double for 64. For example when
+     *          RNG is Philox4x32 the return is a std::array<float,4>.
+     */
+    template <typename RNG, typename T = typename std::conditional
+        <sizeof(typename RNG::ctr_type::value_type) == sizeof(uint32_t), float, double>::type>
+    static
+    auto generate(
+        RNG &rng,
+        typename RNG::ctr_type const& c,
+        typename RNG::key_type const& k
+    ) {
+        return r123::uneg11all<T>(rng(c,k));
+    }
+};
+
+/// @}
+
+} // end of namespace r123ext
 
 #endif

--- a/RandBLAS/sparse.hh
+++ b/RandBLAS/sparse.hh
@@ -241,16 +241,18 @@ auto fill_sparse(
 }
 
 template <typename SKOP>
-void print_saso(SKOP const& S0) {
+void print_sparse(SKOP const& S0) {
     std::cout << "SparseSkOp information" << std::endl;
-    std::cout << "\tn_rows = " << S0.dist.n_rows << std::endl;
-    std::cout << "\tn_cols = " << S0.dist.n_cols << std::endl;
     int64_t nnz;
     if (S0.dist.family == SparseDistName::SASO) {
         nnz = S0.dist.vec_nnz * MAX(S0.dist.n_rows, S0.dist.n_cols);
+        std::cout << "\tSASO: short-axis-sparse operator" << std::endl;
     } else {
         nnz = S0.dist.vec_nnz * MIN(S0.dist.n_rows, S0.dist.n_cols);
+        std::cout << "\tLASO: long-axis-sparse operator" << std::endl;
     }
+    std::cout << "\tn_rows = " << S0.dist.n_rows << std::endl;
+    std::cout << "\tn_cols = " << S0.dist.n_cols << std::endl;
     std::cout << "\tvector of row indices\n\t\t";
     for (int64_t i = 0; i < nnz; ++i) {
         std::cout << S0.rows[i] << ", ";

--- a/RandBLAS/sparse.hh
+++ b/RandBLAS/sparse.hh
@@ -619,14 +619,12 @@ void lskges(
     }
 
     // Dimensionality sanity checks
+    //      Both A and B are checked based on "layout"; A is *not* checked on layout_A.
     if (layout == blas::Layout::ColMajor) {
         randblas_require(lda >= rows_A);
-    } else {
-        randblas_require(lda >= cols_A);
-    }
-    if (layout == blas::Layout::ColMajor) {
         randblas_require(ldb >= d);
     } else {
+        randblas_require(lda >= cols_A);
         randblas_require(ldb >= n);
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,3 +18,6 @@ if (GTest_FOUND)
 
 endif()
 message(STATUS "Checking for regression tests ... ${tmp}")
+
+add_executable(test_rng_speed test_rng_speed.cpp)
+target_link_libraries(test_rng_speed RandBLAS)

--- a/test/test_dense.cc
+++ b/test/test_dense.cc
@@ -1,3 +1,6 @@
+#include "RandBLAS/config.h"
+#include "RandBLAS/base.hh"
+#include "RandBLAS/random_gen.hh"
 #include "RandBLAS/dense.hh"
 #include "RandBLAS/util.hh"
 #include "RandBLAS/test_util.hh"
@@ -6,7 +9,6 @@
 
 #include <cmath>
 #include <numeric>
-#include <Random123/philox.h>
 
 
 class TestDenseMoments : public ::testing::Test
@@ -36,7 +38,7 @@ class TestDenseMoments : public ::testing::Test
             .n_cols = n_cols
         };
         auto state = RandBLAS::base::RNGState{0, key};
-        auto next_state = RandBLAS::dense::fill_buff<T>(A.data(), D, state);
+        auto next_state = RandBLAS::dense::fill_buff(A.data(), D, state);
 
         // Compute the entrywise empirical mean and standard deviation.
         T mean = std::accumulate(A.data(), A.data() + size, 0.0) /size;
@@ -120,11 +122,11 @@ class TestLSKGE3 : public ::testing::Test
         std::vector<T> buff; // awkward.
         if (preallocate) {
             buff.resize(d * m, 0.0);
-            S0_ptr = new RandBLAS::dense::DenseSkOp<T>(
+            S0_ptr = new RandBLAS::dense::DenseSkOp(
                 D, seed, 0, buff.data(), false, true, layout
             );
         } else {
-            S0_ptr = new RandBLAS::dense::DenseSkOp<T>(
+            S0_ptr = new RandBLAS::dense::DenseSkOp(
                 D, seed, 0, buff.data(), false, true, layout
             );
         }

--- a/test/test_dense.cc
+++ b/test/test_dense.cc
@@ -83,19 +83,6 @@ TEST_F(TestDenseMoments, Uniform)
 
 class TestLSKGE3 : public ::testing::Test
 {
-    /*
-    Things that need to be tested:
-        1. Sketching the identity matrix works as expected.
-        2. Transposing the sketching operator works as expected.
-        3. Using a submatrix of the sketching operator.
-        4. sketching a submatrix of a data matrix.
-        5. row-major sketching
-            5.1 An exception should be raised if S0.layout != 
-                declared layout.
-
-    Things that don't need to be tested:
-        ?
-    */
     protected:
     
     virtual void SetUp(){};
@@ -318,41 +305,92 @@ class TestLSKGE3 : public ::testing::Test
 
 };
 
-TEST_F(TestLSKGE3, eye_double_preallocate_colmajor)
+
+////////////////////////////////////////////////////////////////////////
+//
+//
+//      Basic sketching (vary preallocation, row vs col major)
+//
+//
+////////////////////////////////////////////////////////////////////////
+
+TEST_F(TestLSKGE3, sketch_eye_double_preallocate_colmajor)
 {
     for (uint32_t seed : {0})
         sketch_eye<double>(seed, 200, 30, true, blas::Layout::ColMajor);
 }
 
-TEST_F(TestLSKGE3, eye_double_preallocate_rowmajor)
+TEST_F(TestLSKGE3, sketch_eye_double_preallocate_rowmajor)
 {
     for (uint32_t seed : {0})
         sketch_eye<double>(seed, 200, 30, true, blas::Layout::RowMajor);
 }
 
-TEST_F(TestLSKGE3, eye_double_null_colmajor)
+TEST_F(TestLSKGE3, sketch_eye_double_null_colmajor)
 {
     for (uint32_t seed : {0})
         sketch_eye<double>(seed, 200, 30, false, blas::Layout::ColMajor);
 }
 
-TEST_F(TestLSKGE3, eye_double_null_rowmajor)
+TEST_F(TestLSKGE3, sketch_eye_double_null_rowmajor)
 {
     for (uint32_t seed : {0})
         sketch_eye<double>(seed, 200, 30, false, blas::Layout::RowMajor);
 }
 
-TEST_F(TestLSKGE3, eye_single_preallocate)
+TEST_F(TestLSKGE3, sketch_eye_single_preallocate)
 {
     for (uint32_t seed : {0})
         sketch_eye<float>(seed, 200, 30, true, blas::Layout::ColMajor);
 }
 
-TEST_F(TestLSKGE3, eye_single_null)
+TEST_F(TestLSKGE3, sketch_eye_single_null)
 {
     for (uint32_t seed : {0})
         sketch_eye<float>(seed, 200, 30, false, blas::Layout::ColMajor);
 }
+
+
+////////////////////////////////////////////////////////////////////////
+//
+//
+//      Lifting
+//
+//
+////////////////////////////////////////////////////////////////////////
+
+TEST_F(TestLSKGE3, lift_eye_double_preallocate_colmajor)
+{
+    for (uint32_t seed : {0})
+        sketch_eye<double>(seed, 10, 51, true, blas::Layout::ColMajor);
+}
+
+TEST_F(TestLSKGE3, lift_eye_double_preallocate_rowmajor)
+{
+    for (uint32_t seed : {0})
+        sketch_eye<double>(seed, 10, 51, true, blas::Layout::RowMajor);
+}
+
+TEST_F(TestLSKGE3, lift_eye_double_null_colmajor)
+{
+    for (uint32_t seed : {0})
+        sketch_eye<double>(seed, 10, 51, false, blas::Layout::ColMajor);
+}
+
+TEST_F(TestLSKGE3, lift_eye_double_null_rowmajor)
+{
+    for (uint32_t seed : {0})
+        sketch_eye<double>(seed, 10, 51, false, blas::Layout::RowMajor);
+}
+
+
+////////////////////////////////////////////////////////////////////////
+//
+//
+//      transpose of S
+//
+//
+////////////////////////////////////////////////////////////////////////
 
 TEST_F(TestLSKGE3, transpose_double_colmajor)
 {
@@ -371,6 +409,14 @@ TEST_F(TestLSKGE3, transpose_single)
     for (uint32_t seed : {0})
         transpose_S<float>(seed, 200, 30, blas::Layout::ColMajor);
 }
+
+////////////////////////////////////////////////////////////////////////
+//
+//
+//      Submatrices of S
+//
+//
+////////////////////////////////////////////////////////////////////////
 
 TEST_F(TestLSKGE3, submatrix_s_double_colmajor) 
 {
@@ -407,6 +453,14 @@ TEST_F(TestLSKGE3, submatrix_s_single)
             blas::Layout::ColMajor
         );
 }
+
+////////////////////////////////////////////////////////////////////////
+//
+//
+//     submatrix of A
+//
+//
+////////////////////////////////////////////////////////////////////////
 
 TEST_F(TestLSKGE3, submatrix_a_double_colmajor) 
 {

--- a/test/test_rng_speed.cpp
+++ b/test/test_rng_speed.cpp
@@ -1,0 +1,68 @@
+
+#include "RandBLAS/config.h"
+#include "RandBLAS/random_gen.hh"
+#include "RandBLAS/base.hh"
+#include "RandBLAS/dense.hh"
+
+#include <iostream>
+#include <vector>
+#include <typeinfo>
+#include <cstring>
+#include <chrono>
+
+using namespace RandBLAS;
+
+
+template <typename T>
+std::ostream &operator<<(std::ostream &os, std::vector<T> &v)
+{
+    size_t n = v.size();
+    os << "{";
+    if (n)
+    {
+        os << v[0];
+        for (size_t i = 1; i < n; ++i)
+            os << ", " << v[i];
+    }
+    os << "}";
+    return os;
+}
+
+
+
+template <typename T, typename RNG, typename OP>
+auto run_test(int64_t m, int64_t n, T *mat)
+{
+    auto t0 = std::chrono::high_resolution_clock::now();
+    base::RNGState<RNG> seed;
+    dense::fill_rmat<T,RNG,OP>(m, n, mat, seed);
+    auto t1 = std::chrono::high_resolution_clock::now();
+    return (t1 - t0).count();
+}
+
+
+int main(int argc, char **argv)
+{
+    (void) argc;
+
+    using T = float;
+    using RNG = r123::Philox4x32;
+    using OP = r123ext::uneg11;
+
+    int64_t m = atoi(argv[1]);
+    int64_t n = atoi(argv[2]);
+    int64_t d = m*n;
+
+    std::vector<T> mat(d);
+
+    auto dt = run_test<T,RNG,OP>(m, n, mat.data());
+
+    std::cerr << "[" << typeid(RNG).name() << ", "
+        << typeid(OP).name() << "] dt = " << dt << std::endl;
+
+    if (d < 100)
+        std::cerr << "mat = " << mat << std::endl;
+
+    return 0;
+}
+

--- a/test/test_sparse.cc
+++ b/test/test_sparse.cc
@@ -394,7 +394,6 @@ class TestLSKGES : public ::testing::Test
         RandBLAS::base::RNGState state(42, 42000);
         RandBLAS::dense::fill_buff(B0.data(), DB, state);
         int64_t ldb = (is_colmajor) ? d : m;
-
         std::vector<T> B1(d * m);
         blas::copy(d * m, B0.data(), 1, B1.data(), 1);
 
@@ -410,8 +409,6 @@ class TestLSKGES : public ::testing::Test
         );
 
         // compute the reference result
-        //std::vector<T> B1(d * m);
-        //RandBLAS::dense::fill_buff(B1.data(), DB, state);
         std::vector<T> S_dense(d * m);
         sparseskop_to_dense<T>(S, S_dense.data(), layout);
         int64_t lds = (is_colmajor) ? d : m;
@@ -513,7 +510,11 @@ class TestLSKGES : public ::testing::Test
         std::vector<T> A0(m0 * n0, 0.0);
         uint32_t ctr_A0 = 42;
         uint32_t seed_A0 = 42000;
-        RandBLAS::dense::DenseDist DA0 = {.n_rows = m0, .n_cols = n0};
+        RandBLAS::dense::DenseDist DA0 = {
+            .family=RandBLAS::dense::DenseDistName::Uniform,
+            .n_rows = m0,
+            .n_cols = n0
+        };
         RandBLAS::dense::fill_buff(A0.data(), DA0, RandBLAS::base::RNGState{ctr_A0, seed_A0});
         std::vector<T> B(d * n, 0.0);
         int64_t lda = (is_colmajor) ? DA0.n_rows : DA0.n_cols;
@@ -572,7 +573,11 @@ class TestLSKGES : public ::testing::Test
         std::vector<T> At(m * n, 0.0);
         uint32_t ctr_A = 42;
         uint32_t seed_A = 42000;
-        RandBLAS::dense::DenseDist DAt = {.n_rows = n, .n_cols = m};
+        RandBLAS::dense::DenseDist DAt = {
+            .family=RandBLAS::dense::DenseDistName::Uniform,
+            .n_rows = n,
+            .n_cols = m
+        };
         RandBLAS::dense::fill_buff(At.data(), DAt, RandBLAS::base::RNGState{ctr_A, seed_A});
         std::vector<T> B(d * n, 0.0);
         int64_t lda = (is_colmajor) ? DAt.n_rows : DAt.n_cols;

--- a/test/test_sparse.cc
+++ b/test/test_sparse.cc
@@ -7,7 +7,7 @@
 
 
 template <typename T>
-RandBLAS::sparse::SparseSkOp<T> make_wide_saso(
+auto make_wide_saso(
     int64_t n_rows,
     int64_t n_cols,
     int64_t vec_nnz,
@@ -19,7 +19,7 @@ RandBLAS::sparse::SparseSkOp<T> make_wide_saso(
         RandBLAS::sparse::SparseDistName::SASO,
         n_rows, n_cols, vec_nnz, key, ctr_offset
     );
-    RandBLAS::sparse::fill_sparse<T>(S0);
+    RandBLAS::sparse::fill_sparse(S0);
     return S0;
 }
 
@@ -66,7 +66,7 @@ class TestSparseSkOpConstruction : public ::testing::Test
             RandBLAS::sparse::SparseDistName::SASO,
             d, m, vec_nnzs[nnz_index], keys[key_index], 0
         );
-        RandBLAS::sparse::fill_sparse<double>(S0);
+       RandBLAS::sparse::fill_sparse(S0);
        if (d < m) {
             check_fixed_nnz_per_col(S0);
        } else {
@@ -79,7 +79,7 @@ class TestSparseSkOpConstruction : public ::testing::Test
             RandBLAS::sparse::SparseDistName::LASO,
             d, m, vec_nnzs[nnz_index], keys[key_index], 0
         );
-        RandBLAS::sparse::fill_sparse<double>(S0);
+        RandBLAS::sparse::fill_sparse(S0);
        if (d < m) {
             check_fixed_nnz_per_row(S0);
        } else {
@@ -221,7 +221,7 @@ class TestLSKGES : public ::testing::Test
             distname, d, m,
             vec_nnzs[nnz_index], keys[key_index], 0
         );
-        RandBLAS::sparse::fill_sparse<T>(S0);
+        RandBLAS::sparse::fill_sparse(S0);
         sparseskop_to_dense<T>(S0, S, layout);
         int64_t lda, ldahat, lds;
         if (layout == blas::Layout::RowMajor) {

--- a/test/test_sparse.cc
+++ b/test/test_sparse.cc
@@ -35,7 +35,7 @@ class TestSparseSkOpConstruction : public ::testing::Test
 
     virtual void TearDown() {};
 
-    void fixed_nnz_per_col(RandBLAS::sparse::SparseSkOp<double> &S0) {
+    void check_fixed_nnz_per_col(RandBLAS::sparse::SparseSkOp<double> &S0) {
         std::set<int64_t> s;
         for (int64_t i = 0; i < S0.dist.n_cols; ++i) {
             int64_t offset = S0.dist.vec_nnz * i;
@@ -48,7 +48,7 @@ class TestSparseSkOpConstruction : public ::testing::Test
         }
     }
 
-    void fixed_nnz_per_row(RandBLAS::sparse::SparseSkOp<double> &S0) {
+    void check_fixed_nnz_per_row(RandBLAS::sparse::SparseSkOp<double> &S0) {
         std::set<int64_t> s;
         for (int64_t i = 0; i < S0.dist.n_rows; ++i) {
             int64_t offset = S0.dist.vec_nnz * i;
@@ -68,9 +68,9 @@ class TestSparseSkOpConstruction : public ::testing::Test
         );
         RandBLAS::sparse::fill_sparse<double>(S0);
        if (d < m) {
-            fixed_nnz_per_col(S0);
+            check_fixed_nnz_per_col(S0);
        } else {
-            fixed_nnz_per_row(S0);
+            check_fixed_nnz_per_row(S0);
        }
     } 
 
@@ -81,9 +81,9 @@ class TestSparseSkOpConstruction : public ::testing::Test
         );
         RandBLAS::sparse::fill_sparse<double>(S0);
        if (d < m) {
-            fixed_nnz_per_row(S0);
+            check_fixed_nnz_per_row(S0);
        } else {
-            fixed_nnz_per_col(S0);
+            check_fixed_nnz_per_col(S0);
        }
     } 
 };
@@ -293,7 +293,7 @@ class TestLSKGES : public ::testing::Test
         int64_t pos = (is_colmajor) ? (S_ro + d0 * S_co) : (S_ro * m0 + S_co);
         assert(d0 * m0 >= pos + d1 * m1);
 
-        int64_t vec_nnz = d0 / 4; // this is actually quite dense. 
+        int64_t vec_nnz = d0 / 3; // this is actually quite dense. 
         auto S0 = make_wide_saso<T>(d0, m0, vec_nnz, 0, seed);
         T *S0_dense = new T[d0 * m0];
         sparseskop_to_dense<T>(S0, S0_dense, layout);
@@ -549,14 +549,14 @@ TEST_F(TestLSKGES, sketch_laso_rowMajor_oneThread)
 }
 
 
-TEST_F(TestLSKGES, sketch_saso_rowMajor_twoThreads)
+TEST_F(TestLSKGES, sketch_saso_rowMajor_FourThreads)
 {
     for (int64_t k_idx : {0, 1, 2})
     {
         for (int64_t nz_idx: {4, 1, 2, 3, 0})
         {
-            apply<double>(RandBLAS::sparse::SparseDistName::SASO, 19, 201, 12, blas::Layout::RowMajor, k_idx, nz_idx, 2);
-            apply<float>(RandBLAS::sparse::SparseDistName::SASO, 19, 201, 12, blas::Layout::RowMajor, k_idx, nz_idx, 2);
+            apply<double>(RandBLAS::sparse::SparseDistName::SASO, 19, 201, 12, blas::Layout::RowMajor, k_idx, nz_idx, 4);
+            apply<float>(RandBLAS::sparse::SparseDistName::SASO, 19, 201, 12, blas::Layout::RowMajor, k_idx, nz_idx, 4);
         }
     }
 }
@@ -585,26 +585,14 @@ TEST_F(TestLSKGES, sketch_laso_colMajor_oneThread)
     }
 }
 
-TEST_F(TestLSKGES, sketch_saso_colMajor_twoThreads)
+TEST_F(TestLSKGES, sketch_saso_colMajor_fourThreads)
 {
     for (int64_t k_idx : {0, 1, 2})
     {
         for (int64_t nz_idx: {4, 1, 2, 3, 0})
         {
-            apply<double>(RandBLAS::sparse::SparseDistName::SASO, 19, 201, 12, blas::Layout::ColMajor, k_idx, nz_idx, 2);
-            apply<float>(RandBLAS::sparse::SparseDistName::SASO, 19, 201, 12, blas::Layout::ColMajor, k_idx, nz_idx, 2);
-        }
-    }
-}
-
-TEST_F(TestLSKGES, sketch_saso_default_threads)
-{
-    for (int64_t k_idx : {0, 1, 2})
-    {
-        for (int64_t nz_idx: {4, 1, 2, 3, 0})
-        {
-            apply<double>(RandBLAS::sparse::SparseDistName::SASO, 19, 201, 12, blas::Layout::ColMajor, k_idx, nz_idx, 0);
-            apply<double>(RandBLAS::sparse::SparseDistName::SASO, 19, 201, 12, blas::Layout::RowMajor, k_idx, nz_idx, 0);
+            apply<double>(RandBLAS::sparse::SparseDistName::SASO, 19, 201, 12, blas::Layout::ColMajor, k_idx, nz_idx, 4);
+            apply<float>(RandBLAS::sparse::SparseDistName::SASO, 19, 201, 12, blas::Layout::ColMajor, k_idx, nz_idx, 4);
         }
     }
 }


### PR DESCRIPTION
This PR supersedes PR #26. Big changes include:
* Added support for long-axis-sparse sketching operators, or "LASOs". Prior to this PR, we only supported short-axis-sparse operators, or "SASOs."
* Added support for transposes on the sketching operator and data matrix.
* Added support for "lifting" instead of just "sketching" with LSKGES and LSKGE3. More on this below.
* LSKGES previously had a helper function for sketching row-major data from the left with a (non-transposed) SASO. This PR removes that function. More on this below.
* Burlen's changes in PR #28 for improved templating of RNGState structs.

### Lifting versus sketching

We used to have a requirement that ``B = op(S) * op(A)`` had fewer rows than ``op(A)``. That requirement is valid if we only allow proper sketching. However, there are situations where we need to "lift" the result of a sketch back into the higher-dimensional space, in the sense that ``B = op(S) * op(A)`` has more rows than ``op(A)``.

### Removing specialized row-major sketching function

The new implementation for applying a CSC-like sketching operator accesses data with appropriate strides. I did this because it substantially simplified the case handling for SASOs, LASOs, transposes thereof, row-major and column-major data, and (eventually) right-sketching. However, accessing data via strides does introduce a performance penalty, so we should look at restoring the functionality I removed in the near future.