### PR TITLE
WIP : sketching sparse data matrices

### DIFF
--- a/RandBLAS.hh
+++ b/RandBLAS.hh
@@ -5,7 +5,7 @@
 #include <RandBLAS/exceptions.hh>
 #include <RandBLAS/base.hh>
 #include <RandBLAS/util.hh>
-#include <RandBLAS/sparse.hh>
+#include <RandBLAS/sparse_skops.hh>
 #include <RandBLAS/dense.hh>
 #include <RandBLAS/skge.hh>
 

--- a/RandBLAS/skge.hh
+++ b/RandBLAS/skge.hh
@@ -5,7 +5,7 @@
 #include "RandBLAS/exceptions.hh"
 #include "RandBLAS/random_gen.hh"
 #include "RandBLAS/dense.hh"
-#include "RandBLAS/sparse.hh"
+#include "RandBLAS/sparse_skops.hh"
 
 #include <blas.hh>
 

--- a/RandBLAS/sparse_data.hh
+++ b/RandBLAS/sparse_data.hh
@@ -1,0 +1,55 @@
+#ifndef randblas_sparse_data.hh
+#define randblas_sparse_data.hh
+
+#include "RandBLAS/config.h"
+#include "RandBLAS/base.hh"
+#include <blas.hh>
+
+namespace RandBLAS::sparse_data {
+
+enum class IndexBase : char {
+    // ---------------------------------------------------------------
+    // zero-based indexing
+    Zero = 'Z',
+    // ---------------------------------------------------------------
+    // one-based indexing
+    One = 'O'
+};
+
+template <typename T>
+struct SparseMatrix {
+    const int64_t n_rows;
+    const int64_t n_cols;
+    const int64_t nnz;
+    const IndexBase index_base;
+    const T *vals;
+};
+
+template <typename T>
+struct CSCMatrix : SparseMatrix<T> {
+    const int64_t *colptr;
+    const int64_t *rowidxs;
+};
+
+template <typename T>
+struct CSRMatrix : SparseMatrix<T> {
+    const int64_t *rowptr;
+    const int64_t *colidxs;
+};
+
+enum class NonzeroSort : char {
+    CSC = 'C',
+    CSR = 'R',
+    None = 'N'
+};
+
+template <typename T>
+struct COOMatrix : SparseMatrix<T> {
+    const int64_t *rows;
+    const int64_t *cols;
+    const NonzeroSort sort;
+};
+
+} // end namespace RandBLAS::sparse_data
+
+#endif

--- a/RandBLAS/sparse_skops.hh
+++ b/RandBLAS/sparse_skops.hh
@@ -1,5 +1,5 @@
-#ifndef randblas_sparse_hh
-#define randblas_sparse_hh
+#ifndef randblas_sparse_skops.hh
+#define randblas_sparse_skops.hh
 
 #include "RandBLAS/config.h"
 #include "RandBLAS/base.hh"

--- a/RandBLAS/test_util.hh
+++ b/RandBLAS/test_util.hh
@@ -16,7 +16,7 @@
 #include <cstdlib>
 
 #include <RandBLAS/dense.hh>
-#include <RandBLAS/sparse.hh>
+#include <RandBLAS/sparse_skops.hh>
 #include <RandBLAS/util.hh>
 #include <math.h>
 

--- a/test/test_sparse/test_construction.cc
+++ b/test/test_sparse/test_construction.cc
@@ -1,5 +1,5 @@
 #include <RandBLAS/dense.hh>
-#include <RandBLAS/sparse.hh>
+#include <RandBLAS/sparse_skops.hh>
 #include <RandBLAS/util.hh>
 #include <RandBLAS/test_util.hh>
 #include <gtest/gtest.h>

--- a/test/test_sparse/test_sketch_gefls.cc
+++ b/test/test_sparse/test_sketch_gefls.cc
@@ -1,5 +1,5 @@
 #include <RandBLAS/dense.hh>
-#include <RandBLAS/sparse.hh>
+#include <RandBLAS/sparse_skops.hh>
 #include <RandBLAS/skge.hh>
 #include <RandBLAS/util.hh>
 #include <RandBLAS/test_util.hh>

--- a/test/test_sparse/test_sketch_gefrs.cc
+++ b/test/test_sparse/test_sketch_gefrs.cc
@@ -1,5 +1,5 @@
 #include <RandBLAS/dense.hh>
-#include <RandBLAS/sparse.hh>
+#include <RandBLAS/sparse_skops.hh>
 #include <RandBLAS/skge.hh>
 #include <RandBLAS/util.hh>
 #include <RandBLAS/test_util.hh>


### PR DESCRIPTION
This PR will take _a while_ to complete. Per the title, the goal is to support sketching sparse data matrices. After attending the SparseBLAS workshop I feel that some big-picture design questions are worth revisiting. I'm only opening the PR now to track my thoughts on the matter.

### Approach 1. It's can't be that hard, let's just do it ourselves.

After attending the SparseBLAS workshop it became clear that the needs for sketching sparse matrices are much simpler than the needs for general sparse BLAS. This suggests an approach where we just make everything we need directly in RandBLAS. That is, we'd make ...

1. classes (or rather, structs) for sparse matrices in CSC, CSR, and COO formats.
2. deterministic methods for computing products with (sub)matrices in these formats.
3. (Using the above ...) methods for sketching (sub)matrices in these formats, using dense sketching operators.

There's a question here of whether we should expose the first group of methods in the public API. Right now I think we should, for two reasons. First, exposing that functionality means that RandBLAS plus any dense linear algebra library would suffice to implement things like low-rank SVD or a sketch-and-precondition approach to least squares, and that sounds like a nice selling point. Second, if this functionality was not exposed, then it would become more important to provide seamless interoperability with sparse matrix objects from different libraries (like Eigen, OneAPI, or Kokkos Kernels).


### Approach 2. We need third-party integration eventually. Let's get right to it.

Step 1: create a reverse communication approach to sketching sparse data matrices. Step 2: add support for one third-party library at a time (focusing on Eigen, OneAPI, and Kokkos Kernels).