### PR TITLE
Ignore me (opened for debugging purposes)

### DIFF
--- a/CMake/rb_build_options.cmake
+++ b/CMake/rb_build_options.cmake
@@ -1,4 +1,4 @@
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 option(BUILD_SHARED_LIBS OFF "Configure to build shared or static libraries")

--- a/RandBLAS/base.hh
+++ b/RandBLAS/base.hh
@@ -18,9 +18,16 @@
 #endif
 
 #include<iostream>
+#include<numeric>
+
 
 /// code common across the project
 namespace RandBLAS {
+
+
+template<typename T>
+concept SignedInteger = (std::numeric_limits<T>::is_signed && std::numeric_limits<T>::is_integer);
+
 
 enum class MajorAxis : char {
     // ---------------------------------------------------------------------------

--- a/RandBLAS/config.h
+++ b/RandBLAS/config.h
@@ -1,2 +1,0 @@
-// This file only exists to keep IDEs from complaining about an include error.
-// It will be overwritten at build-time.

--- a/RandBLAS/config.h
+++ b/RandBLAS/config.h
@@ -1,0 +1,2 @@
+// This file only exists to keep IDEs from complaining about an include error.
+// It will be overwritten at build-time.

--- a/RandBLAS/sparse_data/base.hh
+++ b/RandBLAS/sparse_data/base.hh
@@ -59,16 +59,17 @@ static inline stride_64t layout_to_strides(blas::Layout layout, int64_t ldim) {
     }
 }
 
+template <RandBLAS::SignedInteger sint_t = int64_t>
 static inline void sorted_nonzero_locations_to_pointer_array(
     int64_t nnz,
-    int64_t *sorted, // length at least max(nnz, last_ptr_index + 1)
+    sint_t *sorted, // length at least max(nnz, last_ptr_index + 1)
     int64_t last_ptr_index
 ) {
     int64_t i;
     for (i = 1; i < nnz; ++i)
         randblas_require(sorted[i - 1] <= sorted[i]);
     
-    auto temp = new int64_t[last_ptr_index + 1];
+    auto temp = new sint_t[last_ptr_index + 1];
     temp[0] = 0;
     int64_t ell = 0;
     for (i = 0; i < last_ptr_index; ++i) {

--- a/RandBLAS/sparse_data/coo_matrix.hh
+++ b/RandBLAS/sparse_data/coo_matrix.hh
@@ -16,7 +16,8 @@ enum class NonzeroSort : char {
     None = 'N'
 };
 
-static inline bool increasing_by_csr(int64_t i0, int64_t j0, int64_t i1, int64_t j1) {
+template <RandBLAS::SignedInteger sint_t>
+static inline bool increasing_by_csr(sint_t i0, sint_t j0, sint_t i1, sint_t j1) {
     if (i0 > i1) {
         return false;
     } else if (i0 == i1) {
@@ -26,7 +27,8 @@ static inline bool increasing_by_csr(int64_t i0, int64_t j0, int64_t i1, int64_t
     }
 }
 
-static inline bool increasing_by_csc(int64_t i0, int64_t j0, int64_t i1, int64_t j1) {
+template <RandBLAS::SignedInteger sint_t>
+static inline bool increasing_by_csc(sint_t i0, sint_t j0, sint_t i1, sint_t j1) {
     if (j0 > j1) {
         return false;
     } else if (j0 == j1) {
@@ -36,7 +38,8 @@ static inline bool increasing_by_csc(int64_t i0, int64_t j0, int64_t i1, int64_t
     }
 }
 
-static inline NonzeroSort coo_sort_type(int64_t nnz, int64_t *rows, int64_t *cols) {
+template <RandBLAS::SignedInteger sint_t>
+static inline NonzeroSort coo_sort_type(int64_t nnz, sint_t *rows, sint_t *cols) {
     bool csc_okay = true;
     bool csr_okay = true;
     for (int64_t ell = 1; ell < nnz; ++ell) {
@@ -60,10 +63,9 @@ static inline NonzeroSort coo_sort_type(int64_t nnz, int64_t *rows, int64_t *col
     } else {
         return NonzeroSort::None;
     }
-    
 }
 
-template <typename T>
+template <typename T, RandBLAS::SignedInteger sint_t = int64_t>
 struct COOMatrix {
     const int64_t n_rows;
     const int64_t n_cols;
@@ -71,10 +73,9 @@ struct COOMatrix {
     const bool own_memory;
     int64_t nnz;
     T *vals;
-    int64_t *rows;
-    int64_t *cols;
+    sint_t *rows;
+    sint_t *cols;
     NonzeroSort sort;
-    int64_t *_sortptr;
     bool _can_reserve = true;
 
     COOMatrix(
@@ -94,8 +95,8 @@ struct COOMatrix {
         int64_t n_cols,
         int64_t nnz,
         T *vals,
-        int64_t *rows,
-        int64_t *cols,
+        sint_t *rows,
+        sint_t *cols,
         bool compute_sort_type = true,
         IndexBase index_base = IndexBase::Zero
     ) : n_rows(n_rows), n_cols(n_cols), index_base(index_base), own_memory(false) {
@@ -124,15 +125,15 @@ struct COOMatrix {
         randblas_require(this->own_memory);
         this->nnz = nnz;
         this->vals = new T[nnz];
-        this->rows = new int64_t[nnz];
-        this->cols = new int64_t[nnz];
+        this->rows = new sint_t[nnz];
+        this->cols = new sint_t[nnz];
         this->_can_reserve = false;
     }
 
 };
 
-template <typename T>
-void sort_coo_data(NonzeroSort s, int64_t nnz, T *vals, int64_t *rows, int64_t *cols) {
+template <typename T, RandBLAS::SignedInteger sint_t>
+void sort_coo_data(NonzeroSort s, int64_t nnz, T *vals, sint_t *rows, sint_t *cols) {
     if (s == NonzeroSort::None)
         return;
     auto curr_s = coo_sort_type(nnz, rows, cols);
@@ -142,7 +143,7 @@ void sort_coo_data(NonzeroSort s, int64_t nnz, T *vals, int64_t *rows, int64_t *
     //  (right now we make expensive copies)
 
     // get a vector-of-triples representation of the matrix
-    using tuple_type = std::tuple<int64_t, int64_t, T>;
+    using tuple_type = std::tuple<sint_t, sint_t, T>;
     std::vector<tuple_type> nonzeros;
     nonzeros.reserve(nnz);
     for (int64_t ell = 0; ell < nnz; ++ell)

--- a/RandBLAS/sparse_data/coo_multiply.hh
+++ b/RandBLAS/sparse_data/coo_multiply.hh
@@ -9,12 +9,12 @@
 
 namespace RandBLAS::sparse_data::coo {
 
-template <typename T>
+template <typename T, RandBLAS::SignedInteger sint_t = int64_t>
 static int64_t set_filtered_coo(
     // COO-format matrix data
     const T       *vals,
-    const int64_t *rowidxs,
-    const int64_t *colidxs,
+    const sint_t *rowidxs,
+    const sint_t *colidxs,
     int64_t nnz,
     // submatrix bounds
     int64_t col_start,
@@ -23,8 +23,8 @@ static int64_t set_filtered_coo(
     int64_t row_end,
     // COO-format submatrix data
     T       *new_vals,
-    int64_t *new_rowidxs,
-    int64_t *new_colidxs
+    sint_t *new_rowidxs,
+    sint_t *new_colidxs
 ) {
     int64_t new_nnz = 0;
     for (int64_t ell = 0; ell < nnz; ++ell) {
@@ -41,12 +41,12 @@ static int64_t set_filtered_coo(
     return new_nnz;
 }
 
-template <typename T>
+template <typename T, RandBLAS::SignedInteger sint_t = int64_t>
 static void apply_csc_to_vector_from_left(
     // CSC-format data
     const T *vals,
-    int64_t *rowidxs,
-    int64_t *colptr,
+    sint_t *rowidxs,
+    sint_t *colptr,
     // input-output vector data
     int64_t len_v,
     const T *v,
@@ -65,12 +65,12 @@ static void apply_csc_to_vector_from_left(
     }
 }
 
-template <typename T>
+template <typename T, RandBLAS::SignedInteger sint_t = int64_t>
 static void apply_regular_csc_to_vector_from_left(
     // data for "regular CSC": CSC with fixed nnz per col,
     // which obviates the requirement for colptr.
     const T *vals,
-    int64_t *rowidxs,
+    sint_t *rowidxs,
     int64_t col_nnz,
     // input-output vector data
     int64_t len_v,

--- a/RandBLAS/sparse_data/csc_matrix.hh
+++ b/RandBLAS/sparse_data/csc_matrix.hh
@@ -6,7 +6,7 @@
 
 namespace RandBLAS::sparse_data {
 
-template <typename T>
+template <typename T, RandBLAS::SignedInteger sint_t = int64_t>
 struct CSCMatrix {
     const int64_t n_rows;
     const int64_t n_cols;
@@ -14,8 +14,8 @@ struct CSCMatrix {
     const bool own_memory;
     int64_t nnz;
     T *vals;
-    int64_t *rowidxs;
-    int64_t *colptr;
+    sint_t *rowidxs;
+    sint_t *colptr;
     bool _can_reserve = true;
 
     CSCMatrix(
@@ -34,8 +34,8 @@ struct CSCMatrix {
         int64_t n_cols,
         int64_t nnz,
         T *vals,
-        int64_t *rowidxs,
-        int64_t *colptr,
+        sint_t *rowidxs,
+        sint_t *colptr,
         IndexBase index_base = IndexBase::Zero
     ) : n_rows(n_rows), n_cols(n_cols), index_base(index_base), own_memory(false) {
         this->nnz = nnz;
@@ -56,8 +56,8 @@ struct CSCMatrix {
         randblas_require(this->_can_reserve);
         randblas_require(this->own_memory);
         this->nnz = nnz;
-        this->rowidxs = new int64_t[nnz]{0};
-        this->colptr = new int64_t[this->n_cols + 1]{0};
+        this->rowidxs = new sint_t[nnz]{0};
+        this->colptr = new sint_t[this->n_cols + 1]{0};
         this->vals = new T[nnz]{0.0};
         this->_can_reserve = false;
     };

--- a/RandBLAS/sparse_data/csr_matrix.hh
+++ b/RandBLAS/sparse_data/csr_matrix.hh
@@ -6,7 +6,7 @@
 
 namespace RandBLAS::sparse_data {
 
-template <typename T>
+template <typename T, RandBLAS::SignedInteger sint_t = int64_t>
 struct CSRMatrix {
     const int64_t n_rows;
     const int64_t n_cols;
@@ -14,8 +14,8 @@ struct CSRMatrix {
     const bool own_memory;
     int64_t nnz;
     T *vals;
-    int64_t *rowptr;
-    int64_t *colidxs;
+    sint_t *rowptr;
+    sint_t *colidxs;
     bool _can_reserve = true;
 
     CSRMatrix(
@@ -34,8 +34,8 @@ struct CSRMatrix {
         int64_t n_cols,
         int64_t nnz,
         T *vals,
-        int64_t *rowptr,
-        int64_t *colidxs,
+        sint_t *rowptr,
+        sint_t *colidxs,
         IndexBase index_base = IndexBase::Zero
     ) : n_rows(n_rows), n_cols(n_cols), index_base(index_base), own_memory(false) {
         this->nnz = nnz;
@@ -56,8 +56,8 @@ struct CSRMatrix {
         randblas_require(this->_can_reserve);
         randblas_require(this->own_memory);
         this->nnz = nnz;
-        this->rowptr = new int64_t[this->n_rows + 1]{0};
-        this->colidxs = new int64_t[nnz]{0};
+        this->rowptr = new sint_t[this->n_rows + 1]{0};
+        this->colidxs = new sint_t[nnz]{0};
         this->vals = new T[nnz]{0.0};
         this->_can_reserve = false;
     };


### PR DESCRIPTION
Making this PR now only so that CI runs.

First commit: switch to C++20, define a template concept for signed integers and use it in sparse matrices. For reasons that are entirely unclear, the TestStateUpdate.Gaussian_identity and TestStateUpdate.Final_State tests are failing. Maybe this stems from the switch to C++20? Need to investigate.

#### Investigation notes
The tests only fail on OpenMP builds. There's an [old StackOverflow post](https://stackoverflow.com/questions/2820621/why-arent-unsigned-openmp-index-variables-allowed) about OpenMP not allowing unsigned types in for loops. Maybe that's at play? Unclear to me why this would happen only after bumping the C++ standard from 17 to 20. I googled C++20 OpenMP and found someone asking a question [here](https://www.reddit.com/r/cpp_questions/comments/kri5mx/clang_c20_openmp_oddity/) three years ago; one commenter there said "The support for OpenMP and newer C++ features is still quite patchy and buggy across compilers."  

## The verdict

I had defined a ``config.h`` file explicitly so that VSCode's Intellisense didn't complain about not being able to find it. Even though CMake creates a config.h file at build time, it looks like it was being shadowed by the empty config.h file I had created. So in order to fix failing tests I needed to remove the empty config.h file and make VSCode happy some other way.

(The underlying technical problem is that a compiler preprocessor directive was causing us to think OpenMP was using one thread when it fact it was using several threads.)