### PR TITLE
Add support for sketching from the right : dense and sparse operators

### DIFF
--- a/RandBLAS/dense.hh
+++ b/RandBLAS/dense.hh
@@ -520,6 +520,107 @@ void lskge3(
     return;
 }
 
+// =============================================================================
+/// RSKGE3: Perform a GEMM-like operation
+/// @verbatim embed:rst:leading-slashes
+/// .. math::
+///     \mat(B) = \alpha \cdot \underbrace{\op(\mat(A))}_{m \times n} \cdot \underbrace{\op(\submat(S))}_{n \times d} + \beta \cdot \underbrace{\mat(B)}_{m \times d},    \tag{$\star$}
+/// @endverbatim
+/// where \math{\alpha} and \math{\beta} are real scalars, \math{\op(X)} either returns a matrix \math{X}
+/// or its transpose, and \math{S} is a sketching operator that takes Level 3 BLAS effort to apply.
+/// 
+/// @verbatim embed:rst:leading-slashes
+/// What are :math:`\mat(A)` and :math:`\mat(B)`?
+///     Their shapes are defined implicitly by :math:`(m, d, n, \transA)`.
+///     Their precise contents are determined by :math:`(A, \lda)`, :math:`(B, \ldb)`,
+///     and "layout", following the same convention as BLAS.
+///
+/// What is :math:`\submat(S)`?
+///     Its shape is defined implicitly by :math:`(\transS, n, d)`.
+///     If :math:`{\submat(S)}` is of shape :math:`r \times c`,
+///     then it is the :math:`r \times c` submatrix of :math:`{S}` whose upper-left corner
+///     appears at index :math:`(\texttt{i_os}, \texttt{j_os})` of :math:`{S}`.
+/// @endverbatim
+/// @param[in] layout
+///     Layout::ColMajor or Layout::RowMajor
+///      - Matrix storage for \math{\mat(A)} and \math{\mat(B)}.
+///
+/// @param[in] transA
+///      - If \math{\transA} == NoTrans, then \math{\op(\mat(A)) = \mat(A)}.
+///      - If \math{\transA} == Trans, then \math{\op(\mat(A)) = \mat(A)^T}.
+///
+/// @param[in] transS
+///      - If \math{\transS} = NoTrans, then \math{ \op(\submat(S)) = \submat(S)}.
+///      - If \math{\transS} = Trans, then \math{\op(\submat(S)) = \submat(S)^T }.
+///
+/// @param[in] m
+///     A nonnegative integer.
+///     - The number of rows in \math{\mat(B)}.
+///     - The number of rows in \math{\op(\mat(A))}.
+///
+/// @param[in] d
+///     A nonnegative integer.
+///     - The number of columns in \math{\mat(B)}
+///     - The number of columns in \math{\op(\mat(S))}.
+///
+/// @param[in] n
+///     A nonnegative integer.
+///     - The number of columns in \math{\op(\mat(A))}
+///     - The number of rows in \math{\op(\submat(S))}.
+///
+/// @param[in] alpha
+///     A real scalar.
+///     - If zero, then \math{A} is not accessed.
+///
+/// @param[in] A
+///     Pointer to a 1D array of real scalars.
+///     - Defines \math{\mat(A)}.
+///
+/// @param[in] lda
+///     A nonnegative integer.
+///     * Leading dimension of \math{\mat(A)} when reading from \math{A}.
+///     * If layout == ColMajor, then
+///         @verbatim embed:rst:leading-slashes
+///             .. math::
+///                 \mat(A)[i, j] = A[i + j \cdot \lda].
+///         @endverbatim
+///       In this case, \math{\lda} must be \math{\geq} the length of a column in \math{\mat(A)}.
+///     * If layout == RowMajor, then
+///         @verbatim embed:rst:leading-slashes
+///             .. math::
+///                 \mat(A)[i, j] = A[i \cdot \lda + j].
+///         @endverbatim
+///       In this case, \math{\lda} must be \math{\geq} the length of a row in \math{\mat(A)}.
+///
+/// @param[in] S
+///    A DenseSkOp object.
+///    - Defines \math{\submat(S)}.
+///
+/// @param[in] i_os
+///     A nonnegative integer.
+///     - The rows of \math{\submat(S)} are a contiguous subset of rows of \math{S}.
+///     - The rows of \math{\submat(S)} start at \math{S[\texttt{i_os}, :]}.
+///
+/// @param[in] j_os
+///     A nonnnegative integer.
+///     - The columns of \math{\submat(S)} are a contiguous subset of columns of \math{S}.
+///     - The columns \math{\submat(S)} start at \math{S[:,\texttt{j_os}]}. 
+///
+/// @param[in] beta
+///     A real scalar.
+///     - If zero, then \math{B} need not be set on input.
+///
+/// @param[in, out] B
+///    Pointer to 1D array of real scalars.
+///    - On entry, defines \math{\mat(B)}
+///      on the RIGHT-hand side of \math{(\star)}.
+///    - On exit, defines \math{\mat(B)}
+///      on the LEFT-hand side of \math{(\star)}.
+///
+/// @param[in] ldb
+///    - Leading dimension of \math{\mat(B)} when reading from \math{B}.
+///    - Refer to documentation for \math{\lda} for details. 
+///
 template <typename T, typename RNG>
 void rskge3(
     blas::Layout layout,

--- a/RandBLAS/sparse.hh
+++ b/RandBLAS/sparse.hh
@@ -845,6 +845,107 @@ void lskges(
 }
 
 
+// =============================================================================
+/// RSKGES: Perform a GEMM-like operation
+/// @verbatim embed:rst:leading-slashes
+/// .. math::
+///     \mat(B) = \alpha \cdot \underbrace{\op(\mat(A))}_{m \times n} \cdot \underbrace{\op(\submat(S))}_{n \times d} + \beta \cdot \underbrace{\mat(B)}_{m \times d},    \tag{$\star$}
+/// @endverbatim
+/// where \math{\alpha} and \math{\beta} are real scalars, \math{\op(X)} either returns a matrix \math{X}
+/// or its transpose, and \math{S} is a sparse sketching operator.
+/// 
+/// @verbatim embed:rst:leading-slashes
+/// What are :math:`\mat(A)` and :math:`\mat(B)`?
+///     Their shapes are defined implicitly by :math:`(m, d, n, \transA)`.
+///     Their precise contents are determined by :math:`(A, \lda)`, :math:`(B, \ldb)`,
+///     and "layout", following the same convention as BLAS.
+///
+/// What is :math:`\submat(S)`?
+///     Its shape is defined implicitly by :math:`(\transS, n, d)`.
+///     If :math:`{\submat(S)}` is of shape :math:`r \times c`,
+///     then it is the :math:`r \times c` submatrix of :math:`{S}` whose upper-left corner
+///     appears at index :math:`(\texttt{i_os}, \texttt{j_os})` of :math:`{S}`.
+/// @endverbatim
+/// @param[in] layout
+///     Layout::ColMajor or Layout::RowMajor
+///      - Matrix storage for \math{\mat(A)} and \math{\mat(B)}.
+///
+/// @param[in] transA
+///      - If \math{\transA} == NoTrans, then \math{\op(\mat(A)) = \mat(A)}.
+///      - If \math{\transA} == Trans, then \math{\op(\mat(A)) = \mat(A)^T}.
+///
+/// @param[in] transS
+///      - If \math{\transS} = NoTrans, then \math{ \op(\submat(S)) = \submat(S)}.
+///      - If \math{\transS} = Trans, then \math{\op(\submat(S)) = \submat(S)^T }.
+///
+/// @param[in] m
+///     A nonnegative integer.
+///     - The number of rows in \math{\mat(B)}.
+///     - The number of rows in \math{\op(\mat(A))}.
+///
+/// @param[in] d
+///     A nonnegative integer.
+///     - The number of columns in \math{\mat(B)}
+///     - The number of columns in \math{\op(\mat(S))}.
+///
+/// @param[in] n
+///     A nonnegative integer.
+///     - The number of columns in \math{\op(\mat(A))}
+///     - The number of rows in \math{\op(\submat(S))}.
+///
+/// @param[in] alpha
+///     A real scalar.
+///     - If zero, then \math{A} is not accessed.
+///
+/// @param[in] A
+///     Pointer to a 1D array of real scalars.
+///     - Defines \math{\mat(A)}.
+///
+/// @param[in] lda
+///     A nonnegative integer.
+///     * Leading dimension of \math{\mat(A)} when reading from \math{A}.
+///     * If layout == ColMajor, then
+///         @verbatim embed:rst:leading-slashes
+///             .. math::
+///                 \mat(A)[i, j] = A[i + j \cdot \lda].
+///         @endverbatim
+///       In this case, \math{\lda} must be \math{\geq} the length of a column in \math{\mat(A)}.
+///     * If layout == RowMajor, then
+///         @verbatim embed:rst:leading-slashes
+///             .. math::
+///                 \mat(A)[i, j] = A[i \cdot \lda + j].
+///         @endverbatim
+///       In this case, \math{\lda} must be \math{\geq} the length of a row in \math{\mat(A)}.
+///
+/// @param[in] S
+///    A SparseSkOp object.
+///    - Defines \math{\submat(S)}.
+///
+/// @param[in] i_os
+///     A nonnegative integer.
+///     - The rows of \math{\submat(S)} are a contiguous subset of rows of \math{S}.
+///     - The rows of \math{\submat(S)} start at \math{S[\texttt{i_os}, :]}.
+///
+/// @param[in] j_os
+///     A nonnnegative integer.
+///     - The columns of \math{\submat(S)} are a contiguous subset of columns of \math{S}.
+///     - The columns \math{\submat(S)} start at \math{S[:,\texttt{j_os}]}. 
+///
+/// @param[in] beta
+///     A real scalar.
+///     - If zero, then \math{B} need not be set on input.
+///
+/// @param[in, out] B
+///    Pointer to 1D array of real scalars.
+///    - On entry, defines \math{\mat(B)}
+///      on the RIGHT-hand side of \math{(\star)}.
+///    - On exit, defines \math{\mat(B)}
+///      on the LEFT-hand side of \math{(\star)}.
+///
+/// @param[in] ldb
+///    - Leading dimension of \math{\mat(B)} when reading from \math{B}.
+///    - Refer to documentation for \math{\lda} for details. 
+///
 template <typename T, typename RNG>
 void rskges(
     blas::Layout layout,

--- a/RandBLAS/test_util.hh
+++ b/RandBLAS/test_util.hh
@@ -97,9 +97,10 @@ void buffs_approx_equal(
         T actual_err = abs(actual_ptr[i] - expect_ptr[i]);
         T allowed_err = bounds_ptr[i];
         if (actual_err > allowed_err) {
-            FAIL() << std::endl << file_name << ":" << line_no << std::endl
-                    << test_name << std::endl << "Test failed at index "
-                    << i << oss.str() << std::endl;
+            FAIL() << std::endl << "\t" <<  file_name << ":" << line_no << std::endl
+                    << "\t" << test_name << std::endl << "\tTest failed at index "
+                    << i << ".\n\t| (" << actual_ptr[i] << ") - (" << expect_ptr[i] << ") | "
+                    << " > " << allowed_err << oss.str() << std::endl;
             oss.str("");
         }
     }

--- a/rtd/source/API/index.rst
+++ b/rtd/source/API/index.rst
@@ -76,6 +76,9 @@ Essentials of dense sketching
 .. doxygenfunction:: RandBLAS::dense::lskge3
    :project: RandBLAS
 
+.. doxygenfunction:: RandBLAS::dense::rskge3
+   :project: RandBLAS
+
 Advanced aspects of dense sketching
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -94,9 +97,7 @@ Helper functions for dense sketching
 Sparse sketching
 ----------------
 
-So, you want to sketch a data matrix with a random sparse operator, do you?
-
-Well, you'll need to do four things.
+Sketching a dense data matrix with a random sparse sketching operator has four steps.
   0. Get your hands on an RNGState :math:`\texttt{state}`.
   1. Define a distribution :math:`\mathcal{D}` over sparse matrices.
   2. Using :math:`\texttt{state}`, sample a sketching operator :math:`S` from :math:`\mathcal{D}`.
@@ -118,6 +119,9 @@ Essentials of sparse sketching
    :members: 
 
 .. doxygenfunction:: RandBLAS::sparse::lskges
+   :project: RandBLAS
+
+.. doxygenfunction:: RandBLAS::sparse::rskges
    :project: RandBLAS
 
 Advanced aspects of sparse sketching

--- a/test/test_dense.cc
+++ b/test/test_dense.cc
@@ -906,7 +906,7 @@ TEST_F(TestRSKGE3, submatrix_s_double_colmajor)
         submatrix_S<double>(seed,
             3, 10, // (cols, rows) in S.
             8, 12, // (cols, rows) in S0.
-            3, // The first row of S is in the forth row of S0
+            2, // The first row of S is in the third row of S0
             1, // The first col of S is in the second col of S0
             blas::Layout::ColMajor
         );
@@ -918,7 +918,7 @@ TEST_F(TestRSKGE3, submatrix_s_double_rowmajor)
         submatrix_S<double>(seed,
             3, 10, // (cols, rows) in S.
             8, 12, // (cols, rows) in S0.
-            3, // The first row of S is in the forth row of S0
+            2, // The first row of S is in the third row of S0
             1, // The first col of S is in the second col of S0
             blas::Layout::RowMajor
         );

--- a/test/test_dense.cc
+++ b/test/test_dense.cc
@@ -559,3 +559,426 @@ TEST(TestDenseThreading, GaussianPhilox) {
 }
 
 #endif
+
+
+
+
+class TestRSKGE3 : public ::testing::Test
+{
+    protected:
+    
+    virtual void SetUp(){};
+
+    virtual void TearDown(){};
+
+    template <typename T>
+    static void sketch_eye(
+        uint32_t seed,
+        int64_t m,
+        int64_t d,
+        bool preallocate,
+        blas::Layout layout
+    ) {
+        // Define the distribution for S0.
+        RandBLAS::dense::DenseDist D = {
+            .n_rows = m,
+            .n_cols = d,
+            .family = RandBLAS::dense::DenseDistName::Gaussian
+        };
+
+        // Define the sketching operator struct, S0.
+        // Create a copy that we always realize explicitly.
+        RandBLAS::dense::DenseSkOp<T> S0(D, seed, NULL, layout);
+        if (preallocate)
+            RandBLAS::dense::realize_full(S0);
+        RandBLAS::dense::DenseSkOp<T> S0_ref(D, seed, NULL, layout);
+        RandBLAS::dense::realize_full(S0_ref);
+
+        // define a matrix to be sketched, and create workspace for sketch.
+        bool is_colmajor = layout == blas::Layout::ColMajor;
+        std::vector<T> A(m * m, 0.0);
+        for (int i = 0; i < m; ++i)
+            A[i + m*i] = 1.0;
+        std::vector<T> B(d * m, 0.0);
+        int64_t lda = m;
+        int64_t ldb = (is_colmajor) ? m : d;
+
+        // Perform the sketch
+        RandBLAS::dense::rskge3<T>(
+            S0.layout,
+            blas::Op::NoTrans,
+            blas::Op::NoTrans,
+            m, d, m,
+            1.0, A.data(), lda,
+            S0, 0, 0,
+            0.0, B.data(), ldb
+        );
+
+        // check the result
+        RandBLAS_Testing::Util::buffs_approx_equal(B.data(), S0_ref.buff, d*m,
+             __PRETTY_FUNCTION__, __FILE__, __LINE__
+        );
+    }
+
+    template <typename T>
+    static void transpose_S(
+        uint32_t seed,
+        int64_t m,
+        int64_t d,
+        blas::Layout layout
+    ) {
+        // Define the distribution for S0.
+        RandBLAS::dense::DenseDist Dt = {
+            .n_rows = d,
+            .n_cols = m,
+            .family = RandBLAS::dense::DenseDistName::Gaussian
+        };
+        // Define the sketching operator struct, S0.
+        RandBLAS::dense::DenseSkOp<T> S0(Dt, seed, NULL, layout);
+        RandBLAS::dense::realize_full(S0);
+        bool is_colmajor = layout == blas::Layout::ColMajor;
+
+        // define a matrix to be sketched, and create workspace for sketch.
+        std::vector<T> A(m * m, 0.0);
+        for (int i = 0; i < m; ++i)
+            A[i + m*i] = 1.0;
+        std::vector<T> B(d * m, 0.0);
+        int64_t ldb = (is_colmajor) ? m : d;
+
+        // perform the sketch
+        RandBLAS::dense::rskge3<T>(
+            S0.layout,
+            blas::Op::NoTrans,
+            blas::Op::Trans,
+            m, d, m,
+            1.0, A.data(), m,
+            S0, 0, 0,
+            0.0, B.data(), ldb   
+        );
+
+        // check that B == S.T
+        int64_t lds = (is_colmajor) ? d : m;
+        RandBLAS_Testing::Util::matrices_approx_equal(
+            S0.layout, blas::Op::Trans, m, d,
+            B.data(), ldb, S0.buff, lds,
+            __PRETTY_FUNCTION__, __FILE__, __LINE__
+        );
+    }
+
+    // TODO: enable tests below for submatrix of S and submatrix of A.
+
+    template <typename T>
+    static void submatrix_S(
+        uint32_t seed,
+        int64_t d, // columns in sketch
+        int64_t m, // size of identity matrix
+        int64_t d0, // cols in S0
+        int64_t m0, // rows in S0
+        int64_t S_ro, // row offset for S in S0
+        int64_t S_co, // column offset for S in S0
+        blas::Layout layout
+    ) {
+        assert(d0 > d);
+        assert(m0 > m);
+        bool is_colmajor = layout == blas::Layout::ColMajor;
+        int64_t pos = (is_colmajor) ? (S_ro + m0 * S_co) : (S_ro * d0 + S_co);
+        assert(d0 * m0 >= pos + d * m);
+
+        // Define the distribution for S0.
+        RandBLAS::dense::DenseDist D = {
+            .n_rows = m0,
+            .n_cols = d0,
+            .family = RandBLAS::dense::DenseDistName::Gaussian
+        };
+        // Define the sketching operator struct, S0.
+        RandBLAS::dense::DenseSkOp<T> S0(D, seed, NULL,  layout);
+        RandBLAS::dense::realize_full(S0);
+        int64_t lds = (is_colmajor) ? S0.dist.n_rows : S0.dist.n_cols;
+
+        // define a matrix to be sketched, and create workspace for sketch.
+        std::vector<T> A(m * m, 0.0);
+        for (int i = 0; i < m; ++i)
+            A[i + m*i] = 1.0;
+        std::vector<T> B(m * d, 0.0);
+        int64_t lda = m;
+        int64_t ldb = (is_colmajor) ? m : d;
+        
+        // Perform the sketch
+        RandBLAS::dense::rskge3<T>(
+            S0.layout,
+            blas::Op::NoTrans,
+            blas::Op::NoTrans,
+            m, d, m,
+            1.0, A.data(), lda,
+            S0, S_ro, S_co,
+            0.0, B.data(), ldb   
+        );
+        // Check the result
+        T *S_ptr = &S0.buff[pos];
+        RandBLAS_Testing::Util::matrices_approx_equal(
+            S0.layout, blas::Op::NoTrans,
+            m, d,
+            B.data(), ldb,
+            S_ptr, lds,
+            __PRETTY_FUNCTION__, __FILE__, __LINE__
+        );
+    }
+
+    template <typename T>
+    static void submatrix_A(
+        uint32_t seed_S0, // seed for S
+        int64_t d, // cols in S
+        int64_t m, // rows in A.
+        int64_t n, // cols in A, rows in S.
+        int64_t m0, // rows in A0
+        int64_t n0, // cols in A0
+        int64_t A_ro, // row offset for A in A0
+        int64_t A_co, // column offset for A in A0
+        blas::Layout layout
+    ) {
+        assert(m0 > m);
+        assert(n0 > n);
+
+        // Define the distribution for S0.
+        RandBLAS::dense::DenseDist D = {
+            .n_rows = n,
+            .n_cols = d,
+            .family = RandBLAS::dense::DenseDistName::Gaussian
+        };
+        // Define the sketching operator struct, S0.
+        RandBLAS::dense::DenseSkOp<T> S0(D, seed_S0, NULL, layout);
+        RandBLAS::dense::realize_full(S0);
+        bool is_colmajor = layout == blas::Layout::ColMajor;
+
+        // define a matrix to be sketched, and create workspace for sketch.
+        std::vector<T> A0(m0 * n0, 0.0);
+        uint32_t seed_A0 = 42000;
+        RandBLAS::dense::DenseDist DA0 = {.n_rows = m0, .n_cols = n0};
+        RandBLAS::dense::fill_buff(A0.data(), DA0, RandBLAS::base::RNGState(seed_A0));
+        std::vector<T> B(m * d, 0.0);
+        int64_t lda = (is_colmajor) ? DA0.n_rows : DA0.n_cols;
+        int64_t ldb = (is_colmajor) ? m : d;
+        
+        // Perform the sketch
+        int64_t a_offset = (is_colmajor) ? (A_ro + m0 * A_co) : (A_ro * n0 + A_co);
+        T *A_ptr = &A0.data()[a_offset]; 
+        RandBLAS::dense::rskge3<T>(
+            S0.layout,
+            blas::Op::NoTrans,
+            blas::Op::NoTrans,
+            m, d, n,
+            1.0, A_ptr, lda,
+            S0, 0, 0,
+            0.0, B.data(), ldb   
+        );
+
+        // Check the result
+        int64_t lds = (is_colmajor) ? S0.dist.n_rows : S0.dist.n_cols;
+        std::vector<T> B_expect(m * d, 0.0);
+        blas::gemm<T>(S0.layout, blas::Op::NoTrans, blas::Op::NoTrans,
+            m, d, n,
+            1.0, A_ptr, lda, S0.buff, lds,
+            0.0, B_expect.data(), ldb
+        );
+        RandBLAS_Testing::Util::buffs_approx_equal(B.data(), B_expect.data(), d * n,
+            __PRETTY_FUNCTION__, __FILE__, __LINE__
+        );
+    }
+
+};
+
+
+////////////////////////////////////////////////////////////////////////
+//
+//
+//      RSKGE3: Basic sketching (vary preallocation, row vs col major)
+//
+//
+////////////////////////////////////////////////////////////////////////
+
+TEST_F(TestRSKGE3, right_sketch_eye_double_preallocate_colmajor)
+{
+    for (uint32_t seed : {0})
+        sketch_eye<double>(seed, 200, 30, true, blas::Layout::ColMajor);
+}
+
+TEST_F(TestRSKGE3, right_sketch_eye_double_preallocate_rowmajor)
+{
+    for (uint32_t seed : {0})
+        sketch_eye<double>(seed, 200, 30, true, blas::Layout::RowMajor);
+}
+
+TEST_F(TestRSKGE3, right_sketch_eye_double_null_colmajor)
+{
+    for (uint32_t seed : {0})
+        sketch_eye<double>(seed, 200, 30, false, blas::Layout::ColMajor);
+}
+
+TEST_F(TestRSKGE3, right_sketch_eye_double_null_rowmajor)
+{
+    for (uint32_t seed : {0})
+        sketch_eye<double>(seed, 200, 30, false, blas::Layout::RowMajor);
+}
+
+TEST_F(TestRSKGE3, right_sketch_eye_single_preallocate)
+{
+    for (uint32_t seed : {0})
+        sketch_eye<float>(seed, 200, 30, true, blas::Layout::ColMajor);
+}
+
+TEST_F(TestRSKGE3, right_sketch_eye_single_null)
+{
+    for (uint32_t seed : {0})
+        sketch_eye<float>(seed, 200, 30, false, blas::Layout::ColMajor);
+}
+
+
+////////////////////////////////////////////////////////////////////////
+//
+//
+//      RSKGE3: Lifting
+//
+//
+////////////////////////////////////////////////////////////////////////
+
+TEST_F(TestRSKGE3, right_lift_eye_double_preallocate_colmajor)
+{
+    for (uint32_t seed : {0})
+        sketch_eye<double>(seed, 10, 51, true, blas::Layout::ColMajor);
+}
+
+TEST_F(TestRSKGE3, right_lift_eye_double_preallocate_rowmajor)
+{
+    for (uint32_t seed : {0})
+        sketch_eye<double>(seed, 10, 51, true, blas::Layout::RowMajor);
+}
+
+TEST_F(TestRSKGE3, right_lift_eye_double_null_colmajor)
+{
+    for (uint32_t seed : {0})
+        sketch_eye<double>(seed, 10, 51, false, blas::Layout::ColMajor);
+}
+
+TEST_F(TestRSKGE3, right_lift_eye_double_null_rowmajor)
+{
+    for (uint32_t seed : {0})
+        sketch_eye<double>(seed, 10, 51, false, blas::Layout::RowMajor);
+}
+
+
+////////////////////////////////////////////////////////////////////////
+//
+//
+//      RSKGE3: transpose of S
+//
+//
+////////////////////////////////////////////////////////////////////////
+
+TEST_F(TestRSKGE3, transpose_double_colmajor)
+{
+    for (uint32_t seed : {0})
+        transpose_S<double>(seed, 200, 30, blas::Layout::ColMajor);
+}
+
+TEST_F(TestRSKGE3, transpose_double_rowmajor)
+{
+    for (uint32_t seed : {0})
+        transpose_S<double>(seed, 200, 30, blas::Layout::RowMajor);
+}
+
+TEST_F(TestRSKGE3, transpose_single)
+{
+    for (uint32_t seed : {0})
+        transpose_S<float>(seed, 200, 30, blas::Layout::ColMajor);
+}
+
+////////////////////////////////////////////////////////////////////////
+//
+//
+//      RSKGE3: Submatrices of S
+//
+//
+////////////////////////////////////////////////////////////////////////
+
+TEST_F(TestRSKGE3, submatrix_s_double_colmajor) 
+{
+    for (uint32_t seed : {0})
+        submatrix_S<double>(seed,
+            3, 10, // (cols, rows) in S.
+            8, 12, // (cols, rows) in S0.
+            3, // The first row of S is in the forth row of S0
+            1, // The first col of S is in the second col of S0
+            blas::Layout::ColMajor
+        );
+}
+
+TEST_F(TestRSKGE3, submatrix_s_double_rowmajor) 
+{
+    for (uint32_t seed : {0})
+        submatrix_S<double>(seed,
+            3, 10, // (cols, rows) in S.
+            8, 12, // (cols, rows) in S0.
+            3, // The first row of S is in the forth row of S0
+            1, // The first col of S is in the second col of S0
+            blas::Layout::RowMajor
+        );
+}
+
+TEST_F(TestRSKGE3, submatrix_s_single) 
+{
+    for (uint32_t seed : {0})
+        submatrix_S<float>(seed,
+            3, 10, // (cols, rows) in S.
+            8, 12, // (cols, rows) in S0.
+            3, // The first row of S is in the forth row of S0
+            1, // The first col of S is in the second col of S0
+            blas::Layout::ColMajor
+        );
+}
+
+////////////////////////////////////////////////////////////////////////
+//
+//
+//     RSKGE3: submatrix of A
+//
+//
+////////////////////////////////////////////////////////////////////////
+
+TEST_F(TestRSKGE3, submatrix_a_double_colmajor) 
+{
+    for (uint32_t seed : {0})
+        submatrix_A<double>(seed,
+            3, // number of columns in sketch
+            10, 5, // (rows, cols) in A.
+            12, 8, // (rows, cols) in A0.
+            2, // The first row of A is in the third row of A0.
+            1, // The first col of A is in the second col of A0.
+            blas::Layout::ColMajor
+        );
+}
+
+TEST_F(TestRSKGE3, submatrix_a_double_rowmajor) 
+{
+    for (uint32_t seed : {0})
+        submatrix_A<double>(seed,
+            3, // number of columns in sketch
+            10, 5, // (rows, cols) in A.
+            12, 8, // (rows, cols) in A0.
+            2, // The first row of A is in the third row of A0.
+            1, // The first col of A is in the second col of A0.
+            blas::Layout::RowMajor
+        );
+}
+
+TEST_F(TestRSKGE3, submatrix_a_single) 
+{
+    for (uint32_t seed : {0})
+        submatrix_A<float>(seed,
+            3, // number of columns in sketch.
+            10, 5, // (rows, cols) in A.
+            12, 8, // (rows, cols) in A0.
+            2, // The first row of A is in the third row of A0.
+            1, // The first col of A is in the second col of A0.
+            blas::Layout::ColMajor
+        );
+}

--- a/test/test_sparse.cc
+++ b/test/test_sparse.cc
@@ -252,14 +252,12 @@ void reference_lskges(
         rows_submat_S = m;
         cols_submat_S = d;
     }
-    randblas_require(S.dist.n_rows >= rows_submat_S);
-    randblas_require(S.dist.n_cols >= cols_submat_S);
-
     // Sanity checks on dimensions and strides
     int64_t lds, pos, size_A, size_B;
     if (layout == blas::Layout::ColMajor) {
         lds = S.dist.n_rows;
         pos = i_os + lds * j_os;
+        randblas_require(lds >= rows_submat_S);
         randblas_require(lda >= rows_mat_A);
         randblas_require(ldb >= d);
         size_A = lda * (cols_mat_A - 1) + rows_mat_A;;
@@ -267,6 +265,7 @@ void reference_lskges(
     } else {
         lds = S.dist.n_cols;
         pos = i_os * lds + j_os;
+        randblas_require(S.dist.n_cols >= cols_submat_S);
         randblas_require(lda >= cols_mat_A);
         randblas_require(ldb >= n);
         size_A = lda * (rows_mat_A - 1) + cols_mat_A;

--- a/test/test_sparse.cc
+++ b/test/test_sparse.cc
@@ -265,7 +265,7 @@ void reference_lskges(
     } else {
         lds = S.dist.n_cols;
         pos = i_os * lds + j_os;
-        randblas_require(S.dist.n_cols >= cols_submat_S);
+        randblas_require(lds >= cols_submat_S);
         randblas_require(lda >= cols_mat_A);
         randblas_require(ldb >= n);
         size_A = lda * (rows_mat_A - 1) + cols_mat_A;

--- a/test/test_sparse.cc
+++ b/test/test_sparse.cc
@@ -295,8 +295,6 @@ void reference_lskges(
     blas::gemm(layout, transS, transA, d, n, m,
         err_alpha, &S_abs_ptr[pos], lds, A_abs, lda, err_beta, E, ldb
     );
-    for (int i = 0; i < d * n; ++i)
-        E[i] = MAX(E[i], eps);
     return;
 }
 

--- a/test/test_sparse.cc
+++ b/test/test_sparse.cc
@@ -252,12 +252,14 @@ void reference_lskges(
         rows_submat_S = m;
         cols_submat_S = d;
     }
+    randblas_require(rows_submat_S <= S.dist.n_rows);
+    randblas_require(cols_submat_S <= S.dist.n_cols);
+
     // Sanity checks on dimensions and strides
     int64_t lds, pos, size_A, size_B;
     if (layout == blas::Layout::ColMajor) {
         lds = S.dist.n_rows;
         pos = i_os + lds * j_os;
-        randblas_require(lds >= rows_submat_S);
         randblas_require(lda >= rows_mat_A);
         randblas_require(ldb >= d);
         size_A = lda * (cols_mat_A - 1) + rows_mat_A;;
@@ -265,7 +267,6 @@ void reference_lskges(
     } else {
         lds = S.dist.n_cols;
         pos = i_os * lds + j_os;
-        randblas_require(lds >= cols_submat_S);
         randblas_require(lda >= cols_mat_A);
         randblas_require(ldb >= n);
         size_A = lda * (rows_mat_A - 1) + cols_mat_A;
@@ -1118,4 +1119,408 @@ TEST_F(TestLSKGES, nontrivial_scales_rowmajor2)
     double alpha = 5.5;
     double beta = -1.0;
     alpha_beta<double>(0, alpha, beta, 21, 4, blas::Layout::RowMajor);
+}
+
+template <typename T, typename RNG>
+void reference_rskges(
+    blas::Layout layout,
+    blas::Op transA,
+    blas::Op transS,
+    int64_t m, // B is m-by-d
+    int64_t d, // op(S) is n-by-d
+    int64_t n, // op(A) is m-by-n
+    T alpha,
+    const T *A,
+    int64_t lda,
+    RandBLAS::sparse::SparseSkOp<T,RNG> &S0,
+    int64_t i_os,
+    int64_t j_os,
+    T beta,
+    T *B, // expected value produced by LSKGES; compute via GEMM.
+    T *E, // allowable floating point error; apply theory + compute by GEMM.
+    int64_t ldb
+) { 
+    using blas::Layout;
+    using blas::Op;
+    auto L = (layout == Layout::ColMajor) ? Layout::RowMajor : Layout::ColMajor;
+    auto opS = (transS == Op::NoTrans) ? Op::Trans : Op::NoTrans;
+    auto opA = (transA == Op::NoTrans) ? Op::Trans : Op::NoTrans;
+    auto S0t = transpose(S0);    
+    reference_lskges(L, opS, opA, d, m, n, alpha, S0t, j_os, i_os, A, lda, beta, B, E, ldb);
+}
+
+
+
+class TestRSKGES : public ::testing::Test
+{
+    protected:
+        static inline std::vector<uint32_t> keys = {42, 0, 1};
+        static inline std::vector<int64_t> vec_nnzs = {1, 2, 3, 7};     
+    
+    virtual void SetUp() {};
+
+    virtual void TearDown() {};
+
+    //
+    //
+    //  TODO: create a basic sketch_eye test for RSKGES, like that for RSKGE3 in test_dense.cc.
+    //  TODO: make an apply function for LSKGE3 and RSKGE3, like this apply function like this in test_dense.cc.
+    //      Don't spent too much time on this. Maybe write it from scratch to avoid repeat bugs?
+    //
+    //
+
+    template <typename T>
+    static void apply(
+        RandBLAS::sparse::SparsityPattern distname,
+        int64_t d,
+        int64_t m,
+        int64_t n,
+        blas::Layout layout,
+        int64_t key_index,
+        int64_t nnz_index,
+        int threads
+    ) {
+#if !defined (RandBLAS_HAS_OpenMP)
+        UNUSED(threads);
+#endif
+        uint32_t a_seed = 99;
+        bool is_colmajor = layout == blas::Layout::ColMajor;
+
+        // construct test data: matrix A, SparseSkOp "S0", and dense representation S
+        T *a = new T[m * n];
+        T *B0 = new T[m * d]{};
+        RandBLAS::util::genmat(m, n, a, a_seed);  
+        RandBLAS::sparse::SparseDist D = {
+            .n_rows=n, .n_cols=d, .family=distname, .vec_nnz=vec_nnzs[nnz_index]
+        };
+        RandBLAS::sparse::SparseSkOp<T> S0(D, keys[key_index]);
+        RandBLAS::sparse::fill_sparse(S0);
+        int64_t lda = (is_colmajor) ? m : n;
+        int64_t ldb = (is_colmajor) ? m : d;
+
+        // compute S*A. 
+#if defined (RandBLAS_HAS_OpenMP)
+        int orig_threads = omp_get_num_threads();
+        omp_set_num_threads(threads);
+#endif
+        RandBLAS::sparse::rskges<T>(
+            layout, blas::Op::NoTrans, blas::Op::NoTrans,
+            m, d, n,
+            1.0, a, lda,
+            S0, 0, 0,
+            0.0, B0, ldb 
+        );
+#if defined (RandBLAS_HAS_OpenMP)
+        omp_set_num_threads(orig_threads);
+#endif
+
+        // compute expected result (B1) and allowable error (E)
+        T *B1 = new T[d * m]{};
+        T *E = new T[d * m]{};
+        reference_rskges<T>(
+            layout, blas::Op::NoTrans, blas::Op::NoTrans,
+            m, d, n,
+            1.0, a, lda,
+            S0, 0, 0,
+            0.0, B1, E, ldb
+        );
+
+        // check the result
+        RandBLAS_Testing::Util::buffs_approx_equal<T>(
+            B0, B1, E, m * d,
+            __PRETTY_FUNCTION__, __FILE__, __LINE__
+        );
+
+        delete [] a;
+        delete [] B0;
+        delete [] B1;
+        delete [] E;
+    }
+
+    template <typename T>
+    static void submatrix_S(
+        uint32_t seed,
+        int64_t d1, // cols in sketch
+        int64_t n1, // size of identity matrix
+        int64_t d0, // cols in S0
+        int64_t n0, // rows in S0
+        int64_t S_ro, // row offset for S in S0
+        int64_t S_co, // column offset for S in S0
+        blas::Layout layout
+    ) {
+        assert(d0 >= d1);
+        assert(n0 >= n1);
+        bool is_colmajor = layout == blas::Layout::ColMajor;
+        int64_t pos = (is_colmajor) ? (S_ro + n0 * S_co) : (S_ro * d0 + S_co);
+        assert(d0 * n0 >= pos + d1 * n1);
+
+        int64_t vec_nnz = d0 / 3; // this is actually quite dense. 
+        RandBLAS::sparse::SparseSkOp<T> S0(
+            {n0, d0, RandBLAS::sparse::SparsityPattern::SASO, vec_nnz}, seed
+        );
+        RandBLAS::sparse::fill_sparse(S0);
+        T *S0_dense = new T[n0 * d0];
+        sparseskop_to_dense<T>(S0, S0_dense, layout);
+        int64_t ldb = (is_colmajor) ? n1 : d1;
+        int64_t lds0 = (is_colmajor) ? n0 : d0;
+
+
+        // define a matrix to be sketched, and create workspace for sketch.
+        std::vector<T> A(n1 * n1, 0.0);
+        for (int i = 0; i < n1; ++i)
+            A[i + n1*i] = 1.0;
+        std::vector<T> B(n1 * d1, 0.0);
+        
+        // Perform the sketch
+#if defined (RandBLAS_HAS_OpenMP)
+        int orig_threads = omp_get_num_threads();
+        omp_set_num_threads(1);
+#endif
+        RandBLAS::sparse::rskges<T>(
+            layout,
+            blas::Op::NoTrans,
+            blas::Op::NoTrans,
+            n1, d1, n1,
+            1.0, A.data(), n1,
+            S0, S_ro, S_co,
+            0.0, B.data(), ldb   
+        );
+#if defined (RandBLAS_HAS_OpenMP)
+        omp_set_num_threads(orig_threads);
+#endif
+
+        // Check the result
+        RandBLAS_Testing::Util::matrices_approx_equal(
+            layout, blas::Op::NoTrans,
+            n1, d1,
+            B.data(), ldb,
+            &S0_dense[pos], lds0,
+            __PRETTY_FUNCTION__, __FILE__, __LINE__
+        );
+
+        delete [] S0_dense;
+    }
+};
+
+////////////////////////////////////////////////////////////////////////
+//
+//
+//      RSKGES: Sketch with SASOs and LASOs.
+//
+//
+////////////////////////////////////////////////////////////////////////
+
+TEST_F(TestRSKGES, sketch_saso_rowMajor_oneThread)
+{
+    for (int64_t k_idx : {0, 1, 2}) {
+        for (int64_t nz_idx: {1, 2, 3, 0}) {
+            apply<double>(RandBLAS::sparse::SparsityPattern::SASO,
+                19, 201, 12, blas::Layout::RowMajor, k_idx, nz_idx, 1
+            );
+            apply<float>(RandBLAS::sparse::SparsityPattern::SASO,
+                19, 201, 12, blas::Layout::RowMajor, k_idx, nz_idx, 1
+            );
+        }
+    }
+}
+
+
+TEST_F(TestRSKGES, sketch_laso_rowMajor_oneThread)
+{
+    for (int64_t k_idx : {0, 1, 2}) {
+        for (int64_t nz_idx: {1, 2, 3, 0}) {
+            apply<double>(RandBLAS::sparse::SparsityPattern::LASO, 19, 201, 12, blas::Layout::RowMajor, k_idx, nz_idx, 1);
+            apply<float>(RandBLAS::sparse::SparsityPattern::LASO, 19, 201, 12, blas::Layout::RowMajor, k_idx, nz_idx, 1);
+        }
+    }
+}
+
+TEST_F(TestRSKGES, sketch_saso_colMajor_oneThread)
+{
+    for (int64_t k_idx : {0, 1, 2}) {
+        for (int64_t nz_idx: {1, 2, 3, 0}) {
+            apply<double>(RandBLAS::sparse::SparsityPattern::SASO, 19, 201, 12, blas::Layout::ColMajor, k_idx, nz_idx, 1);
+            apply<float>(RandBLAS::sparse::SparsityPattern::SASO, 19, 201, 12, blas::Layout::ColMajor, k_idx, nz_idx, 1);
+        }
+    }
+}
+
+TEST_F(TestRSKGES, sketch_laso_colMajor_oneThread)
+{
+    for (int64_t k_idx : {0, 1, 2}) {
+        for (int64_t nz_idx: {1, 2, 3, 0}) {
+            apply<double>(RandBLAS::sparse::SparsityPattern::LASO, 19, 201, 12, blas::Layout::ColMajor, k_idx, nz_idx, 1);
+            apply<float>(RandBLAS::sparse::SparsityPattern::LASO, 19, 201, 12, blas::Layout::ColMajor, k_idx, nz_idx, 1);
+        }
+    }
+}
+
+
+////////////////////////////////////////////////////////////////////////
+//
+//
+//      RSKGES: Lift with SASOs and LASOs.
+//
+//
+////////////////////////////////////////////////////////////////////////
+
+
+TEST_F(TestRSKGES, lift_saso_rowMajor_oneThread)
+{
+    for (int64_t k_idx : {0, 1, 2}) {
+        for (int64_t nz_idx: {1, 2, 3, 0}) {
+            apply<double>(RandBLAS::sparse::SparsityPattern::SASO,
+                201, 19, 12, blas::Layout::RowMajor, k_idx, nz_idx, 1
+            );
+            apply<float>(RandBLAS::sparse::SparsityPattern::SASO,
+                201, 19, 12, blas::Layout::RowMajor, k_idx, nz_idx, 1
+            );
+        }
+    }
+}
+
+TEST_F(TestRSKGES, lift_laso_rowMajor_oneThread)
+{
+    for (int64_t k_idx : {0, 1, 2}) {
+        for (int64_t nz_idx: {1, 2, 3, 0}) {
+            apply<double>(RandBLAS::sparse::SparsityPattern::LASO, 201, 19, 12, blas::Layout::RowMajor, k_idx, nz_idx, 1);
+            apply<float>(RandBLAS::sparse::SparsityPattern::LASO, 201, 19, 12, blas::Layout::RowMajor, k_idx, nz_idx, 1);
+        }
+    }
+}
+
+TEST_F(TestRSKGES, lift_saso_colMajor_oneThread)
+{
+    for (int64_t k_idx : {0, 1, 2}) {
+        for (int64_t nz_idx: {1, 2, 3, 0}) {
+            apply<double>(RandBLAS::sparse::SparsityPattern::SASO, 201, 19, 12, blas::Layout::ColMajor, k_idx, nz_idx, 1);
+            apply<float>(RandBLAS::sparse::SparsityPattern::SASO, 201, 19, 12, blas::Layout::ColMajor, k_idx, nz_idx, 1);
+        }
+    }
+}
+
+TEST_F(TestRSKGES, lift_laso_colMajor_oneThread)
+{
+    for (int64_t k_idx : {0, 1, 2}) {
+        for (int64_t nz_idx: {1, 2, 3, 0}) {
+            apply<double>(RandBLAS::sparse::SparsityPattern::LASO, 201, 19, 12, blas::Layout::ColMajor, k_idx, nz_idx, 1);
+            apply<float>(RandBLAS::sparse::SparsityPattern::LASO, 201, 19, 12, blas::Layout::ColMajor, k_idx, nz_idx, 1);
+        }
+    }
+}
+
+
+////////////////////////////////////////////////////////////////////////
+//
+//
+//      RSKGES: Submatrices of S, column major
+//
+//
+////////////////////////////////////////////////////////////////////////
+
+
+TEST_F(TestRSKGES, subset_rows_s_colmajor1) 
+{
+    for (uint32_t seed : {0})
+        submatrix_S<double>(seed,
+            3, 10, // (cols, rows) in S.
+            8, 10, // (cols, rows) in S0.
+            0,
+            0,
+            blas::Layout::ColMajor
+        );
+}
+
+TEST_F(TestRSKGES, subset_rows_s_colmajor2) 
+{
+    for (uint32_t seed : {0})
+        submatrix_S<double>(seed,
+            3, 10, // (cols, rows) in S.
+            8, 10, // (cols, rows) in S0.
+            0,
+            3,  // The first column of S is in the forth column of S0
+            blas::Layout::ColMajor
+        );
+}
+
+TEST_F(TestRSKGES, subset_cols_s_colmajor1) 
+{
+    for (uint32_t seed : {0})
+        submatrix_S<double>(seed,
+            3, 10, // (cols, rows) in S.
+            3, 12, // (cols, rows) in S0.
+            0,
+            0,
+            blas::Layout::ColMajor
+        );
+}
+
+TEST_F(TestRSKGES, subset_cols_s_colmajor2) 
+{
+    for (uint32_t seed : {0})
+        submatrix_S<double>(seed,
+            3, 10, // (cols, rows) in S.
+            3, 12, // (cols, rows) in S0.
+            1, // The first row of S is in the second row of S0
+            0,
+            blas::Layout::ColMajor
+        );
+}
+
+
+////////////////////////////////////////////////////////////////////////
+//
+//
+//      RSKGES: Submatrices of S,row major
+//
+//
+////////////////////////////////////////////////////////////////////////
+
+
+TEST_F(TestRSKGES, subset_rows_s_rowmajor1) 
+{
+    for (uint32_t seed : {0})
+        submatrix_S<double>(seed,
+            3, 10, // (cols, rows) in S.
+            8, 10, // (cols, rows) in S0.
+            0,
+            0,
+            blas::Layout::RowMajor
+        );
+}
+
+TEST_F(TestRSKGES, subset_rows_s_rowmajor2) 
+{
+    for (uint32_t seed : {0})
+        submatrix_S<double>(seed,
+            3, 10, // (cols, rows) in S.
+            8, 10, // (cols, rows) in S0.
+            0,
+            3, // The first column of S is in the forth column of S0
+            blas::Layout::RowMajor
+        );
+}
+
+TEST_F(TestRSKGES, subset_cols_s_rowmajor1) 
+{
+    for (uint32_t seed : {0})
+        submatrix_S<double>(seed,
+            3, 10, // (cols, rows) in S.
+            3, 12, // (cols, rows) in S0.
+            0,
+            0,
+            blas::Layout::RowMajor
+        );
+}
+
+TEST_F(TestRSKGES, subset_cols_s_rowmajor2) 
+{
+    for (uint32_t seed : {0})
+        submatrix_S<double>(seed,
+            3, 10, // (cols, rows) in S.
+            3, 12, // (cols, rows) in S0.
+            1, // The first row of S is in the second row of S0
+            0,
+            blas::Layout::RowMajor
+        );
 }


### PR DESCRIPTION
### Main changes

This PR implements right-sketching with dense and sparse operators. The implementations pass reasonably thorough tests. Documentation is included for right-sketching in a way that matches left-sketching.

### Secondary changes

This PR also simplifies a private helper function that's used with sparse sketching. The helper function's behavior was very complicated because it tried to avoid allocating memory. I've decided that for the sake of readability and simplicity, we should just _always_ allocate that memory. The effect of this change is that the new LSKGES and RSKGES have about double the workspace requirement of the old LSKGES.

To bring this point home, I'll note that this means our sparse and dense sketching operators have different memory management semantics. With dense sketching, it's possible to define things so that [L/R]GESK3 does not allocate any dynamically sized arrays. But as of this PR, it's no longer possible to do that with sparse sketching. My belief (of which I'm fairly confident) is that this inefficiency will not have an observable impact on performance in downstream applications.

### Remarks

Writing tests for this functionality was a bit onerous. I think we'd benefit from figuring out how to abstract away certain differences in testing with dense vs sparse operators. It might also be helpful to have each file test one method instead of one class.