### PR TITLE
Testing sparse sketching : use theoretical floating point error bounds to define tolerances

### DIFF
--- a/RandBLAS/test_util.hh
+++ b/RandBLAS/test_util.hh
@@ -83,6 +83,29 @@ void buffs_approx_equal(
 }
 
 template <typename T>
+void buffs_approx_equal(
+    const T *actual_ptr,
+    const T *expect_ptr,
+    const T *bounds_ptr,
+    int64_t size,
+    const char *test_name,
+    const char *file_name,
+    int line_no
+) {
+    std::ostringstream oss;
+    for (int64_t i = 0; i < size; ++i) {
+        T actual_err = abs(actual_ptr[i] - expect_ptr[i]);
+        T allowed_err = bounds_ptr[i];
+        if (actual_err > allowed_err) {
+            FAIL() << std::endl << file_name << ":" << line_no << std::endl
+                    << test_name << std::endl << "Test failed at index "
+                    << i << oss.str() << std::endl;
+            oss.str("");
+        }
+    }
+}
+
+template <typename T>
 void matrices_approx_equal(
     blas::Layout layout,
     blas::Op transB,

--- a/test/test_sparse.cc
+++ b/test/test_sparse.cc
@@ -44,7 +44,6 @@ type_name()
 
 class TestSparseSkOpConstruction : public ::testing::Test
 {
-    // only tests column-sparse SASOs for now.
     protected:
         std::vector<uint32_t> keys{42, 0, 1};
         std::vector<int64_t> vec_nnzs{(int64_t) 1, (int64_t) 2, (int64_t) 3, (int64_t) 7};     

--- a/test/test_sparse.cc
+++ b/test/test_sparse.cc
@@ -269,7 +269,6 @@ void reference_lskges(
         randblas_require(lds >= cols_submat_S);
         randblas_require(lda >= cols_mat_A);
         randblas_require(ldb >= n);
-        // compute size_A.
         size_A = lda * (rows_mat_A - 1) + cols_mat_A;
         size_B = ldb * (d - 1) + n;
     }

--- a/test/test_sparse.cc
+++ b/test/test_sparse.cc
@@ -228,6 +228,9 @@ void reference_lskges(
     T *E,  // allowable floating point error; apply theory + compute by GEMM.
     int64_t ldb
 ){
+    randblas_require(d > 0);
+    randblas_require(m > 0);
+    randblas_require(n > 0);
     std::vector<T> S_dense(S.dist.n_rows * S.dist.n_cols);
     sparseskop_to_dense<T>(S, S_dense.data(), layout, false);
     std::vector<T> S_dense_abs(S.dist.n_rows * S.dist.n_cols);
@@ -258,16 +261,17 @@ void reference_lskges(
         randblas_require(lds >= rows_submat_S);
         randblas_require(lda >= rows_mat_A);
         randblas_require(ldb >= d);
-        size_A = lda * cols_mat_A;
-        size_B = ldb * n;
+        size_A = lda * (cols_mat_A - 1) + rows_mat_A;;
+        size_B = ldb * (n - 1) + d;
     } else {
         lds = S.dist.n_cols;
         pos = i_os * lds + j_os;
         randblas_require(lds >= cols_submat_S);
         randblas_require(lda >= cols_mat_A);
         randblas_require(ldb >= n);
-        size_A = lda * rows_mat_A;
-        size_B = ldb * d;
+        // compute size_A.
+        size_A = lda * (rows_mat_A - 1) + cols_mat_A;
+        size_B = ldb * (d - 1) + n;
     }
 
     // Compute the reference value

--- a/test/test_sparse.cc
+++ b/test/test_sparse.cc
@@ -365,7 +365,7 @@ class TestLSKGES : public ::testing::Test
         // check the result
         RandBLAS_Testing::Util::buffs_approx_equal<T>(
             B0, B1, E, d * n,
-            __PRETTY_FUNCTION__, __FILE_NAME__, __LINE__
+            __PRETTY_FUNCTION__, __FILE__, __LINE__
         );
 
         delete [] a;


### PR DESCRIPTION
This PR is a work in progress. I'll add a proper explanation once it's ready for review.

Need documentation for ...
* The new ``buffs_approx_equal`` function in ``RandBLAS/test_util.hh``.
* ``sparseskop_to_dense`` in ``test_sparse.cc``
* ``reference_lskges`` in ``test_sparse.cc``
