### PR TITLE
API change for fill_dense, plus fixes for Random123's sincospi on macOS.

### DIFF
--- a/.github/workflows/core-linux.yaml
+++ b/.github/workflows/core-linux.yaml
@@ -44,7 +44,7 @@ jobs:
           mkdir RandBLAS-build
           cd RandBLAS-build
           cmake -DCMAKE_BUILD_TYPE=Release \
-            -Dblaspp_DIR=`pwd`/../blaspp-install/lib/blaspp/ \
+            -Dblaspp_DIR=`pwd`/../blaspp-install/lib/cmake/blaspp/ \
             -DRandom123_DIR=`pwd`/../Random123-install/include/ \
             -DCMAKE_INSTALL_PREFIX=`pwd`/../RandBLAS-install \
             -DCMAKE_BINARY_DIR=`pwd` \
@@ -59,7 +59,7 @@ jobs:
           cd RandBLAS-asan-build
           cmake -DCMAKE_BUILD_TYPE=Debug \
             -DSANITIZE_ADDRESS=ON \
-            -Dblaspp_DIR=`pwd`/../blaspp-install/lib/blaspp/ \
+            -Dblaspp_DIR=`pwd`/../blaspp-install/lib/cmake/blaspp/ \
             -DRandom123_DIR=`pwd`/../Random123-install/include/ \
             -DCMAKE_INSTALL_PREFIX=`pwd`/../RandBLAS-install \
             -DCMAKE_BINARY_DIR=`pwd` \

--- a/.github/workflows/core-macos.yml
+++ b/.github/workflows/core-macos.yml
@@ -39,7 +39,7 @@ jobs:
           mkdir RandBLAS-build
           cd RandBLAS-build
           cmake -DCMAKE_BUILD_TYPE=Release \
-            -Dblaspp_DIR=`pwd`/../blaspp-install/lib/blaspp/ \
+            -Dblaspp_DIR=`pwd`/../blaspp-install/lib/cmake/blaspp/ \
             -DRandom123_DIR=`pwd`/../Random123-install/include/ \
             -DCMAKE_INSTALL_PREFIX=`pwd`/../RandBLAS-install \
             -DCMAKE_BINARY_DIR=`pwd` \
@@ -54,7 +54,7 @@ jobs:
           cd RandBLAS-asan-build
           cmake -DCMAKE_BUILD_TYPE=Debug \
             -DSANITIZE_ADDRESS=ON \
-            -Dblaspp_DIR=`pwd`/../blaspp-install/lib/blaspp/ \
+            -Dblaspp_DIR=`pwd`/../blaspp-install/lib/cmake/blaspp/ \
             -DRandom123_DIR=`pwd`/../Random123-install/include/ \
             -DCMAKE_INSTALL_PREFIX=`pwd`/../RandBLAS-install \
             -DCMAKE_BINARY_DIR=`pwd` \

--- a/.github/workflows/openmp-macos.yaml
+++ b/.github/workflows/openmp-macos.yaml
@@ -47,7 +47,7 @@ jobs:
             -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ \
             -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang \
             -DCMAKE_BUILD_TYPE=Release \
-            -Dblaspp_DIR=`pwd`/../blaspp-install/lib/blaspp/ \
+            -Dblaspp_DIR=`pwd`/../blaspp-install/lib/cmake/blaspp/ \
             -DRandom123_DIR=`pwd`/../Random123-install/include/ \
             -DCMAKE_INSTALL_PREFIX=`pwd`/../RandBLAS-install \
             ../RandBLAS

--- a/RandBLAS/dense.hh
+++ b/RandBLAS/dense.hh
@@ -518,22 +518,20 @@ void lskge3(
     }
 
     // Sanity checks on dimensions and strides
+    if (opposing_layouts) {
+        randblas_require(S.dist.n_rows >= cols_submat_S + i_off);
+        randblas_require(S.dist.n_cols >= rows_submat_S + j_off);
+    } else {
+        randblas_require(S.dist.n_rows >= rows_submat_S + i_off);
+        randblas_require(S.dist.n_cols >= cols_submat_S + j_off);
+    }
+
     int64_t lds, pos;
     if (S.layout == blas::Layout::ColMajor) {
         lds = S.dist.n_rows;
-        if (opposing_layouts) {
-            randblas_require(lds >= cols_submat_S);
-        } else {
-            randblas_require(lds >= rows_submat_S);
-        }
         pos = i_off + lds * j_off;
     } else {
         lds = S.dist.n_cols;
-        if (opposing_layouts) {
-            randblas_require(lds >= rows_submat_S);
-        } else {
-            randblas_require(lds >= cols_submat_S);
-        }
         pos = i_off * lds + j_off;
     }
 

--- a/RandBLAS/dense.hh
+++ b/RandBLAS/dense.hh
@@ -380,16 +380,18 @@ std::pair<blas::Layout, RandBLAS::RNGState<RNG>> fill_dense(
     switch (D.family) {
         case DenseDistName::Gaussian: {
             auto next_state_g = fill_dense_submat_impl<T,RNG,r123ext::boxmul>(ma_len, buff, n_rows_, n_cols_, ptr, seed);
-            return std::make_tuple(layout, next_state_g);
+            return std::make_pair(layout, next_state_g);
         }
         case DenseDistName::Uniform: {
             auto next_state_u = fill_dense_submat_impl<T,RNG,r123ext::uneg11>(ma_len, buff, n_rows_, n_cols_, ptr, seed);
-            return std::make_tuple(layout, next_state_u);
+            return std::make_pair(layout, next_state_u);
         }
-        case DenseDistName::BlackBox:
+        case DenseDistName::BlackBox: {
             throw std::invalid_argument(std::string("fill_buff cannot be called with the BlackBox distribution."));
-        default:
+        }
+        default: {
             throw std::runtime_error(std::string("Unrecognized distribution."));
+        }
     }
 }
  

--- a/RandBLAS/dense.hh
+++ b/RandBLAS/dense.hh
@@ -331,30 +331,6 @@ RNGState<RNG> fill_dense(
     return fill_dense_submat(D, buff, D.n_rows, D.n_cols, 0, 0, state);
 }
 
-template <typename T, typename RNG>
-RNGState<RNG> fill_dense(
-    const DenseDist &D,
-    int64_t n_rows,
-    int64_t n_cols,
-    int64_t i_off,
-    int64_t j_off,
-    blas::Layout layout,
-    T* S_buff,
-    int64_t lds,
-    const RNGState<RNG> &state
-) {
-    // We want the (n_rows by n_cols) operator whose upper-left corner
-    // is at index (i_off, j_off) of a sketching operator drawn from D.
-    //
-    // The operator needs to be stored in "layout" order.
-
-    // Note: the major-axis and aspect ratio of D imply a layout
-    // that we assume in our implementation of lskge3 / rskge3.
-    // That layout might not be the same as the "layout" argument here.
-    // If that happens then we ... what? 
-    throw std::runtime_error(std::string("Not implemented"));
-}
-
 template <typename SKOP>
 auto fill_dense(
     SKOP &S

--- a/RandBLAS/random_gen.hh
+++ b/RandBLAS/random_gen.hh
@@ -3,11 +3,32 @@
 
 /// @file
 
+#include <Random123/features/compilerfeatures.h>
+
 // this is for sincosf
 #if !defined(_GNU_SOURCE)
 #define _GNU_SOURCE
 #endif
 #include <math.h>
+
+#if !defined(R123_NO_SINCOS) && defined(__APPLE__)
+/* MacOS X 10.10.5 (2015) doesn't have sincosf */
+// use "-D __APPLE__" as a compiler flag to make sure this is hit.
+#define R123_NO_SINCOS 1
+#endif
+
+#if R123_NO_SINCOS /* enable this if sincos and sincosf are not in the math library */
+R123_CUDA_DEVICE R123_STATIC_INLINE void sincosf(float x, float *s, float *c) {
+    *s = sinf(x);
+    *c = cosf(x);
+}
+
+R123_CUDA_DEVICE R123_STATIC_INLINE void sincos(double x, double *s, double *c) {
+    *s = sin(x);
+    *c = cos(x);
+}
+#endif /* sincos is not in the math library */
+
 // this is for sincosf
 #if !defined(__CUDACC__)
 static inline void sincospif(float x, float *s, float *c) {
@@ -21,7 +42,6 @@ static inline void sincospi(double x, double *s, double *c) {
 }
 #endif
 
-#include <math.h>
 #include <Random123/array.h>
 #include <Random123/philox.h>
 #include <Random123/threefry.h>

--- a/RandBLAS/sparse.hh
+++ b/RandBLAS/sparse.hh
@@ -216,8 +216,8 @@ SparseSkOp<T,RNG>::~SparseSkOp() {
 // =============================================================================
 /// Populate the internal data structures of S with values that are 
 /// consistent with S.dist and S.seed_state. This step is needed before
-/// S can be applied to data matrices. LSKGES and RSKGES will automatically
-/// perform this step if needed.
+/// S can be applied to data matrices. Sketching functions in RandBLAS will
+/// automatically call this function if needed.
 ///
 /// @param[in] S
 ///     SparseSkOp object.

--- a/rtd/source/abstract_interface.rst
+++ b/rtd/source/abstract_interface.rst
@@ -62,10 +62,13 @@ Dense sketching operators
    :project: RandBLAS
    :members: 
 
-.. doxygenfunction:: RandBLAS::fill_dense(const DenseDist &D, T *buff, RNGState<RNG> const& state)
+.. doxygenfunction:: RandBLAS::fill_dense(const DenseDist &D, int64_t n_rows, int64_t n_cols, int64_t i_off, int64_t j_off, T *buff, const RNGState<RNG> &seed)
    :project: RandBLAS
 
-.. doxygenfunction:: RandBLAS::fill_dense(SKOP &S)
+.. doxygenfunction:: RandBLAS::fill_dense(const DenseDist &D, T *buff, const RNGState<RNG> &seed)
+   :project: RandBLAS
+
+.. doxygenfunction:: RandBLAS::fill_dense(DenseSkOp<T, RNG> &S)
    :project: RandBLAS
 
 Sparse sketching operators

--- a/test/test_dense/test_construction.cc
+++ b/test/test_dense/test_construction.cc
@@ -366,7 +366,7 @@ class TestStateUpdate : public ::testing::Test
         };
 
         auto state = RandBLAS::RNGState(key);
-        auto next_state = RandBLAS::fill_dense(D, A.data(), state);
+        auto [layout, next_state] = RandBLAS::fill_dense(D, A.data(), state);
         RandBLAS::fill_dense(D, B.data(), next_state);
 
         ASSERT_TRUE(!(A == B));
@@ -409,7 +409,7 @@ class TestStateUpdate : public ::testing::Test
         auto state1 = RandBLAS::RNGState(key);
 
         // Concatenates two matrices generated from state and next_state
-        auto next_state = RandBLAS::fill_dense(D1, A.data(), state);
+        auto [layout, next_state] = RandBLAS::fill_dense(D1, A.data(), state);
         RandBLAS::fill_dense(D3, A.data() + (int64_t) (D1.n_rows * D1.n_cols), next_state);
 
         RandBLAS::fill_dense(D2, B.data(), state1);
@@ -441,7 +441,7 @@ class TestStateUpdate : public ::testing::Test
 
         typename RNG::ctr_type c_ref = state_copy.counter;
 
-        auto final_state = RandBLAS::dense::fill_dense(D, buff, state);
+        auto [layout, final_state] = RandBLAS::dense::fill_dense(D, buff, state);
         auto c = final_state.counter;
         int c_len = c.size();
 

--- a/test/test_dense/test_construction.cc
+++ b/test/test_dense/test_construction.cc
@@ -52,7 +52,7 @@ class TestDenseMoments : public ::testing::Test
             .family = dn
         };
         auto state = RandBLAS::RNGState(key);
-        auto next_state = RandBLAS::fill_dense(D, A.data(), state);
+        auto [layout, next_state] = RandBLAS::fill_dense(D, A.data(), state);
 
         // Compute the entrywise empirical mean and standard deviation.
         T mean = std::accumulate(A.data(), A.data() + size, 0.0) /size;


### PR DESCRIPTION
Content of this PR:
* Changed ``blaspp_DIR`` used by CMake in GitHub Actions. This was necessary because blaspp recently changed the folder structure of their installation. Lapackpp presumably has undergone a similar change. We'll need to update RandLAPACK to reflect this. We might also need to update READMEs.
* Cosmetic changes (variable renaming) in ``dense.hh``.
* Renamed ``fill_dense_submat`` to be yet another overload of ``fill_dense``. The latter now has two overloads that populate user-provided buffers. These two overloads return a ``std::pair`` that we intend for the user to unpack with C++ structured bindings. The first element of this pair specifies the layout of the populated buffer. The second element is the updated random state.
* Wrote documentation for all ``fill_dense`` functions.
* Changed dimension sanity checks in LSKGE3 to be the same as those from RSKGE3.
* Updated ``RandBLAS/random_gen.hh`` to include more fixes related to Random123 and compiling on macOS. The fix is a bit messy now.