### PR TITLE
Add COOMatrix and other key classes/functions into RandBLAS namespace; write tests

### DIFF
--- a/RandBLAS/sparse_data/base.hh
+++ b/RandBLAS/sparse_data/base.hh
@@ -17,16 +17,6 @@ enum class IndexBase : char {
 };
 
 template <typename T>
-struct SparseMatrix {
-    const int64_t n_rows;
-    const int64_t n_cols;
-    const IndexBase index_base;
-    const bool own_memory;
-    int64_t nnz;
-    T *vals;
-};
-
-template <typename T>
 int64_t nnz_in_dense(
     int64_t n_rows,
     int64_t n_cols,
@@ -72,5 +62,9 @@ static inline void sorted_nonzero_locations_to_pointer_array(
 }
 
 } // end namespace RandBLAS::sparse_data
+
+namespace RandBLAS {
+    using RandBLAS::sparse_data::IndexBase;
+}
 
 #endif

--- a/RandBLAS/sparse_data/coo_matrix.hh
+++ b/RandBLAS/sparse_data/coo_matrix.hh
@@ -192,6 +192,14 @@ void sort_coo_data(NonzeroSort s, COOMatrix<T> &spmat) {
     return;
 }
 
+} // end namespace RandBLAS::sparse_data
+
+
+namespace RandBLAS::sparse_data::coo {
+
+using namespace RandBLAS::sparse_data;
+using blas::Layout;
+
 template <typename T>
 static auto transpose(COOMatrix<T> &S) {
     COOMatrix<T> St(S.n_cols, S.n_rows, S.nnz, S.vals, S.cols, S.rows, false, S.index_base);
@@ -202,14 +210,6 @@ static auto transpose(COOMatrix<T> &S) {
     }
     return St;
 }
-
-} // end namespace RandBLAS::sparse_data
-
-
-namespace RandBLAS::sparse_data::coo {
-
-using namespace RandBLAS::sparse_data;
-using blas::Layout;
 
 template <typename T>
 void dense_to_coo(int64_t stride_row, int64_t stride_col, T *mat, T abs_tol, COOMatrix<T> &spmat) {
@@ -271,7 +271,13 @@ void coo_to_dense(const COOMatrix<T> &spmat, Layout layout, T *mat) {
     }
 }
 
-
 } // end namespace RandBLAS::sparse_data::coo
+
+
+namespace RandBLAS {
+    using RandBLAS::sparse_data::COOMatrix;
+    using RandBLAS::sparse_data::NonzeroSort;
+    using RandBLAS::sparse_data::coo::transpose;
+}
 
 #endif

--- a/RandBLAS/sparse_data/coo_matrix.hh
+++ b/RandBLAS/sparse_data/coo_matrix.hh
@@ -10,6 +10,10 @@
 
 namespace RandBLAS::sparse_data {
 
+// =============================================================================
+/// Indicates whether the (rows, cols, vals) data of a COO-format sparse matrix
+/// are known to be sorted in CSC order, CSR order, or neither of those orders.
+///
 enum class NonzeroSort : char {
     CSC = 'C',
     CSR = 'R',
@@ -65,18 +69,44 @@ static inline NonzeroSort coo_sort_type(int64_t nnz, sint_t *rows, sint_t *cols)
     }
 }
 
+// =============================================================================
+/// A sparse matrix stored in COO format.
+///
 template <typename T, RandBLAS::SignedInteger sint_t = int64_t>
 struct COOMatrix {
+    // ---------------------------------------------------------------------------
+    ///  The number of rows in this sparse matrix.
     const int64_t n_rows;
+    // ---------------------------------------------------------------------------
+    ///  The number of columns in this sparse matrix.
     const int64_t n_cols;
+    // ---------------------------------------------------------------------------
+    ///  Whether data in (rows, cols) is zero-indexed or one-indexed.
     const IndexBase index_base;
+    // ---------------------------------------------------------------------------
+    ///  A flag to indicate if this object is responsible for allocating and 
+    ///  deallocating memory for (rows, cols, vals).
     const bool own_memory;
+    // ---------------------------------------------------------------------------
+    ///  The number of entries in (rows, cols, vals).
     int64_t nnz;
+    // ---------------------------------------------------------------------------
+    ///  Values of the nonzeros.
     T *vals;
+    // ---------------------------------------------------------------------------
+    ///  Row indicies for nonzeros (interpreted with respect to index_base).
     sint_t *rows;
+    // ---------------------------------------------------------------------------
+    ///  Column indicies for nonzeros (interpreted with respect to index_base).
     sint_t *cols;
+    // ---------------------------------------------------------------------------
+    ///  A flag to indicate if the data in (rows, cols, vals) is sorted in a 
+    ///  CSC-like order, a CSR-like order, or neither order.
     NonzeroSort sort;
+
     bool _can_reserve = true;
+    // ^ A flag to indicate if we're allowed to allocate new memory for 
+    //   (rows, cols, vals). Set to false after COOMatrix.reserve(...) is called.
 
     COOMatrix(
         int64_t n_rows,

--- a/RandBLAS/sparse_data/coo_multiply.hh
+++ b/RandBLAS/sparse_data/coo_multiply.hh
@@ -281,7 +281,22 @@ void rspgemm(
     );
 }
 
-
 } // end namespace
+
+namespace RandBLAS {
+
+template <typename T>
+void multiply_general(blas::Layout layout, blas::Op opA, blas::Op opB, int64_t m, int64_t n, int64_t k, T alpha, COOMatrix<T> &A, int64_t i_off, int64_t j_off, const T *B, int64_t ldb, T beta, T *C, int64_t ldc) {
+    RandBLAS::sparse_data::coo::lspgemm(layout, opA, opB, m, n, k, alpha, A, i_off, j_off, B, ldb, beta, C, ldc);
+    return;
+};
+
+template <typename T>
+void multiply_general(blas::Layout layout, blas::Op opA, blas::Op opB, int64_t m, int64_t n, int64_t k, T alpha, const T *A, int64_t lda, COOMatrix<T> &B, int64_t i_off, int64_t j_off, T beta, T *C, int64_t ldc) {
+    RandBLAS::sparse_data::coo::rspgemm(layout, opA, opB, m, n, k, alpha, A, lda, B, i_off, j_off, B, beta, C, ldc);
+    return;
+}
+
+}
 
 #endif

--- a/RandBLAS/util.hh
+++ b/RandBLAS/util.hh
@@ -6,6 +6,15 @@
 #include <Random123/philox.h>
 #include <Random123/uniform.hpp>
 
+#include <type_traits>
+#include <typeinfo>
+#ifndef _MSC_VER
+#   include <cxxabi.h>
+#endif
+#include <memory>
+#include <string>
+#include <cstdlib>
+
 
 namespace RandBLAS::util {
 
@@ -86,6 +95,30 @@ bool compare_ctr(typename RNG::ctr_type c1, typename RNG::ctr_type c2) {
     return false;
 }
 
+template <class T>
+std::string type_name() { // call as type_name<obj>()
+    typedef typename std::remove_reference<T>::type TR;
+    std::unique_ptr<char, void(*)(void*)> own
+           (
+#ifndef _MSC_VER
+                abi::__cxa_demangle(typeid(TR).name(), nullptr,
+                                           nullptr, nullptr),
+#else
+                nullptr,
+#endif
+                std::free
+           );
+    std::string r = own != nullptr ? own.get() : typeid(TR).name();
+    if (std::is_const<TR>::value)
+        r += " const";
+    if (std::is_volatile<TR>::value)
+        r += " volatile";
+    if (std::is_lvalue_reference<T>::value)
+        r += "&";
+    else if (std::is_rvalue_reference<T>::value)
+        r += "&&";
+    return r;
+}
 
 } // end namespace RandBLAS::util
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,7 +6,8 @@ if (GTest_FOUND)
     set(tmp TRUE)
 
     add_executable(RandBLAS_tests
-        common.hh
+        linop_common.hh
+        comparison.hh
         test_sketch_vector.cc
         # dense sketching operators for dense data matrices
         test_dense/test_construction.cc
@@ -26,6 +27,7 @@ if (GTest_FOUND)
 
     add_executable(SparseRandBLAS_tests
         # dense sketching operators for sparse matrices
+        comparison.hh
         test_sparse_data/common.hh
         test_sparse_data/test_csc.cc
         test_sparse_data/test_csr.cc

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,7 +30,8 @@ if (GTest_FOUND)
         test_sparse_data/test_csc.cc
         test_sparse_data/test_csr.cc
         test_sparse_data/test_coo.cc
-        test_sparse_data/test_multiply.cc
+        test_sparse_data/test_left_multiply.cc
+        test_sparse_data/test_right_multiply.cc
     )
     target_link_libraries(SparseRandBLAS_tests
         RandBLAS

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,6 +30,7 @@ if (GTest_FOUND)
         test_sparse_data/test_csc.cc
         test_sparse_data/test_csr.cc
         test_sparse_data/test_coo.cc
+        test_sparse_data/test_multiply.cc
     )
     target_link_libraries(SparseRandBLAS_tests
         RandBLAS

--- a/test/common.hh
+++ b/test/common.hh
@@ -14,7 +14,7 @@
 
 namespace test::common {
 
-using RandBLAS::sparse_data::COOMatrix;
+using RandBLAS::COOMatrix;
 using RandBLAS::sparse_data::CSRMatrix;
 using RandBLAS::sparse_data::CSCMatrix;
 using RandBLAS::SparseSkOp;

--- a/test/common.hh
+++ b/test/common.hh
@@ -658,7 +658,7 @@ void test_right_apply_to_transposed(
     int64_t lda = (is_colmajor) ? n : m;
     int64_t ldb = (is_colmajor) ? m : d;
 
-    right_apply<T>(layout, blas::Op::Trans, blas::Op::NoTrans, m, d, n, 1.0, At, lda, S, 0, 0, 0.0, B0.data(), ldb, threads);
+    right_apply<T>(layout, blas::Op::Trans, blas::Op::NoTrans, m, d, n, 1.0, At.data(), lda, S, 0, 0, 0.0, B0.data(), ldb, threads);
 
     std::vector<T> B1(m * d, 0.0);
     std::vector<T> E(m * d, 0.0);

--- a/test/linop_common.hh
+++ b/test/linop_common.hh
@@ -2,7 +2,7 @@
 #include "RandBLAS/base.hh"
 #include "RandBLAS/dense.hh"
 #include "RandBLAS/util.hh"
-#include "RandBLAS/test_util.hh"
+#include "comparison.hh"
 #include "RandBLAS/sparse_skops.hh"
 #include "RandBLAS/sparse_data/coo_matrix.hh"
 #include "RandBLAS/sparse_data/csr_matrix.hh"
@@ -12,7 +12,7 @@
 #include <tuple>
 
 
-namespace test::common {
+namespace test::linop_common {
 
 using RandBLAS::COOMatrix;
 using RandBLAS::sparse_data::CSRMatrix;
@@ -252,7 +252,7 @@ void test_left_apply_to_random(
     );
 
     // check the result
-    RandBLAS_Testing::Util::buffs_approx_equal<T>(
+    test::comparison::buffs_approx_equal<T>(
         B0.data(), B1.data(), E.data(), d * n,
         __PRETTY_FUNCTION__, __FILE__, __LINE__
     );
@@ -300,7 +300,7 @@ void test_left_apply_submatrix_to_eye(
         }
     }
 
-    RandBLAS_Testing::Util::matrices_approx_equal(
+    test::comparison::matrices_approx_equal(
         layout, blas::Op::NoTrans,
         d1, m1,
         B.data(), ldb,
@@ -334,7 +334,7 @@ void test_left_apply_transpose_to_eye(
 
     std::vector<T> S_dense(m * d, 0.0);
     to_explicit_buffer(S, S_dense.data(), layout);
-    RandBLAS_Testing::Util::matrices_approx_equal(
+    test::comparison::matrices_approx_equal(
         layout, blas::Op::Trans, d, m,
         B.data(), ldb, S_dense.data(), lds,
         __PRETTY_FUNCTION__, __FILE__, __LINE__
@@ -379,7 +379,7 @@ void test_left_apply_to_submatrix(
         A_ptr, lda,
         0.0, B1.data(), E.data(), ldb
     );
-    RandBLAS_Testing::Util::buffs_approx_equal(
+    test::comparison::buffs_approx_equal(
         B0.data(), B1.data(), E.data(), d * n,
         __PRETTY_FUNCTION__, __FILE__, __LINE__
     );
@@ -416,7 +416,7 @@ void test_left_apply_to_transposed(
         At.data(), lda,
         0.0, B1.data(), E.data(), ldb
     );
-    RandBLAS_Testing::Util::buffs_approx_equal(
+    test::comparison::buffs_approx_equal(
         B0.data(), B1.data(), E.data(), d * n,
         __PRETTY_FUNCTION__, __FILE__, __LINE__
     );
@@ -541,7 +541,7 @@ void test_right_apply_to_random(
         beta, B1.data(), E.data(), ldb
     );
 
-    RandBLAS_Testing::Util::buffs_approx_equal<T>(
+    test::comparison::buffs_approx_equal<T>(
         B0.data(), B1.data(), E.data(), m * d,
         __PRETTY_FUNCTION__, __FILE__, __LINE__
     );
@@ -579,7 +579,7 @@ void test_right_apply_submatrix_to_eye(
         }
     }
 
-    RandBLAS_Testing::Util::matrices_approx_equal(
+    test::comparison::matrices_approx_equal(
         layout, blas::Op::NoTrans, n, d, B.data(), ldb, &expect[offset], ld_expect,
         __PRETTY_FUNCTION__, __FILE__, __LINE__
     );
@@ -603,7 +603,7 @@ void test_right_apply_tranpose_to_eye(
 
     std::vector<T> S_dense(n * d, 0.0);
     to_explicit_buffer(S, S_dense.data(), layout);
-    RandBLAS_Testing::Util::matrices_approx_equal(
+    test::comparison::matrices_approx_equal(
         layout, blas::Op::Trans, n, d, 
         B.data(), ldb, S_dense.data(), lds,
         __PRETTY_FUNCTION__, __FILE__, __LINE__
@@ -639,7 +639,7 @@ void test_right_apply_to_submatrix(
         1.0, A_ptr, lda, S, 0, 0,
         0.0, B1.data(), E.data(), ldb
     );
-    RandBLAS_Testing::Util::buffs_approx_equal(
+    test::comparison::buffs_approx_equal(
         B0.data(), B1.data(), E.data(), d * m,
         __PRETTY_FUNCTION__, __FILE__, __LINE__
     );
@@ -668,12 +668,12 @@ void test_right_apply_to_transposed(
         1.0, At.data(), lda, S, 0, 0,
         0.0, B1.data(), E.data(), ldb
     );
-    RandBLAS_Testing::Util::buffs_approx_equal(
+    test::comparison::buffs_approx_equal(
         B0.data(), B1.data(), E.data(), m * d,
         __PRETTY_FUNCTION__, __FILE__, __LINE__
     );
 }
 
 
-} // end namespace test::common
+} // end namespace test::linop_common
 

--- a/test/test_dense/test_sketch_gefl3.cc
+++ b/test/test_dense/test_sketch_gefl3.cc
@@ -1,8 +1,9 @@
-#include "../common.hh"
+#include "../linop_common.hh"
 #include <gtest/gtest.h>
 
 using RandBLAS::DenseDist;
 using RandBLAS::DenseSkOp;
+using namespace test::linop_common;
 
 class TestLSKGE3 : public ::testing::Test
 {
@@ -24,7 +25,7 @@ class TestLSKGE3 : public ::testing::Test
         DenseSkOp<T> S0(D, seed, nullptr);
         if (preallocate)
             RandBLAS::fill_dense(S0);
-        test::common::test_left_apply_submatrix_to_eye<T>(1.0, S0, d, m, 0, 0, layout, 0.0);
+        test_left_apply_submatrix_to_eye<T>(1.0, S0, d, m, 0, 0, layout, 0.0);
     }
 
     template <typename T>
@@ -37,7 +38,7 @@ class TestLSKGE3 : public ::testing::Test
         DenseDist Dt(m, d);
         DenseSkOp<T> S0(Dt, seed, nullptr);
         RandBLAS::fill_dense(S0);
-        test::common::test_left_apply_transpose_to_eye<T>(S0, layout);
+        test_left_apply_transpose_to_eye<T>(S0, layout);
     }
 
     template <typename T>
@@ -55,7 +56,7 @@ class TestLSKGE3 : public ::testing::Test
         randblas_require(m0 > m);
         DenseDist D(d0, m0);
         DenseSkOp<T> S0(D, seed);
-        test::common::test_left_apply_submatrix_to_eye<T>(1.0, S0, d, m, S_ro, S_co, layout, 0.0);
+        test_left_apply_submatrix_to_eye<T>(1.0, S0, d, m, S_ro, S_co, layout, 0.0);
     }
 
     template <typename T>
@@ -74,7 +75,7 @@ class TestLSKGE3 : public ::testing::Test
         randblas_require(n0 > n);
         DenseDist D(d, m);
         DenseSkOp<T> S0(D, seed_S0, nullptr);
-        test::common::test_left_apply_to_submatrix<T>(S0, n, m0, n0, A_ro, A_co, layout);
+        test_left_apply_to_submatrix<T>(S0, n, m0, n0, A_ro, A_co, layout);
     }
 
 };

--- a/test/test_dense/test_sketch_gefr3.cc
+++ b/test/test_dense/test_sketch_gefr3.cc
@@ -1,6 +1,10 @@
-#include "../common.hh"
+#include "../linop_common.hh"
 #include <gtest/gtest.h>
 
+using namespace test::linop_common;
+using RandBLAS::DenseDist;
+using RandBLAS::DenseSkOp;
+using blas::Layout;
 
 class TestRSKGE3 : public ::testing::Test
 {
@@ -16,13 +20,13 @@ class TestRSKGE3 : public ::testing::Test
         int64_t m,
         int64_t d,
         bool preallocate,
-        blas::Layout layout
+        Layout layout
     ) {
-        RandBLAS::DenseDist D(m, d);
-        RandBLAS::DenseSkOp<T> S0(D, seed, nullptr);
+        DenseDist D(m, d);
+        DenseSkOp<T> S0(D, seed, nullptr);
         if (preallocate)
             RandBLAS::fill_dense(S0);
-        test::common::test_right_apply_submatrix_to_eye<T>(1.0, S0, m, d, 0, 0, layout, 0.0, 0);
+        test_right_apply_submatrix_to_eye<T>(1.0, S0, m, d, 0, 0, layout, 0.0, 0);
     }
 
     template <typename T>
@@ -30,11 +34,11 @@ class TestRSKGE3 : public ::testing::Test
         uint32_t seed,
         int64_t m,
         int64_t d,
-        blas::Layout layout
+        Layout layout
     ) {
-        RandBLAS::DenseDist Dt(d, m);
-        RandBLAS::DenseSkOp<T> S0(Dt, seed, nullptr);
-        test::common::test_right_apply_tranpose_to_eye<T>(S0, layout);
+        DenseDist Dt(d, m);
+        DenseSkOp<T> S0(Dt, seed, nullptr);
+        test_right_apply_tranpose_to_eye<T>(S0, layout);
     }
 
     template <typename T>
@@ -46,11 +50,11 @@ class TestRSKGE3 : public ::testing::Test
         int64_t m0, // rows in S0
         int64_t S_ro, // row offset for S in S0
         int64_t S_co, // column offset for S in S0
-        blas::Layout layout
+        Layout layout
     ) {
-        RandBLAS::DenseDist D(m0, d0);
-        RandBLAS::DenseSkOp<T> S0(D, seed);
-        test::common::test_right_apply_submatrix_to_eye<T>(1.0, S0, m, d, S_ro, S_co, layout, 0.0, 0);
+        DenseDist D(m0, d0);
+        DenseSkOp<T> S0(D, seed);
+        test_right_apply_submatrix_to_eye<T>(1.0, S0, m, d, S_ro, S_co, layout, 0.0, 0);
     }
 
     template <typename T>
@@ -63,11 +67,11 @@ class TestRSKGE3 : public ::testing::Test
         int64_t n0, // cols in A0
         int64_t A_ro, // row offset for A in A0
         int64_t A_co, // column offset for A in A0
-        blas::Layout layout
+        Layout layout
     ) {
-        RandBLAS::DenseDist D(n, d);
-        RandBLAS::DenseSkOp<T> S0(D, seed_S0, nullptr);
-        test::common::test_right_apply_to_submatrix<T>(S0, m, m0, n0, A_ro, A_co, layout);
+        DenseDist D(n, d);
+        DenseSkOp<T> S0(D, seed_S0, nullptr);
+        test_right_apply_to_submatrix<T>(S0, m, m0, n0, A_ro, A_co, layout);
     }
 
 };
@@ -84,37 +88,37 @@ class TestRSKGE3 : public ::testing::Test
 TEST_F(TestRSKGE3, right_sketch_eye_double_preallocate_colmajor)
 {
     for (uint32_t seed : {0})
-        sketch_eye<double>(seed, 200, 30, true, blas::Layout::ColMajor);
+        sketch_eye<double>(seed, 200, 30, true, Layout::ColMajor);
 }
 
 TEST_F(TestRSKGE3, right_sketch_eye_double_preallocate_rowmajor)
 {
     for (uint32_t seed : {0})
-        sketch_eye<double>(seed, 200, 30, true, blas::Layout::RowMajor);
+        sketch_eye<double>(seed, 200, 30, true, Layout::RowMajor);
 }
 
 TEST_F(TestRSKGE3, right_sketch_eye_double_null_colmajor)
 {
     for (uint32_t seed : {0})
-        sketch_eye<double>(seed, 200, 30, false, blas::Layout::ColMajor);
+        sketch_eye<double>(seed, 200, 30, false, Layout::ColMajor);
 }
 
 TEST_F(TestRSKGE3, right_sketch_eye_double_null_rowmajor)
 {
     for (uint32_t seed : {0})
-        sketch_eye<double>(seed, 200, 30, false, blas::Layout::RowMajor);
+        sketch_eye<double>(seed, 200, 30, false, Layout::RowMajor);
 }
 
 TEST_F(TestRSKGE3, right_sketch_eye_single_preallocate)
 {
     for (uint32_t seed : {0})
-        sketch_eye<float>(seed, 200, 30, true, blas::Layout::ColMajor);
+        sketch_eye<float>(seed, 200, 30, true, Layout::ColMajor);
 }
 
 TEST_F(TestRSKGE3, right_sketch_eye_single_null)
 {
     for (uint32_t seed : {0})
-        sketch_eye<float>(seed, 200, 30, false, blas::Layout::ColMajor);
+        sketch_eye<float>(seed, 200, 30, false, Layout::ColMajor);
 }
 
 
@@ -129,25 +133,25 @@ TEST_F(TestRSKGE3, right_sketch_eye_single_null)
 TEST_F(TestRSKGE3, right_lift_eye_double_preallocate_colmajor)
 {
     for (uint32_t seed : {0})
-        sketch_eye<double>(seed, 10, 51, true, blas::Layout::ColMajor);
+        sketch_eye<double>(seed, 10, 51, true, Layout::ColMajor);
 }
 
 TEST_F(TestRSKGE3, right_lift_eye_double_preallocate_rowmajor)
 {
     for (uint32_t seed : {0})
-        sketch_eye<double>(seed, 10, 51, true, blas::Layout::RowMajor);
+        sketch_eye<double>(seed, 10, 51, true, Layout::RowMajor);
 }
 
 TEST_F(TestRSKGE3, right_lift_eye_double_null_colmajor)
 {
     for (uint32_t seed : {0})
-        sketch_eye<double>(seed, 10, 51, false, blas::Layout::ColMajor);
+        sketch_eye<double>(seed, 10, 51, false, Layout::ColMajor);
 }
 
 TEST_F(TestRSKGE3, right_lift_eye_double_null_rowmajor)
 {
     for (uint32_t seed : {0})
-        sketch_eye<double>(seed, 10, 51, false, blas::Layout::RowMajor);
+        sketch_eye<double>(seed, 10, 51, false, Layout::RowMajor);
 }
 
 
@@ -162,19 +166,19 @@ TEST_F(TestRSKGE3, right_lift_eye_double_null_rowmajor)
 TEST_F(TestRSKGE3, transpose_double_colmajor)
 {
     for (uint32_t seed : {0})
-        transpose_S<double>(seed, 200, 30, blas::Layout::ColMajor);
+        transpose_S<double>(seed, 200, 30, Layout::ColMajor);
 }
 
 TEST_F(TestRSKGE3, transpose_double_rowmajor)
 {
     for (uint32_t seed : {0})
-        transpose_S<double>(seed, 200, 30, blas::Layout::RowMajor);
+        transpose_S<double>(seed, 200, 30, Layout::RowMajor);
 }
 
 TEST_F(TestRSKGE3, transpose_single)
 {
     for (uint32_t seed : {0})
-        transpose_S<float>(seed, 200, 30, blas::Layout::ColMajor);
+        transpose_S<float>(seed, 200, 30, Layout::ColMajor);
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -193,7 +197,7 @@ TEST_F(TestRSKGE3, submatrix_s_double_colmajor)
             8, 12, // (cols, rows) in S0.
             2, // The first row of S is in the third row of S0
             1, // The first col of S is in the second col of S0
-            blas::Layout::ColMajor
+            Layout::ColMajor
         );
 }
 
@@ -205,7 +209,7 @@ TEST_F(TestRSKGE3, submatrix_s_double_rowmajor)
             8, 12, // (cols, rows) in S0.
             2, // The first row of S is in the third row of S0
             1, // The first col of S is in the second col of S0
-            blas::Layout::RowMajor
+            Layout::RowMajor
         );
 }
 
@@ -217,7 +221,7 @@ TEST_F(TestRSKGE3, submatrix_s_single)
             8, 12, // (cols, rows) in S0.
             2, // The first row of S is in the third row of S0
             1, // The first col of S is in the second col of S0
-            blas::Layout::ColMajor
+            Layout::ColMajor
         );
 }
 
@@ -238,7 +242,7 @@ TEST_F(TestRSKGE3, submatrix_a_double_colmajor)
             12, 8, // (rows, cols) in A0.
             2, // The first row of A is in the third row of A0.
             1, // The first col of A is in the second col of A0.
-            blas::Layout::ColMajor
+            Layout::ColMajor
         );
 }
 
@@ -251,7 +255,7 @@ TEST_F(TestRSKGE3, submatrix_a_double_rowmajor)
             12, 8, // (rows, cols) in A0.
             2, // The first row of A is in the third row of A0.
             1, // The first col of A is in the second col of A0.
-            blas::Layout::RowMajor
+            Layout::RowMajor
         );
 }
 
@@ -264,6 +268,6 @@ TEST_F(TestRSKGE3, submatrix_a_single)
             12, 8, // (rows, cols) in A0.
             2, // The first row of A is in the third row of A0.
             1, // The first col of A is in the second col of A0.
-            blas::Layout::ColMajor
+            Layout::ColMajor
         );
 }

--- a/test/test_sketch_vector.cc
+++ b/test/test_sketch_vector.cc
@@ -3,7 +3,7 @@
 #include "RandBLAS/random_gen.hh"
 #include "RandBLAS/dense.hh"
 #include "RandBLAS/util.hh"
-#include "RandBLAS/test_util.hh"
+#include "comparison.hh"
 #include "RandBLAS/skge.hh"
 
 #include <gtest/gtest.h>
@@ -43,7 +43,7 @@ class TestSketchVector : public ::testing::Test
         RandBLAS::sketch_vector<T>(blas::Op::NoTrans, d, m, 1.0, S, 0, 0, x, incx, 0.0, y_actual, incy);
         blas::gemv(S.layout, blas::Op::NoTrans, d, m, 1.0, S.buff, lds, x, incx, 0.0, y_expect, incy); 
 
-        RandBLAS_Testing::Util::buffs_approx_equal(d, y_actual, incy, y_expect, incy,
+        test::comparison::buffs_approx_equal(d, y_actual, incy, y_expect, incy,
                 __PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         delete [] x;
@@ -75,7 +75,7 @@ class TestSketchVector : public ::testing::Test
         blas::gemv(S.layout, blas::Op::Trans, m, d, 1.0, S.buff, lds, x, incx, 0, y_expect, incy); 
         
         // Compare entrywise results of sketching with sketch_vector and using gemv
-        RandBLAS_Testing::Util::buffs_approx_equal(d, y_actual, incy, y_expect, incy,
+        test::comparison::buffs_approx_equal(d, y_actual, incy, y_expect, incy,
                 __PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         delete [] x;
@@ -109,7 +109,7 @@ class TestSketchVector : public ::testing::Test
         RandBLAS::sketch_vector<T>(blas::Op::NoTrans, d, m, 1.0, S_wide, 0, 0, x, incx, 0.0, y_wide, incy);
         RandBLAS::sketch_vector<T>(blas::Op::Trans, m, d, 1.0, S_tall, 0, 0, x, incx, 0.0, y_tall, incy);
         
-        RandBLAS_Testing::Util::buffs_approx_equal(d, y_wide, incy, y_tall, incy,
+        test::comparison::buffs_approx_equal(d, y_wide, incy, y_tall, incy,
                 __PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         delete [] x;
@@ -142,7 +142,7 @@ class TestSketchVector : public ::testing::Test
         blas::gemv(S.layout, blas::Op::NoTrans, d, m, 1, S.buff, lds, x, incx, 0, y_expect, incy); 
 
         // Compare entrywise results of sketching with sketch_vector and using gemv
-        RandBLAS_Testing::Util::buffs_approx_equal(d, y_actual, incy, y_expect, incy,
+        test::comparison::buffs_approx_equal(d, y_actual, incy, y_expect, incy,
                 __PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         delete [] x;

--- a/test/test_sparse_data/common.hh
+++ b/test/test_sparse_data/common.hh
@@ -17,6 +17,27 @@ using namespace RandBLAS::sparse_data::csr;
 using namespace RandBLAS::sparse_data::conversions;
 using blas::Layout;
 
+template <typename T, typename RNG, RandBLAS::SignedInteger sint_t>
+void sparseskop_to_dense(
+    RandBLAS::SparseSkOp<T, RNG, sint_t> &S0,
+    T *mat,
+    Layout layout
+) {
+    RandBLAS::SparseDist D = S0.dist;
+    for (int64_t i = 0; i < D.n_rows * D.n_cols; ++i)
+        mat[i] = 0.0;
+    auto idx = [D, layout](int64_t i, int64_t j) {
+        return  (layout == Layout::ColMajor) ? (i + j*D.n_rows) : (j + i*D.n_cols);
+    };
+    int64_t nnz = RandBLAS::sparse::nnz(S0);
+    for (int64_t i = 0; i < nnz; ++i) {
+        sint_t row = S0.rows[i];
+        sint_t col = S0.cols[i];
+        T val = S0.vals[i];
+        mat[idx(row, col)] = val;
+    }
+}
+
 template <typename T, typename RNG = r123::Philox4x32>
 void iid_sparsify_random_dense(
     int64_t n_rows,

--- a/test/test_sparse_data/test_coo.cc
+++ b/test/test_sparse_data/test_coo.cc
@@ -1,5 +1,5 @@
 #include "test/test_sparse_data/common.hh"
-#include "RandBLAS/test_util.hh"
+#include "../comparison.hh"
 #include <gtest/gtest.h>
 #include <vector>
 
@@ -28,7 +28,7 @@ class TestCOO : public ::testing::Test
         std::vector<T> expect(n * n);
         coo_to_dense(A, 1, n, expect.data());
 
-        RandBLAS_Testing::Util::buffs_approx_equal(actual.data(), expect.data(), n * n,
+        test::comparison::buffs_approx_equal(actual.data(), expect.data(), n * n,
             __PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         EXPECT_GT(A.nnz, 0);
@@ -98,11 +98,11 @@ class Test_SkOp_to_COO : public ::testing::Test
         EXPECT_EQ(RandBLAS::sparse::nnz(S), A.nnz);
 
         std::vector<T> S_dense(d * m);
-        RandBLAS_Testing::Util::sparseskop_to_dense(S, S_dense.data(), Layout::ColMajor);
+        sparseskop_to_dense(S, S_dense.data(), Layout::ColMajor);
         std::vector<T> A_dense(d * m);
         coo_to_dense(A, Layout::ColMajor, A_dense.data());
     
-        RandBLAS_Testing::Util::buffs_approx_equal(S_dense.data(), A_dense.data(), d * m,
+        test::comparison::buffs_approx_equal(S_dense.data(), A_dense.data(), d * m,
             __PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         return;

--- a/test/test_sparse_data/test_coo.cc
+++ b/test/test_sparse_data/test_coo.cc
@@ -1,5 +1,4 @@
 #include "test/test_sparse_data/common.hh"
-#include "RandBLAS/sparse_data/coo_multiply.hh"
 #include "RandBLAS/test_util.hh"
 #include <gtest/gtest.h>
 #include <vector>

--- a/test/test_sparse_data/test_csc.cc
+++ b/test/test_sparse_data/test_csc.cc
@@ -1,5 +1,5 @@
 #include "test/test_sparse_data/common.hh"
-#include "RandBLAS/test_util.hh"
+#include "../comparison.hh"
 #include <gtest/gtest.h>
 #include <algorithm>
 
@@ -34,7 +34,7 @@ class TestCSC_Conversions : public ::testing::Test
         csc_to_dense(spmat, layout, dn_mat_recon);
 
         // check equivalence of dn_mat and dn_mat_recon
-        RandBLAS_Testing::Util::buffs_approx_equal(dn_mat, dn_mat_recon, m * n,
+        test::comparison::buffs_approx_equal(dn_mat, dn_mat_recon, m * n,
             __PRETTY_FUNCTION__, __FILE__, __LINE__
         );
 
@@ -66,7 +66,7 @@ class TestCSC_Conversions : public ::testing::Test
         T *mat_actual = new T[m * n]{0.0};
         csc_to_dense(csc, Layout::ColMajor, mat_actual);
 
-        RandBLAS_Testing::Util::matrices_approx_equal(
+        test::comparison::matrices_approx_equal(
             Layout::ColMajor, Layout::ColMajor, blas::Op::NoTrans,
             m, n, mat_expect, m, mat_actual, m,
             __PRETTY_FUNCTION__, __FILE__, __LINE__

--- a/test/test_sparse_data/test_csr.cc
+++ b/test/test_sparse_data/test_csr.cc
@@ -1,5 +1,5 @@
 #include "test/test_sparse_data/common.hh"
-#include "RandBLAS/test_util.hh"
+#include "../comparison.hh"
 #include <gtest/gtest.h>
 #include <algorithm>
 
@@ -33,7 +33,7 @@ class TestCSR_Conversions : public ::testing::Test
         T *eye = new T[n*n]{0.0};
         for (int i = 0; i < n; ++i)
             eye[i + n*i] = 1.0 + (T) i;
-        RandBLAS_Testing::Util::buffs_approx_equal(mat, eye, n * n,
+        test::comparison::buffs_approx_equal(mat, eye, n * n,
             __PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         
@@ -58,7 +58,7 @@ class TestCSR_Conversions : public ::testing::Test
         csr_to_dense(spmat, layout, dn_mat_recon);
 
         // check equivalence of dn_mat and dn_mat_recon
-        RandBLAS_Testing::Util::buffs_approx_equal(dn_mat, dn_mat_recon, m * n,
+        test::comparison::buffs_approx_equal(dn_mat, dn_mat_recon, m * n,
             __PRETTY_FUNCTION__, __FILE__, __LINE__
         );
 
@@ -90,7 +90,7 @@ class TestCSR_Conversions : public ::testing::Test
         T *mat_actual = new T[m * n]{0.0};
         csr_to_dense(csr, Layout::ColMajor, mat_actual);
 
-        RandBLAS_Testing::Util::matrices_approx_equal(
+        test::comparison::matrices_approx_equal(
             Layout::ColMajor, Layout::ColMajor, blas::Op::NoTrans,
             m, n, mat_expect, m, mat_actual, m,
             __PRETTY_FUNCTION__, __FILE__, __LINE__

--- a/test/test_sparse_data/test_left_multiply.cc
+++ b/test/test_sparse_data/test_left_multiply.cc
@@ -23,6 +23,8 @@ COOMatrix<T> make_test_matrix(int64_t m, int64_t n, T nonzero_prob, uint32_t key
 
 class TestLeftMultiply : public ::testing::Test
 {
+    // C = alpha * opA(submat(A)) @ opB(B) + beta * C
+    // In what follows, "self" refers to A and "other" refers to B.
     protected:
     
     virtual void SetUp(){};
@@ -43,13 +45,13 @@ class TestLeftMultiply : public ::testing::Test
     }
 
     template <typename T>
-    static void transpose_sparse(uint32_t key, int64_t m, int64_t n, Layout layout, T p) {
+    static void transpose_self(uint32_t key, int64_t m, int64_t n, Layout layout, T p) {
         auto A = make_test_matrix<T>(m, n, p, key);
         test_left_apply_transpose_to_eye<T>(A, layout);
     }
 
     template <typename T>
-    static void submatrix_sparse(
+    static void submatrix_self(
         uint32_t key,   // key for RNG that generates sparse A
         int64_t d,      // rows in A
         int64_t m,      // columns in A, rows in B = eye(m)
@@ -176,58 +178,58 @@ TEST_F(TestLeftMultiply, nontrivial_scales_rowmajor2) {
 
 ////////////////////////////////////////////////////////////////////////
 //
-//      transpose of sparse operator
+//      transpose of self (sparse operator)
 //
 ////////////////////////////////////////////////////////////////////////
 
-TEST_F(TestLeftMultiply, transpose_sparse_double_colmajor) {
+TEST_F(TestLeftMultiply, transpose_self_double_colmajor) {
     for (uint32_t key : {0}) {
-        transpose_sparse<double>(key, 200, 30, Layout::ColMajor, 0.01);
-        transpose_sparse<double>(key, 200, 30, Layout::ColMajor, 0.10);
-        transpose_sparse<double>(key, 200, 30, Layout::ColMajor, 0.80);
+        transpose_self<double>(key, 200, 30, Layout::ColMajor, 0.01);
+        transpose_self<double>(key, 200, 30, Layout::ColMajor, 0.10);
+        transpose_self<double>(key, 200, 30, Layout::ColMajor, 0.80);
     }
 }
 
-TEST_F(TestLeftMultiply, transpose_sparse_double_rowmajor) {
+TEST_F(TestLeftMultiply, transpose_self_double_rowmajor) {
     for (uint32_t key : {0}) {
-        transpose_sparse<double>(key, 200, 30, Layout::RowMajor, 0.01);
-        transpose_sparse<double>(key, 200, 30, Layout::RowMajor, 0.10);
-        transpose_sparse<double>(key, 200, 30, Layout::RowMajor, 0.80);
+        transpose_self<double>(key, 200, 30, Layout::RowMajor, 0.01);
+        transpose_self<double>(key, 200, 30, Layout::RowMajor, 0.10);
+        transpose_self<double>(key, 200, 30, Layout::RowMajor, 0.80);
     }
 }
 
-TEST_F(TestLeftMultiply, transpose_sparse_single) {
+TEST_F(TestLeftMultiply, transpose_self_single) {
     for (uint32_t key : {0}) {
-        transpose_sparse<float>(key, 200, 30, Layout::ColMajor, 0.01);
-        transpose_sparse<float>(key, 200, 30, Layout::ColMajor, 0.10);
-        transpose_sparse<float>(key, 200, 30, Layout::ColMajor, 0.80);
+        transpose_self<float>(key, 200, 30, Layout::ColMajor, 0.01);
+        transpose_self<float>(key, 200, 30, Layout::ColMajor, 0.10);
+        transpose_self<float>(key, 200, 30, Layout::ColMajor, 0.80);
     }
 }
 
 ////////////////////////////////////////////////////////////////////////
 //
-//      Submatrices of sparse operator
+//      Submatrices of self (sparse operator)
 //
 ////////////////////////////////////////////////////////////////////////
 
-TEST_F(TestLeftMultiply, submatrix_sparse_double_colmajor) {
+TEST_F(TestLeftMultiply, submatrix_self_double_colmajor) {
     for (uint32_t key : {0}) {
-        submatrix_sparse<double>(key, 3, 10, 8, 12, 3, 1, Layout::ColMajor, 0.1);
-        submatrix_sparse<double>(key, 3, 10, 8, 12, 3, 1, Layout::ColMajor, 1.0);
+        submatrix_self<double>(key, 3, 10, 8, 12, 3, 1, Layout::ColMajor, 0.1);
+        submatrix_self<double>(key, 3, 10, 8, 12, 3, 1, Layout::ColMajor, 1.0);
     }
 }
 
-TEST_F(TestLeftMultiply, submatrix_sparse_double_rowmajor) {
+TEST_F(TestLeftMultiply, submatrix_self_double_rowmajor) {
     for (uint32_t key : {0}) {
-        submatrix_sparse<double>(key, 3, 10, 8, 12, 3, 1, Layout::RowMajor, 0.1);
-        submatrix_sparse<double>(key, 3, 10, 8, 12, 3, 1, Layout::RowMajor, 1.0);
+        submatrix_self<double>(key, 3, 10, 8, 12, 3, 1, Layout::RowMajor, 0.1);
+        submatrix_self<double>(key, 3, 10, 8, 12, 3, 1, Layout::RowMajor, 1.0);
     }
 }
 
-TEST_F(TestLeftMultiply, submatrix_sparse_single) {
+TEST_F(TestLeftMultiply, submatrix_self_single) {
     for (uint32_t key : {0}) {
-        submatrix_sparse<float>(key, 3, 10, 8, 12, 3, 1, Layout::ColMajor, 0.1);
-        submatrix_sparse<float>(key, 3, 10, 8, 12, 3, 1, Layout::ColMajor, 1.0);
+        submatrix_self<float>(key, 3, 10, 8, 12, 3, 1, Layout::ColMajor, 0.1);
+        submatrix_self<float>(key, 3, 10, 8, 12, 3, 1, Layout::ColMajor, 1.0);
     }
 }
 

--- a/test/test_sparse_data/test_left_multiply.cc
+++ b/test/test_sparse_data/test_left_multiply.cc
@@ -1,11 +1,11 @@
-#include "../common.hh"
+#include "../linop_common.hh"
 #include "common.hh"
 #include <gtest/gtest.h>
 #include <vector>
 
 using RandBLAS::sparse_data::coo::dense_to_coo;
 using namespace test::sparse_data::common;
-using namespace test::common;
+using namespace test::linop_common;
 using blas::Layout;
 
 template <typename T>
@@ -102,7 +102,6 @@ class TestLeftMultiply : public ::testing::Test
 
 };
 
-
 ////////////////////////////////////////////////////////////////////////
 //
 //
@@ -174,7 +173,6 @@ TEST_F(TestLeftMultiply, nontrivial_scales_rowmajor2) {
     alpha_beta<double>(0, alpha, beta, 21, 4, Layout::RowMajor, 0.10);
     alpha_beta<double>(0, alpha, beta, 21, 4, Layout::RowMajor, 0.80);
 }
-
 
 ////////////////////////////////////////////////////////////////////////
 //

--- a/test/test_sparse_data/test_multiply.cc
+++ b/test/test_sparse_data/test_multiply.cc
@@ -1,0 +1,303 @@
+#include "../common.hh"
+#include "common.hh"
+#include <gtest/gtest.h>
+#include <vector>
+
+using RandBLAS::sparse_data::coo::dense_to_coo;
+using namespace test::sparse_data::common;
+using namespace test::common;
+using blas::Layout;
+
+template <typename T>
+COOMatrix<T> make_test_matrix(int64_t m, int64_t n, T nonzero_prob, uint32_t seed = 0) {
+    randblas_require(nonzero_prob >= 0);
+    randblas_require(nonzero_prob <= 1);
+    COOMatrix<T> A(m, n);
+    std::vector<T> actual(m * n);
+    RandBLAS::RNGState s(seed);
+    iid_sparsify_random_dense<T>(m, n, Layout::ColMajor, actual.data(), nonzero_prob, s);
+    dense_to_coo<T>(blas::Layout::ColMajor, actual.data(), 0.0, A);
+    return A;
+}
+
+
+class TestLeftMultiply : public ::testing::Test
+{
+    protected:
+    
+    virtual void SetUp(){};
+
+    virtual void TearDown(){};
+
+    template <typename T>
+    static void multiply_eye(
+        uint32_t seed,
+        int64_t m,
+        int64_t n,
+        blas::Layout layout,
+        T p = 0.8
+    ) {
+        auto A = make_test_matrix<T>(m, n, p, seed);
+        test_left_apply_submatrix_to_eye<T>(1.0, A, m, n, 0, 0, layout, 0.0);
+    }
+
+    template <typename T>
+    static void alpha_beta(
+        uint32_t key,
+        T alpha,
+        T beta,
+        int64_t m,
+        int64_t d,
+        blas::Layout layout,
+        T p = 0.8
+    ) {
+        auto A = make_test_matrix<T>(d, m, p, key);
+        test_left_apply_submatrix_to_eye<T>(alpha, A, d, m, 0, 0, layout, beta);
+    }
+
+    template <typename T>
+    static void transpose_sparse(
+        uint32_t seed,
+        int64_t m,
+        int64_t n,
+        blas::Layout layout,
+        T p = 0.8
+    ) {
+        auto A = make_test_matrix<T>(m, n, p, seed);
+        test_left_apply_transpose_to_eye<T>(A, layout);
+    }
+
+    template <typename T>
+    static void submatrix_sparse(
+        uint32_t seed,
+        int64_t d, // rows in sketch
+        int64_t m, // size of identity matrix
+        int64_t d0, // rows in A0
+        int64_t m0, // cols in A0
+        int64_t A_ro, // row offset for A in A0
+        int64_t A_co, // column offset for A in A0
+        blas::Layout layout,
+        T p = 0.8
+    ) {
+        randblas_require(d0 > d);
+        randblas_require(m0 > m);
+        auto A0 = make_test_matrix<T>(d0, m0, p, seed);
+        test_left_apply_submatrix_to_eye<T>(1.0, A0, d, m, A_ro, A_co, layout, 0.0);
+    }
+
+    template <typename T>
+    static void submatrix_other(
+        uint32_t seed, // seed for A
+        int64_t d, // rows in A
+        int64_t m, // cols in A, and rows in B.
+        int64_t n, // cols in B
+        int64_t m0, // rows in B0
+        int64_t n0, // cols in B0
+        int64_t B_ro, // row offset for B in B0
+        int64_t B_co, // column offset for B in B0
+        blas::Layout layout,
+        T p = 0.8
+    ) {
+        auto A = make_test_matrix<T>(d, m, p, seed);
+        randblas_require(m0 > m);
+        randblas_require(n0 > n);
+        test_left_apply_to_submatrix<T>(A, n, m0, n0, B_ro, B_co, layout);
+    }
+
+    template <typename T>
+    static void transpose_other(
+        uint32_t key, // seed for A
+        int64_t d, // rows in A
+        int64_t m, // cols in A, and rows in B.
+        int64_t n, // cols in B
+        blas::Layout layout,
+        T p = 0.8
+    ) {
+        // Define the distribution for S0.
+        auto A = make_test_matrix<T>(d, m, p, key);
+        test_left_apply_to_transposed<T>(A, n, layout);
+    }
+
+};
+
+
+////////////////////////////////////////////////////////////////////////
+//
+//
+//      Left-muliplication
+//
+//
+////////////////////////////////////////////////////////////////////////
+
+TEST_F(TestLeftMultiply, tall_multiply_eye_double_colmajor) {
+    for (uint32_t seed : {0}) {
+        multiply_eye<double>(seed, 200, 30, blas::Layout::ColMajor, 0.01);
+        multiply_eye<double>(seed, 200, 30, blas::Layout::ColMajor, 0.10);
+        multiply_eye<double>(seed, 200, 30, blas::Layout::ColMajor, 0.80);
+    }
+}
+
+TEST_F(TestLeftMultiply, tall_multiply_eye_double_rowmajor) {
+    for (uint32_t seed : {0}) {
+        multiply_eye<double>(seed, 200, 30, blas::Layout::RowMajor, 0.01);
+        multiply_eye<double>(seed, 200, 30, blas::Layout::RowMajor, 0.10);
+        multiply_eye<double>(seed, 200, 30, blas::Layout::RowMajor, 0.80);
+    }
+}
+
+TEST_F(TestLeftMultiply, wide_multiply_eye_double_colmajor) {
+    for (uint32_t seed : {0}) {
+        multiply_eye<double>(seed, 51, 101, blas::Layout::ColMajor, 0.01);
+        multiply_eye<double>(seed, 51, 101, blas::Layout::ColMajor, 0.10);
+        multiply_eye<double>(seed, 51, 101, blas::Layout::ColMajor, 0.80);
+    }
+}
+
+TEST_F(TestLeftMultiply, wide_multiply_eye_double_rowmajor) {
+    for (uint32_t seed : {0}) {
+        multiply_eye<double>(seed, 51, 101, blas::Layout::RowMajor, 0.01);
+        multiply_eye<double>(seed, 51, 101, blas::Layout::RowMajor, 0.10);
+        multiply_eye<double>(seed, 51, 101, blas::Layout::RowMajor, 0.80);
+    }
+}
+
+TEST_F(TestLeftMultiply, nontrivial_scales_colmajor1) {
+    double alpha = 5.5;
+    double beta = 0.0;
+    alpha_beta<double>(0, alpha, beta, 21, 4, blas::Layout::ColMajor, 0.05);
+    alpha_beta<double>(0, alpha, beta, 21, 4, blas::Layout::ColMajor, 0.10);
+    alpha_beta<double>(0, alpha, beta, 21, 4, blas::Layout::ColMajor, 0.80);
+}
+
+TEST_F(TestLeftMultiply, nontrivial_scales_colmajor2) {
+    double alpha = 5.5;
+    double beta = -1.0;
+    alpha_beta<double>(0, alpha, beta, 21, 4, blas::Layout::ColMajor, 0.05);
+    alpha_beta<double>(0, alpha, beta, 21, 4, blas::Layout::ColMajor, 0.10);
+    alpha_beta<double>(0, alpha, beta, 21, 4, blas::Layout::ColMajor, 0.80);
+}
+
+TEST_F(TestLeftMultiply, nontrivial_scales_rowmajor1) {
+    double alpha = 5.5;
+    double beta = 0.0;
+    alpha_beta<double>(0, alpha, beta, 21, 4, blas::Layout::RowMajor, 0.05);
+    alpha_beta<double>(0, alpha, beta, 21, 4, blas::Layout::RowMajor, 0.10);
+    alpha_beta<double>(0, alpha, beta, 21, 4, blas::Layout::RowMajor, 0.80);
+}
+
+TEST_F(TestLeftMultiply, nontrivial_scales_rowmajor2) {
+    double alpha = 5.5;
+    double beta = -1.0;
+    alpha_beta<double>(0, alpha, beta, 21, 4, blas::Layout::RowMajor, 0.05);
+    alpha_beta<double>(0, alpha, beta, 21, 4, blas::Layout::RowMajor, 0.10);
+    alpha_beta<double>(0, alpha, beta, 21, 4, blas::Layout::RowMajor, 0.80);
+}
+
+
+////////////////////////////////////////////////////////////////////////
+//
+//
+//      transpose of sparse operator
+//
+//
+////////////////////////////////////////////////////////////////////////
+
+TEST_F(TestLeftMultiply, transpose_sparse_double_colmajor) {
+    for (uint32_t seed : {0}) {
+        transpose_sparse<double>(seed, 200, 30, blas::Layout::ColMajor, 0.01);
+        transpose_sparse<double>(seed, 200, 30, blas::Layout::ColMajor, 0.10);
+        transpose_sparse<double>(seed, 200, 30, blas::Layout::ColMajor, 0.80);
+    }
+}
+
+TEST_F(TestLeftMultiply, transpose_sparse_double_rowmajor) {
+    for (uint32_t seed : {0}) {
+        transpose_sparse<double>(seed, 200, 30, blas::Layout::RowMajor, 0.01);
+        transpose_sparse<double>(seed, 200, 30, blas::Layout::RowMajor, 0.10);
+        transpose_sparse<double>(seed, 200, 30, blas::Layout::RowMajor, 0.80);
+    }
+}
+
+TEST_F(TestLeftMultiply, transpose_sparse_single) {
+    for (uint32_t seed : {0}) {
+        transpose_sparse<float>(seed, 200, 30, blas::Layout::ColMajor, 0.01);
+        transpose_sparse<float>(seed, 200, 30, blas::Layout::ColMajor, 0.10);
+        transpose_sparse<float>(seed, 200, 30, blas::Layout::ColMajor, 0.80);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////
+//
+//      Submatrices of sparse operator
+//
+////////////////////////////////////////////////////////////////////////
+
+TEST_F(TestLeftMultiply, submatrix_sparse_double_colmajor) {
+    for (uint32_t seed : {0}) {
+        submatrix_sparse<double>(seed, 3, 10, 8, 12, 3, 1, blas::Layout::ColMajor, 0.1);
+        submatrix_sparse<double>(seed, 3, 10, 8, 12, 3, 1, blas::Layout::ColMajor, 1.0);
+    }
+}
+
+TEST_F(TestLeftMultiply, submatrix_sparse_double_rowmajor) {
+    for (uint32_t seed : {0}) {
+        submatrix_sparse<double>(seed, 3, 10, 8, 12, 3, 1, blas::Layout::RowMajor, 0.1);
+        submatrix_sparse<double>(seed, 3, 10, 8, 12, 3, 1, blas::Layout::RowMajor, 1.0);
+    }
+}
+
+TEST_F(TestLeftMultiply, submatrix_sparse_single) {
+    for (uint32_t seed : {0}) {
+        submatrix_sparse<float>(seed, 3, 10, 8, 12, 3, 1, blas::Layout::ColMajor, 0.1);
+        submatrix_sparse<float>(seed, 3, 10, 8, 12, 3, 1, blas::Layout::ColMajor, 1.0);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////
+//
+//     submatrix of other operand in left-multiply
+//
+////////////////////////////////////////////////////////////////////////
+
+TEST_F(TestLeftMultiply, submatrix_other_double_colmajor) {
+    for (uint32_t seed : {0}) {
+        submatrix_other<double>(seed, 3, 10, 5, 12, 8, 2, 1, blas::Layout::ColMajor, 0.1);
+        submatrix_other<double>(seed, 3, 10, 5, 12, 8, 2, 1, blas::Layout::ColMajor, 1.0);
+    }
+}
+
+TEST_F(TestLeftMultiply, submatrix_other_double_rowmajor) {
+    for (uint32_t seed : {0}) {
+        submatrix_other<double>(seed, 3, 10, 5, 12, 8, 2, 1, blas::Layout::RowMajor, 0.1);
+        submatrix_other<double>(seed, 3, 10, 5, 12, 8, 2, 1, blas::Layout::RowMajor, 1.0);
+    }
+}
+
+TEST_F(TestLeftMultiply, submatrix_other_single) {
+    for (uint32_t seed : {0}) {
+        submatrix_other<float>(seed, 3, 10, 5, 12, 8, 2, 1, blas::Layout::ColMajor, 0.1);
+        submatrix_other<float>(seed, 3, 10, 5, 12, 8, 2, 1, blas::Layout::ColMajor, 1.0);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////
+//
+//     transpose of other
+//
+////////////////////////////////////////////////////////////////////////
+
+
+TEST_F(TestLeftMultiply, sparse_times_trans_other_colmajor) {
+    uint32_t seed = 0;
+    transpose_other<double>(seed, 7, 22, 5, blas::Layout::ColMajor, 0.05);
+    transpose_other<double>(seed, 7, 22, 5, blas::Layout::ColMajor, 0.10);
+    transpose_other<double>(seed, 7, 22, 5, blas::Layout::ColMajor, 0.80);
+}
+
+TEST_F(TestLeftMultiply, sparse_times_trans_other_rowmajor) {
+    uint32_t seed = 0;
+    transpose_other<double>(seed, 7, 22, 5, blas::Layout::RowMajor, 0.05);
+    transpose_other<double>(seed, 7, 22, 5, blas::Layout::RowMajor, 0.10);
+    transpose_other<double>(seed, 7, 22, 5, blas::Layout::RowMajor, 0.80);
+}
+

--- a/test/test_sparse_data/test_multiply.cc
+++ b/test/test_sparse_data/test_multiply.cc
@@ -9,14 +9,14 @@ using namespace test::common;
 using blas::Layout;
 
 template <typename T>
-COOMatrix<T> make_test_matrix(int64_t m, int64_t n, T nonzero_prob, uint32_t seed = 0) {
+COOMatrix<T> make_test_matrix(int64_t m, int64_t n, T nonzero_prob, uint32_t key = 0) {
     randblas_require(nonzero_prob >= 0);
     randblas_require(nonzero_prob <= 1);
     COOMatrix<T> A(m, n);
     std::vector<T> actual(m * n);
-    RandBLAS::RNGState s(seed);
+    RandBLAS::RNGState s(key);
     iid_sparsify_random_dense<T>(m, n, Layout::ColMajor, actual.data(), nonzero_prob, s);
-    dense_to_coo<T>(blas::Layout::ColMajor, actual.data(), 0.0, A);
+    dense_to_coo<T>(Layout::ColMajor, actual.data(), 0.0, A);
     return A;
 }
 
@@ -30,75 +30,56 @@ class TestLeftMultiply : public ::testing::Test
     virtual void TearDown(){};
 
     template <typename T>
-    static void multiply_eye(
-        uint32_t seed,
-        int64_t m,
-        int64_t n,
-        blas::Layout layout,
-        T p = 0.8
-    ) {
-        auto A = make_test_matrix<T>(m, n, p, seed);
+    static void multiply_eye(uint32_t key, int64_t m, int64_t n, Layout layout, T p) {
+        auto A = make_test_matrix<T>(m, n, p, key);
         test_left_apply_submatrix_to_eye<T>(1.0, A, m, n, 0, 0, layout, 0.0);
     }
 
     template <typename T>
-    static void alpha_beta(
-        uint32_t key,
-        T alpha,
-        T beta,
-        int64_t m,
-        int64_t d,
-        blas::Layout layout,
-        T p = 0.8
-    ) {
-        auto A = make_test_matrix<T>(d, m, p, key);
-        test_left_apply_submatrix_to_eye<T>(alpha, A, d, m, 0, 0, layout, beta);
+    static void alpha_beta(uint32_t key, T alpha, T beta, int64_t m, int64_t n, Layout layout, T p) {
+        randblas_require(alpha != (T)1.0 || beta != (T)0.0);
+        auto A = make_test_matrix<T>(m, n, p, key);
+        test_left_apply_submatrix_to_eye<T>(alpha, A, m, n, 0, 0, layout, beta);
     }
 
     template <typename T>
-    static void transpose_sparse(
-        uint32_t seed,
-        int64_t m,
-        int64_t n,
-        blas::Layout layout,
-        T p = 0.8
-    ) {
-        auto A = make_test_matrix<T>(m, n, p, seed);
+    static void transpose_sparse(uint32_t key, int64_t m, int64_t n, Layout layout, T p) {
+        auto A = make_test_matrix<T>(m, n, p, key);
         test_left_apply_transpose_to_eye<T>(A, layout);
     }
 
     template <typename T>
     static void submatrix_sparse(
-        uint32_t seed,
-        int64_t d, // rows in sketch
-        int64_t m, // size of identity matrix
-        int64_t d0, // rows in A0
-        int64_t m0, // cols in A0
-        int64_t A_ro, // row offset for A in A0
-        int64_t A_co, // column offset for A in A0
-        blas::Layout layout,
-        T p = 0.8
+        uint32_t key,   // key for RNG that generates sparse A
+        int64_t d,      // rows in A
+        int64_t m,      // columns in A, rows in B = eye(m)
+        int64_t d0,     // rows in A0
+        int64_t m0,     // cols in A0
+        int64_t A_ro,   // row offset for A in A0
+        int64_t A_co,   // column offset for A in A0
+        Layout layout,  // layout of dense matrix input and output
+        T p
     ) {
         randblas_require(d0 > d);
         randblas_require(m0 > m);
-        auto A0 = make_test_matrix<T>(d0, m0, p, seed);
+        auto A0 = make_test_matrix<T>(d0, m0, p, key);
         test_left_apply_submatrix_to_eye<T>(1.0, A0, d, m, A_ro, A_co, layout, 0.0);
     }
 
     template <typename T>
     static void submatrix_other(
-        uint32_t seed, // seed for A
-        int64_t d, // rows in A
-        int64_t m, // cols in A, and rows in B.
-        int64_t n, // cols in B
-        int64_t m0, // rows in B0
-        int64_t n0, // cols in B0
-        int64_t B_ro, // row offset for B in B0
-        int64_t B_co, // column offset for B in B0
-        blas::Layout layout,
-        T p = 0.8
+        uint32_t key,  // key for RNG that generates sparse A
+        int64_t d,     // rows in A
+        int64_t m,     // cols in A, and rows in B.
+        int64_t n,     // cols in B
+        int64_t m0,    // rows in B0
+        int64_t n0,    // cols in B0
+        int64_t B_ro,  // row offset for B in B0
+        int64_t B_co,  // column offset for B in B0
+        Layout layout, // layout of dense matrix input and output
+        T p
     ) {
-        auto A = make_test_matrix<T>(d, m, p, seed);
+        auto A = make_test_matrix<T>(d, m, p, key);
         randblas_require(m0 > m);
         randblas_require(n0 > n);
         test_left_apply_to_submatrix<T>(A, n, m0, n0, B_ro, B_co, layout);
@@ -106,14 +87,13 @@ class TestLeftMultiply : public ::testing::Test
 
     template <typename T>
     static void transpose_other(
-        uint32_t key, // seed for A
-        int64_t d, // rows in A
-        int64_t m, // cols in A, and rows in B.
-        int64_t n, // cols in B
-        blas::Layout layout,
-        T p = 0.8
+        uint32_t key,  // key for RNG that generates sparse A
+        int64_t d,     // rows in A
+        int64_t m,     // cols in A, and rows in B.
+        int64_t n,     // cols in B
+        Layout layout, // layout of dense matrix input and output
+        T p
     ) {
-        // Define the distribution for S0.
         auto A = make_test_matrix<T>(d, m, p, key);
         test_left_apply_to_transposed<T>(A, n, layout);
     }
@@ -130,99 +110,97 @@ class TestLeftMultiply : public ::testing::Test
 ////////////////////////////////////////////////////////////////////////
 
 TEST_F(TestLeftMultiply, tall_multiply_eye_double_colmajor) {
-    for (uint32_t seed : {0}) {
-        multiply_eye<double>(seed, 200, 30, blas::Layout::ColMajor, 0.01);
-        multiply_eye<double>(seed, 200, 30, blas::Layout::ColMajor, 0.10);
-        multiply_eye<double>(seed, 200, 30, blas::Layout::ColMajor, 0.80);
+    for (uint32_t key : {0}) {
+        multiply_eye<double>(key, 200, 30, Layout::ColMajor, 0.01);
+        multiply_eye<double>(key, 200, 30, Layout::ColMajor, 0.10);
+        multiply_eye<double>(key, 200, 30, Layout::ColMajor, 0.80);
     }
 }
 
 TEST_F(TestLeftMultiply, tall_multiply_eye_double_rowmajor) {
-    for (uint32_t seed : {0}) {
-        multiply_eye<double>(seed, 200, 30, blas::Layout::RowMajor, 0.01);
-        multiply_eye<double>(seed, 200, 30, blas::Layout::RowMajor, 0.10);
-        multiply_eye<double>(seed, 200, 30, blas::Layout::RowMajor, 0.80);
+    for (uint32_t key : {0}) {
+        multiply_eye<double>(key, 200, 30, Layout::RowMajor, 0.01);
+        multiply_eye<double>(key, 200, 30, Layout::RowMajor, 0.10);
+        multiply_eye<double>(key, 200, 30, Layout::RowMajor, 0.80);
     }
 }
 
 TEST_F(TestLeftMultiply, wide_multiply_eye_double_colmajor) {
-    for (uint32_t seed : {0}) {
-        multiply_eye<double>(seed, 51, 101, blas::Layout::ColMajor, 0.01);
-        multiply_eye<double>(seed, 51, 101, blas::Layout::ColMajor, 0.10);
-        multiply_eye<double>(seed, 51, 101, blas::Layout::ColMajor, 0.80);
+    for (uint32_t key : {0}) {
+        multiply_eye<double>(key, 51, 101, Layout::ColMajor, 0.01);
+        multiply_eye<double>(key, 51, 101, Layout::ColMajor, 0.10);
+        multiply_eye<double>(key, 51, 101, Layout::ColMajor, 0.80);
     }
 }
 
 TEST_F(TestLeftMultiply, wide_multiply_eye_double_rowmajor) {
-    for (uint32_t seed : {0}) {
-        multiply_eye<double>(seed, 51, 101, blas::Layout::RowMajor, 0.01);
-        multiply_eye<double>(seed, 51, 101, blas::Layout::RowMajor, 0.10);
-        multiply_eye<double>(seed, 51, 101, blas::Layout::RowMajor, 0.80);
+    for (uint32_t key : {0}) {
+        multiply_eye<double>(key, 51, 101, Layout::RowMajor, 0.01);
+        multiply_eye<double>(key, 51, 101, Layout::RowMajor, 0.10);
+        multiply_eye<double>(key, 51, 101, Layout::RowMajor, 0.80);
     }
 }
 
 TEST_F(TestLeftMultiply, nontrivial_scales_colmajor1) {
     double alpha = 5.5;
     double beta = 0.0;
-    alpha_beta<double>(0, alpha, beta, 21, 4, blas::Layout::ColMajor, 0.05);
-    alpha_beta<double>(0, alpha, beta, 21, 4, blas::Layout::ColMajor, 0.10);
-    alpha_beta<double>(0, alpha, beta, 21, 4, blas::Layout::ColMajor, 0.80);
+    alpha_beta<double>(0, alpha, beta, 21, 4, Layout::ColMajor, 0.05);
+    alpha_beta<double>(0, alpha, beta, 21, 4, Layout::ColMajor, 0.10);
+    alpha_beta<double>(0, alpha, beta, 21, 4, Layout::ColMajor, 0.80);
 }
 
 TEST_F(TestLeftMultiply, nontrivial_scales_colmajor2) {
     double alpha = 5.5;
     double beta = -1.0;
-    alpha_beta<double>(0, alpha, beta, 21, 4, blas::Layout::ColMajor, 0.05);
-    alpha_beta<double>(0, alpha, beta, 21, 4, blas::Layout::ColMajor, 0.10);
-    alpha_beta<double>(0, alpha, beta, 21, 4, blas::Layout::ColMajor, 0.80);
+    alpha_beta<double>(0, alpha, beta, 21, 4, Layout::ColMajor, 0.05);
+    alpha_beta<double>(0, alpha, beta, 21, 4, Layout::ColMajor, 0.10);
+    alpha_beta<double>(0, alpha, beta, 21, 4, Layout::ColMajor, 0.80);
 }
 
 TEST_F(TestLeftMultiply, nontrivial_scales_rowmajor1) {
     double alpha = 5.5;
     double beta = 0.0;
-    alpha_beta<double>(0, alpha, beta, 21, 4, blas::Layout::RowMajor, 0.05);
-    alpha_beta<double>(0, alpha, beta, 21, 4, blas::Layout::RowMajor, 0.10);
-    alpha_beta<double>(0, alpha, beta, 21, 4, blas::Layout::RowMajor, 0.80);
+    alpha_beta<double>(0, alpha, beta, 21, 4, Layout::RowMajor, 0.05);
+    alpha_beta<double>(0, alpha, beta, 21, 4, Layout::RowMajor, 0.10);
+    alpha_beta<double>(0, alpha, beta, 21, 4, Layout::RowMajor, 0.80);
 }
 
 TEST_F(TestLeftMultiply, nontrivial_scales_rowmajor2) {
     double alpha = 5.5;
     double beta = -1.0;
-    alpha_beta<double>(0, alpha, beta, 21, 4, blas::Layout::RowMajor, 0.05);
-    alpha_beta<double>(0, alpha, beta, 21, 4, blas::Layout::RowMajor, 0.10);
-    alpha_beta<double>(0, alpha, beta, 21, 4, blas::Layout::RowMajor, 0.80);
+    alpha_beta<double>(0, alpha, beta, 21, 4, Layout::RowMajor, 0.05);
+    alpha_beta<double>(0, alpha, beta, 21, 4, Layout::RowMajor, 0.10);
+    alpha_beta<double>(0, alpha, beta, 21, 4, Layout::RowMajor, 0.80);
 }
 
 
 ////////////////////////////////////////////////////////////////////////
 //
-//
 //      transpose of sparse operator
-//
 //
 ////////////////////////////////////////////////////////////////////////
 
 TEST_F(TestLeftMultiply, transpose_sparse_double_colmajor) {
-    for (uint32_t seed : {0}) {
-        transpose_sparse<double>(seed, 200, 30, blas::Layout::ColMajor, 0.01);
-        transpose_sparse<double>(seed, 200, 30, blas::Layout::ColMajor, 0.10);
-        transpose_sparse<double>(seed, 200, 30, blas::Layout::ColMajor, 0.80);
+    for (uint32_t key : {0}) {
+        transpose_sparse<double>(key, 200, 30, Layout::ColMajor, 0.01);
+        transpose_sparse<double>(key, 200, 30, Layout::ColMajor, 0.10);
+        transpose_sparse<double>(key, 200, 30, Layout::ColMajor, 0.80);
     }
 }
 
 TEST_F(TestLeftMultiply, transpose_sparse_double_rowmajor) {
-    for (uint32_t seed : {0}) {
-        transpose_sparse<double>(seed, 200, 30, blas::Layout::RowMajor, 0.01);
-        transpose_sparse<double>(seed, 200, 30, blas::Layout::RowMajor, 0.10);
-        transpose_sparse<double>(seed, 200, 30, blas::Layout::RowMajor, 0.80);
+    for (uint32_t key : {0}) {
+        transpose_sparse<double>(key, 200, 30, Layout::RowMajor, 0.01);
+        transpose_sparse<double>(key, 200, 30, Layout::RowMajor, 0.10);
+        transpose_sparse<double>(key, 200, 30, Layout::RowMajor, 0.80);
     }
 }
 
 TEST_F(TestLeftMultiply, transpose_sparse_single) {
-    for (uint32_t seed : {0}) {
-        transpose_sparse<float>(seed, 200, 30, blas::Layout::ColMajor, 0.01);
-        transpose_sparse<float>(seed, 200, 30, blas::Layout::ColMajor, 0.10);
-        transpose_sparse<float>(seed, 200, 30, blas::Layout::ColMajor, 0.80);
+    for (uint32_t key : {0}) {
+        transpose_sparse<float>(key, 200, 30, Layout::ColMajor, 0.01);
+        transpose_sparse<float>(key, 200, 30, Layout::ColMajor, 0.10);
+        transpose_sparse<float>(key, 200, 30, Layout::ColMajor, 0.80);
     }
 }
 
@@ -233,23 +211,23 @@ TEST_F(TestLeftMultiply, transpose_sparse_single) {
 ////////////////////////////////////////////////////////////////////////
 
 TEST_F(TestLeftMultiply, submatrix_sparse_double_colmajor) {
-    for (uint32_t seed : {0}) {
-        submatrix_sparse<double>(seed, 3, 10, 8, 12, 3, 1, blas::Layout::ColMajor, 0.1);
-        submatrix_sparse<double>(seed, 3, 10, 8, 12, 3, 1, blas::Layout::ColMajor, 1.0);
+    for (uint32_t key : {0}) {
+        submatrix_sparse<double>(key, 3, 10, 8, 12, 3, 1, Layout::ColMajor, 0.1);
+        submatrix_sparse<double>(key, 3, 10, 8, 12, 3, 1, Layout::ColMajor, 1.0);
     }
 }
 
 TEST_F(TestLeftMultiply, submatrix_sparse_double_rowmajor) {
-    for (uint32_t seed : {0}) {
-        submatrix_sparse<double>(seed, 3, 10, 8, 12, 3, 1, blas::Layout::RowMajor, 0.1);
-        submatrix_sparse<double>(seed, 3, 10, 8, 12, 3, 1, blas::Layout::RowMajor, 1.0);
+    for (uint32_t key : {0}) {
+        submatrix_sparse<double>(key, 3, 10, 8, 12, 3, 1, Layout::RowMajor, 0.1);
+        submatrix_sparse<double>(key, 3, 10, 8, 12, 3, 1, Layout::RowMajor, 1.0);
     }
 }
 
 TEST_F(TestLeftMultiply, submatrix_sparse_single) {
-    for (uint32_t seed : {0}) {
-        submatrix_sparse<float>(seed, 3, 10, 8, 12, 3, 1, blas::Layout::ColMajor, 0.1);
-        submatrix_sparse<float>(seed, 3, 10, 8, 12, 3, 1, blas::Layout::ColMajor, 1.0);
+    for (uint32_t key : {0}) {
+        submatrix_sparse<float>(key, 3, 10, 8, 12, 3, 1, Layout::ColMajor, 0.1);
+        submatrix_sparse<float>(key, 3, 10, 8, 12, 3, 1, Layout::ColMajor, 1.0);
     }
 }
 
@@ -260,23 +238,23 @@ TEST_F(TestLeftMultiply, submatrix_sparse_single) {
 ////////////////////////////////////////////////////////////////////////
 
 TEST_F(TestLeftMultiply, submatrix_other_double_colmajor) {
-    for (uint32_t seed : {0}) {
-        submatrix_other<double>(seed, 3, 10, 5, 12, 8, 2, 1, blas::Layout::ColMajor, 0.1);
-        submatrix_other<double>(seed, 3, 10, 5, 12, 8, 2, 1, blas::Layout::ColMajor, 1.0);
+    for (uint32_t key : {0}) {
+        submatrix_other<double>(key, 3, 10, 5, 12, 8, 2, 1, Layout::ColMajor, 0.1);
+        submatrix_other<double>(key, 3, 10, 5, 12, 8, 2, 1, Layout::ColMajor, 1.0);
     }
 }
 
 TEST_F(TestLeftMultiply, submatrix_other_double_rowmajor) {
-    for (uint32_t seed : {0}) {
-        submatrix_other<double>(seed, 3, 10, 5, 12, 8, 2, 1, blas::Layout::RowMajor, 0.1);
-        submatrix_other<double>(seed, 3, 10, 5, 12, 8, 2, 1, blas::Layout::RowMajor, 1.0);
+    for (uint32_t key : {0}) {
+        submatrix_other<double>(key, 3, 10, 5, 12, 8, 2, 1, Layout::RowMajor, 0.1);
+        submatrix_other<double>(key, 3, 10, 5, 12, 8, 2, 1, Layout::RowMajor, 1.0);
     }
 }
 
 TEST_F(TestLeftMultiply, submatrix_other_single) {
-    for (uint32_t seed : {0}) {
-        submatrix_other<float>(seed, 3, 10, 5, 12, 8, 2, 1, blas::Layout::ColMajor, 0.1);
-        submatrix_other<float>(seed, 3, 10, 5, 12, 8, 2, 1, blas::Layout::ColMajor, 1.0);
+    for (uint32_t key : {0}) {
+        submatrix_other<float>(key, 3, 10, 5, 12, 8, 2, 1, Layout::ColMajor, 0.1);
+        submatrix_other<float>(key, 3, 10, 5, 12, 8, 2, 1, Layout::ColMajor, 1.0);
     }
 }
 
@@ -288,16 +266,16 @@ TEST_F(TestLeftMultiply, submatrix_other_single) {
 
 
 TEST_F(TestLeftMultiply, sparse_times_trans_other_colmajor) {
-    uint32_t seed = 0;
-    transpose_other<double>(seed, 7, 22, 5, blas::Layout::ColMajor, 0.05);
-    transpose_other<double>(seed, 7, 22, 5, blas::Layout::ColMajor, 0.10);
-    transpose_other<double>(seed, 7, 22, 5, blas::Layout::ColMajor, 0.80);
+    uint32_t key = 0;
+    transpose_other<double>(key, 7, 22, 5, Layout::ColMajor, 0.05);
+    transpose_other<double>(key, 7, 22, 5, Layout::ColMajor, 0.10);
+    transpose_other<double>(key, 7, 22, 5, Layout::ColMajor, 0.80);
 }
 
 TEST_F(TestLeftMultiply, sparse_times_trans_other_rowmajor) {
-    uint32_t seed = 0;
-    transpose_other<double>(seed, 7, 22, 5, blas::Layout::RowMajor, 0.05);
-    transpose_other<double>(seed, 7, 22, 5, blas::Layout::RowMajor, 0.10);
-    transpose_other<double>(seed, 7, 22, 5, blas::Layout::RowMajor, 0.80);
+    uint32_t key = 0;
+    transpose_other<double>(key, 7, 22, 5, Layout::RowMajor, 0.05);
+    transpose_other<double>(key, 7, 22, 5, Layout::RowMajor, 0.10);
+    transpose_other<double>(key, 7, 22, 5, Layout::RowMajor, 0.80);
 }
 

--- a/test/test_sparse_data/test_right_multiply.cc
+++ b/test/test_sparse_data/test_right_multiply.cc
@@ -1,0 +1,276 @@
+#include "../common.hh"
+#include "common.hh"
+#include <gtest/gtest.h>
+#include <vector>
+
+using RandBLAS::sparse_data::coo::dense_to_coo;
+using namespace test::sparse_data::common;
+using namespace test::common;
+using blas::Layout;
+
+template <typename T>
+COOMatrix<T> make_test_matrix(int64_t m, int64_t n, T nonzero_prob, uint32_t key=0) {
+    randblas_require(nonzero_prob >= 0);
+    randblas_require(nonzero_prob <= 1);
+    COOMatrix<T> A(m, n);
+    std::vector<T> actual(m * n);
+    RandBLAS::RNGState s(key);
+    iid_sparsify_random_dense<T>(m, n, Layout::ColMajor, actual.data(), nonzero_prob, s);
+    dense_to_coo<T>(Layout::ColMajor, actual.data(), 0.0, A);
+    return A;
+}
+
+class TestRightMultiply : public ::testing::Test
+{
+    // C = alpha * opB(B) @ opA(submat(A)) + beta * C
+    //
+    //  In what follows, "self" refers to A and "other" refers to B.
+    //
+    //  C is m-by-d (TODO: verify)
+    protected:
+    virtual void SetUp(){};
+    virtual void TearDown(){};
+
+    template <typename T>
+    static void multiply_eye(uint32_t key, int64_t m, int64_t n, Layout layout, T p) {
+        auto A = make_test_matrix<T>(m, n, p, key);
+        test_right_apply_submatrix_to_eye<T>(1.0, A, m, n, 0, 0, layout, 0.0, 0);
+    }
+
+    template <typename T>
+    static void alpha_beta(uint32_t key, T alpha, T beta, int64_t m, int64_t n, Layout layout, T p) {
+        auto A = make_test_matrix<T>(m, n, p, key);
+       test_right_apply_submatrix_to_eye<T>(alpha, A, m, n, 0, 0, layout, beta, 0);
+    }
+
+    template <typename T>
+    static void transpose_self(uint32_t key, int64_t m, int64_t n, Layout layout, T p) {
+        auto A = make_test_matrix<T>(m, n, p, key);
+        test_right_apply_tranpose_to_eye<T>(A, layout, 0);
+    }
+
+    template <typename T>
+    static void submatrix_self(
+        uint32_t key,   // key for RNG that generates sparse A
+        int64_t d,      // cols in A
+        int64_t m,      // rows in A, columns in B = eye(m)
+        int64_t d0,     // cols in A0
+        int64_t m0,     // rows in A0
+        int64_t A_ro,   // row offset for A in A0
+        int64_t A_co,   // col offset for A in A0
+        Layout layout,  // layout of dense matrix input and output
+        T p
+    ) {
+        auto A0 = make_test_matrix<T>(m0, d0, p, key);
+        test_right_apply_submatrix_to_eye<T>(1.0, A0, m, d, A_ro, A_co, layout, 0.0, 0);
+    }
+
+    template <typename T>
+    static void submatrix_other(
+        uint32_t key,   // key for RNG that generates sparse A
+        int64_t d,      // cols in A
+        int64_t m,      // rows in B
+        int64_t n,      // rows in A, columns in B
+        int64_t m0,     // rows in B0
+        int64_t n0,     // cols in B0
+        int64_t B_ro,   // row offset for B in B0
+        int64_t B_co,   // col offset for B in B0
+        Layout layout,  // layout of dense matrix input and output
+        T p
+    ) {
+        auto A = make_test_matrix<T>(n, d, p, key);
+        test_right_apply_to_submatrix<T>(A, m, m0, n0, B_ro, B_co, layout, 0);
+    }
+
+    template <typename T>
+    static void transpose_other(
+        uint32_t key,  // key for RNG that generates sparse A
+        int64_t d,     // cols in A
+        int64_t n,     // rows in A and B
+        int64_t m,     // cols in B
+        Layout layout, // layout of dense matrix input and output
+        T p
+    ) {
+        auto A = make_test_matrix<T>(n, d, p, key);
+        test_right_apply_to_transposed<T>(A, m, layout, 0);
+    }
+};
+
+////////////////////////////////////////////////////////////////////////
+//
+//
+//      Right-muliplication
+//
+//
+////////////////////////////////////////////////////////////////////////
+
+TEST_F(TestRightMultiply, wide_multiply_eye_double_colmajor) {
+    for (uint32_t key : {0}) {
+        multiply_eye<double>(key, 200, 30, Layout::ColMajor, 0.01);
+        multiply_eye<double>(key, 200, 30, Layout::ColMajor, 0.10);
+        multiply_eye<double>(key, 200, 30, Layout::ColMajor, 0.80);
+    }
+}
+
+TEST_F(TestRightMultiply, wide_multiply_eye_double_rowmajor) {
+    for (uint32_t key : {0}) {
+        multiply_eye<double>(key, 200, 30, Layout::RowMajor, 0.01);
+        multiply_eye<double>(key, 200, 30, Layout::RowMajor, 0.10);
+        multiply_eye<double>(key, 200, 30, Layout::RowMajor, 0.80);
+    }
+}
+
+
+TEST_F(TestRightMultiply, tall_multiply_eye_double_colmajor) {
+    for (uint32_t key : {0}) {
+        multiply_eye<double>(key, 51, 101, Layout::ColMajor, 0.01);
+        multiply_eye<double>(key, 51, 101, Layout::ColMajor, 0.10);
+        multiply_eye<double>(key, 51, 101, Layout::ColMajor, 0.80);
+    }
+}
+
+TEST_F(TestRightMultiply, tall_multiply_eye_double_rowmajor) {
+    for (uint32_t key : {0}) {
+        multiply_eye<double>(key, 51, 101, Layout::RowMajor, 0.01);
+        multiply_eye<double>(key, 51, 101, Layout::RowMajor, 0.10);
+        multiply_eye<double>(key, 51, 101, Layout::RowMajor, 0.80);
+    }
+}
+
+TEST_F(TestRightMultiply, nontrivial_scales_colmajor1) {
+    double alpha = 5.5;
+    double beta = 0.0;
+    alpha_beta<double>(0, alpha, beta, 4, 21, Layout::ColMajor, 0.05);
+    alpha_beta<double>(0, alpha, beta, 4, 21, Layout::ColMajor, 0.10);
+    alpha_beta<double>(0, alpha, beta, 4, 21, Layout::ColMajor, 0.80);
+}
+
+TEST_F(TestRightMultiply, nontrivial_scales_colmajor2) {
+    double alpha = 5.5;
+    double beta = -1.0;
+    alpha_beta<double>(0, alpha, beta, 4, 21, Layout::ColMajor, 0.05);
+    alpha_beta<double>(0, alpha, beta, 4, 21, Layout::ColMajor, 0.10);
+    alpha_beta<double>(0, alpha, beta, 4, 21, Layout::ColMajor, 0.80);
+}
+
+TEST_F(TestRightMultiply, nontrivial_scales_rowmajor1) {
+    double alpha = 5.5;
+    double beta = 0.0;
+    alpha_beta<double>(0, alpha, beta, 4, 21, Layout::RowMajor, 0.05);
+    alpha_beta<double>(0, alpha, beta, 4, 21, Layout::RowMajor, 0.10);
+    alpha_beta<double>(0, alpha, beta, 4, 21, Layout::RowMajor, 0.80);
+}
+
+TEST_F(TestRightMultiply, nontrivial_scales_rowmajor2) {
+    double alpha = 5.5;
+    double beta = -1.0;
+    alpha_beta<double>(0, alpha, beta, 4, 21, Layout::RowMajor, 0.05);
+    alpha_beta<double>(0, alpha, beta, 4, 21, Layout::RowMajor, 0.10);
+    alpha_beta<double>(0, alpha, beta, 4, 21, Layout::RowMajor, 0.80);
+}
+
+////////////////////////////////////////////////////////////////////////
+//
+//      transpose of self (sparse operator)
+//
+////////////////////////////////////////////////////////////////////////
+
+TEST_F(TestRightMultiply, transpose_self_double_colmajor) {
+    for (uint32_t key : {0}) {
+        transpose_self<double>(key, 30, 200, Layout::ColMajor, 0.01);
+        transpose_self<double>(key, 30, 200, Layout::ColMajor, 0.10);
+        transpose_self<double>(key, 30, 200, Layout::ColMajor, 0.80);
+    }
+}
+
+TEST_F(TestRightMultiply, transpose_self_double_rowmajor) {
+    for (uint32_t key : {0}) {
+        transpose_self<double>(key, 30, 200, Layout::RowMajor, 0.01);
+        transpose_self<double>(key, 30, 200, Layout::RowMajor, 0.10);
+        transpose_self<double>(key, 30, 200, Layout::RowMajor, 0.80);
+    }
+}
+
+TEST_F(TestRightMultiply, transpose_self_single) {
+    for (uint32_t key : {0}) {
+        transpose_self<float>(key, 30, 200, Layout::ColMajor, 0.01);
+        transpose_self<float>(key, 30, 200, Layout::ColMajor, 0.10);
+        transpose_self<float>(key, 30, 200, Layout::ColMajor, 0.80);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////
+//
+//      Submatrices of self (sparse operator)
+//
+////////////////////////////////////////////////////////////////////////
+
+TEST_F(TestRightMultiply, submatrix_self_double_colmajor) {
+    for (uint32_t key : {0}) {
+        submatrix_self<double>(key, 3, 10, 8, 12, 2, 1, Layout::ColMajor, 0.1);
+        submatrix_self<double>(key, 3, 10, 8, 12, 2, 1, Layout::ColMajor, 1.0);
+    }
+}
+
+TEST_F(TestRightMultiply, submatrix_self_double_rowmajor) {
+    for (uint32_t key : {0}) {
+        submatrix_self<double>(key, 3, 10, 8, 12, 2, 1, Layout::RowMajor, 0.1);
+        submatrix_self<double>(key, 3, 10, 8, 12, 2, 1, Layout::RowMajor, 1.0);
+    }
+}
+
+TEST_F(TestRightMultiply, submatrix_self_single) {
+    for (uint32_t key : {0}) {
+        submatrix_self<float>(key, 3, 10, 8, 12, 2, 1, Layout::ColMajor, 0.1);
+        submatrix_self<float>(key, 3, 10, 8, 12, 2, 1, Layout::ColMajor, 1.0);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////
+//
+//     submatrix of other operand in right-multiply
+//
+////////////////////////////////////////////////////////////////////////
+
+TEST_F(TestRightMultiply, submatrix_other_double_colmajor) {
+    for (uint32_t key : {0}) {
+        submatrix_other<double>(key, 3, 10, 5, 12, 8, 2, 1, Layout::ColMajor, 0.1);
+        submatrix_other<double>(key, 3, 10, 5, 12, 8, 2, 1, Layout::ColMajor, 1.0);
+    }
+}
+
+TEST_F(TestRightMultiply, submatrix_other_double_rowmajor) {
+    for (uint32_t key : {0}) {
+        submatrix_other<double>(key, 3, 10, 5, 12, 8, 2, 1, Layout::RowMajor, 0.1);
+        submatrix_other<double>(key, 3, 10, 5, 12, 8, 2, 1, Layout::RowMajor, 1.0);
+    }
+}
+
+TEST_F(TestRightMultiply, submatrix_other_single) {
+    for (uint32_t key : {0}) {
+        submatrix_other<float>(key, 3, 10, 5, 12, 8, 2, 1, Layout::ColMajor, 0.1);
+        submatrix_other<float>(key, 3, 10, 5, 12, 8, 2, 1, Layout::ColMajor, 1.0);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////
+//
+//     transpose of other
+//
+////////////////////////////////////////////////////////////////////////
+
+
+TEST_F(TestRightMultiply, trans_other_times_sparse_colmajor) {
+    uint32_t key = 0;
+    transpose_other<double>(key, 7, 22, 5, Layout::ColMajor, 0.05);
+    transpose_other<double>(key, 7, 22, 5, Layout::ColMajor, 0.10);
+    transpose_other<double>(key, 7, 22, 5, Layout::ColMajor, 0.80);
+}
+
+TEST_F(TestRightMultiply, trans_other_times_sparse_rowmajor) {
+    uint32_t key = 0;
+    transpose_other<double>(key, 7, 22, 5, Layout::RowMajor, 0.05);
+    transpose_other<double>(key, 7, 22, 5, Layout::RowMajor, 0.10);
+    transpose_other<double>(key, 7, 22, 5, Layout::RowMajor, 0.80);
+}
+

--- a/test/test_sparse_data/test_right_multiply.cc
+++ b/test/test_sparse_data/test_right_multiply.cc
@@ -1,11 +1,11 @@
-#include "../common.hh"
+#include "../linop_common.hh"
 #include "common.hh"
 #include <gtest/gtest.h>
 #include <vector>
 
 using RandBLAS::sparse_data::coo::dense_to_coo;
 using namespace test::sparse_data::common;
-using namespace test::common;
+using namespace test::linop_common;
 using blas::Layout;
 
 template <typename T>
@@ -26,7 +26,6 @@ class TestRightMultiply : public ::testing::Test
     //
     //  In what follows, "self" refers to A and "other" refers to B.
     //
-    //  C is m-by-d (TODO: verify)
     protected:
     virtual void SetUp(){};
     virtual void TearDown(){};

--- a/test/test_sparse_skops/test_construction.cc
+++ b/test/test_sparse_skops/test_construction.cc
@@ -1,7 +1,7 @@
 #include <RandBLAS/dense.hh>
 #include <RandBLAS/sparse_skops.hh>
 #include <RandBLAS/util.hh>
-#include <RandBLAS/test_util.hh>
+#include "../comparison.hh"
 #include <gtest/gtest.h>
 #include <math.h>
 

--- a/test/test_sparse_skops/test_sketch_gefls.cc
+++ b/test/test_sparse_skops/test_sketch_gefls.cc
@@ -1,9 +1,10 @@
-#include "../common.hh"
+#include "../linop_common.hh"
 #include <gtest/gtest.h>
 
 using RandBLAS::SparseDist;
 using RandBLAS::SparseSkOp;
 using RandBLAS::MajorAxis;
+using namespace test::linop_common;
 
 
 class TestLSKGES : public ::testing::Test
@@ -28,7 +29,7 @@ class TestLSKGES : public ::testing::Test
         int threads
     ) {
         SparseSkOp<T> S0({d, m, vec_nnzs[nnz_index], major_axis}, keys[key_index]);
-        test::common::test_left_apply_to_random<T>(1.0, S0, n, 0.0, layout, threads);
+        test_left_apply_to_random<T>(1.0, S0, n, 0.0, layout, threads);
     }
 
     template <typename T>
@@ -44,7 +45,7 @@ class TestLSKGES : public ::testing::Test
     ) {
         int64_t vec_nnz = d0 / 3; // this is actually quite dense. 
         SparseSkOp<T> S0({d0, m0, vec_nnz, MajorAxis::Short}, seed);
-        test::common::test_left_apply_submatrix_to_eye<T>(1.0, S0, d1, m1, S_ro, S_co, layout, 0.0);
+        test_left_apply_submatrix_to_eye<T>(1.0, S0, d1, m1, S_ro, S_co, layout, 0.0);
     }
 
     template <typename T>
@@ -59,7 +60,7 @@ class TestLSKGES : public ::testing::Test
         int64_t vec_nnz = d / 2;
         SparseDist DS = {d, m, vec_nnz, MajorAxis::Short};
         SparseSkOp<T> S(DS, key);
-        test::common::test_left_apply_submatrix_to_eye(alpha, S, d, m, 0, 0, layout, beta);
+        test_left_apply_submatrix_to_eye(alpha, S, d, m, 0, 0, layout, beta);
     }
 
     template <typename T>
@@ -80,7 +81,7 @@ class TestLSKGES : public ::testing::Test
             .major_axis = major_axis
         };
         SparseSkOp<T> S0(Dt, key);
-        test::common::test_left_apply_transpose_to_eye<T>(S0, layout);
+        test_left_apply_transpose_to_eye<T>(S0, layout);
     }
 
     template <typename T>
@@ -106,7 +107,7 @@ class TestLSKGES : public ::testing::Test
             .major_axis = major_axis
         };
         SparseSkOp<T> S0(D, seed_S0);
-        test::common::test_left_apply_to_submatrix<T>(S0, n, m0, n0, A_ro, A_co, layout);
+        test_left_apply_to_submatrix<T>(S0, n, m0, n0, A_ro, A_co, layout);
     }
 
     template <typename T>
@@ -128,7 +129,7 @@ class TestLSKGES : public ::testing::Test
             .major_axis = major_axis
         };
         SparseSkOp<T> S0(D, seed_S0);
-        test::common::test_left_apply_to_transposed<T>(S0, n, layout);
+        test_left_apply_to_transposed<T>(S0, n, layout);
     }
 };
 

--- a/test/test_sparse_skops/test_sketch_gefrs.cc
+++ b/test/test_sparse_skops/test_sketch_gefrs.cc
@@ -1,5 +1,10 @@
-#include "../common.hh"
+#include "../linop_common.hh"
 #include <gtest/gtest.h>
+
+using namespace test::linop_common;
+using RandBLAS::SparseDist;
+using RandBLAS::SparseSkOp;
+using blas::Layout;
 
 
 class TestRSKGES : public ::testing::Test
@@ -19,14 +24,14 @@ class TestRSKGES : public ::testing::Test
         int64_t d,
         RandBLAS::MajorAxis major_axis,
         int64_t vec_nnz,
-        blas::Layout layout
+        Layout layout
     ) {
-        RandBLAS::SparseDist D = {
+        SparseDist D = {
             .n_rows = m, .n_cols = d, .vec_nnz = vec_nnz, .major_axis = major_axis
         };
-        RandBLAS::SparseSkOp<T> S0(D, seed);
+        SparseSkOp<T> S0(D, seed);
         RandBLAS::fill_sparse(S0);
-        test::common::test_right_apply_submatrix_to_eye<T>(1.0, S0, m, d, 0, 0, layout, 0.0, 0);
+        test_right_apply_submatrix_to_eye<T>(1.0, S0, m, d, 0, 0, layout, 0.0, 0);
     }
 
     template <typename T>
@@ -35,17 +40,17 @@ class TestRSKGES : public ::testing::Test
         int64_t d,
         int64_t m,
         int64_t n,
-        blas::Layout layout,
+        Layout layout,
         int64_t key_index,
         int64_t nnz_index,
         int threads
     ) {
-        RandBLAS::SparseDist D = {
+        SparseDist D = {
             .n_rows=n, .n_cols=d, .vec_nnz=vec_nnzs[nnz_index], .major_axis=major_axis
         };
-        RandBLAS::SparseSkOp<T> S0(D, keys[key_index]);
+        SparseSkOp<T> S0(D, keys[key_index]);
         RandBLAS::fill_sparse(S0);
-        test::common::test_right_apply_to_random<T>(1.0, S0, m, layout, 0.0, threads);
+        test_right_apply_to_random<T>(1.0, S0, m, layout, 0.0, threads);
         
 
     }
@@ -59,16 +64,16 @@ class TestRSKGES : public ::testing::Test
         int64_t n0, // rows in S0
         int64_t S_ro, // row offset for S in S0
         int64_t S_co, // column offset for S in S0
-        blas::Layout layout
+        Layout layout
     ) {
         randblas_require(d0 >= d1);
         randblas_require(n0 >= n1);
         int64_t vec_nnz = d0 / 3; // this is actually quite dense. 
-        RandBLAS::SparseSkOp<T> S0(
+        SparseSkOp<T> S0(
             {n0, d0, vec_nnz, RandBLAS::MajorAxis::Short}, seed
         );
         RandBLAS::fill_sparse(S0);
-        test::common::test_right_apply_submatrix_to_eye<T>(1.0, S0, n1, d1, S_ro, S_co, layout, 0.0, 0);
+        test_right_apply_submatrix_to_eye<T>(1.0, S0, n1, d1, S_ro, S_co, layout, 0.0, 0);
     }
 };
 
@@ -83,25 +88,25 @@ class TestRSKGES : public ::testing::Test
 TEST_F(TestRSKGES, right_sketch_eye_saso_colmajor)
 {
     for (uint32_t seed : {0})
-        sketch_eye<double>(seed, 10, 3, RandBLAS::MajorAxis::Short, 1, blas::Layout::ColMajor);
+        sketch_eye<double>(seed, 10, 3, RandBLAS::MajorAxis::Short, 1, Layout::ColMajor);
 }
 
 TEST_F(TestRSKGES, right_sketch_eye_saso_rowmajor)
 {
     for (uint32_t seed : {0})
-        sketch_eye<double>(seed, 10, 3, RandBLAS::MajorAxis::Short, 1,  blas::Layout::RowMajor);
+        sketch_eye<double>(seed, 10, 3, RandBLAS::MajorAxis::Short, 1,  Layout::RowMajor);
 }
 
 TEST_F(TestRSKGES, right_sketch_eye_laso_colmajor)
 {
     for (uint32_t seed : {0})
-        sketch_eye<double>(seed, 10, 3, RandBLAS::MajorAxis::Long, 1,  blas::Layout::ColMajor);
+        sketch_eye<double>(seed, 10, 3, RandBLAS::MajorAxis::Long, 1,  Layout::ColMajor);
 }
 
 TEST_F(TestRSKGES, right_sketch_eye_laso_rowmajor)
 {
     for (uint32_t seed : {0})
-        sketch_eye<double>(seed, 10, 3, RandBLAS::MajorAxis::Long, 1,  blas::Layout::RowMajor);
+        sketch_eye<double>(seed, 10, 3, RandBLAS::MajorAxis::Long, 1,  Layout::RowMajor);
 }
 
 
@@ -116,25 +121,25 @@ TEST_F(TestRSKGES, right_sketch_eye_laso_rowmajor)
 TEST_F(TestRSKGES, right_lift_eye_saso_colmajor)
 {
     for (uint32_t seed : {0})
-        sketch_eye<double>(seed, 22, 51, RandBLAS::MajorAxis::Short, 5, blas::Layout::ColMajor);
+        sketch_eye<double>(seed, 22, 51, RandBLAS::MajorAxis::Short, 5, Layout::ColMajor);
 }
 
 TEST_F(TestRSKGES, right_lift_eye_saso_rowmajor)
 {
     for (uint32_t seed : {0})
-        sketch_eye<double>(seed, 22, 51, RandBLAS::MajorAxis::Short, 5, blas::Layout::RowMajor);
+        sketch_eye<double>(seed, 22, 51, RandBLAS::MajorAxis::Short, 5, Layout::RowMajor);
 }
 
 TEST_F(TestRSKGES, right_lift_eye_laso_colmajor)
 {
     for (uint32_t seed : {0})
-        sketch_eye<double>(seed, 22, 51, RandBLAS::MajorAxis::Long, 13, blas::Layout::ColMajor);
+        sketch_eye<double>(seed, 22, 51, RandBLAS::MajorAxis::Long, 13, Layout::ColMajor);
 }
 
 TEST_F(TestRSKGES, right_lift_eye_laso_rowmajor)
 {
     for (uint32_t seed : {0})
-        sketch_eye<double>(seed, 22, 51, RandBLAS::MajorAxis::Long, 13, blas::Layout::RowMajor);
+        sketch_eye<double>(seed, 22, 51, RandBLAS::MajorAxis::Long, 13, Layout::RowMajor);
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -150,10 +155,10 @@ TEST_F(TestRSKGES, sketch_saso_rowMajor_oneThread)
     for (int64_t k_idx : {0, 1, 2}) {
         for (int64_t nz_idx: {1, 2, 3, 0}) {
             apply<double>(RandBLAS::MajorAxis::Short,
-                12, 19, 201, blas::Layout::RowMajor, k_idx, nz_idx, 1
+                12, 19, 201, Layout::RowMajor, k_idx, nz_idx, 1
             );
             apply<float>(RandBLAS::MajorAxis::Short,
-                12, 19, 201, blas::Layout::RowMajor, k_idx, nz_idx, 1
+                12, 19, 201, Layout::RowMajor, k_idx, nz_idx, 1
             );
         }
     }
@@ -164,8 +169,8 @@ TEST_F(TestRSKGES, sketch_laso_rowMajor_oneThread)
 {
     for (int64_t k_idx : {0, 1, 2}) {
         for (int64_t nz_idx: {1, 2, 3, 0}) {
-            apply<double>(RandBLAS::MajorAxis::Long, 12, 19, 201, blas::Layout::RowMajor, k_idx, nz_idx, 1);
-            apply<float>(RandBLAS::MajorAxis::Long, 12, 19, 201, blas::Layout::RowMajor, k_idx, nz_idx, 1);
+            apply<double>(RandBLAS::MajorAxis::Long, 12, 19, 201, Layout::RowMajor, k_idx, nz_idx, 1);
+            apply<float>(RandBLAS::MajorAxis::Long, 12, 19, 201, Layout::RowMajor, k_idx, nz_idx, 1);
         }
     }
 }
@@ -174,8 +179,8 @@ TEST_F(TestRSKGES, sketch_saso_colMajor_oneThread)
 {
     for (int64_t k_idx : {0, 1, 2}) {
         for (int64_t nz_idx: {1, 2, 3, 0}) {
-            apply<double>(RandBLAS::MajorAxis::Short, 12, 19, 201, blas::Layout::ColMajor, k_idx, nz_idx, 1);
-            apply<float>(RandBLAS::MajorAxis::Short, 12, 19, 201, blas::Layout::ColMajor, k_idx, nz_idx, 1);
+            apply<double>(RandBLAS::MajorAxis::Short, 12, 19, 201, Layout::ColMajor, k_idx, nz_idx, 1);
+            apply<float>(RandBLAS::MajorAxis::Short, 12, 19, 201, Layout::ColMajor, k_idx, nz_idx, 1);
         }
     }
 }
@@ -184,8 +189,8 @@ TEST_F(TestRSKGES, sketch_laso_colMajor_oneThread)
 {
     for (int64_t k_idx : {0, 1, 2}) {
         for (int64_t nz_idx: {1, 2, 3, 0}) {
-            apply<double>(RandBLAS::MajorAxis::Long, 12, 19, 201, blas::Layout::ColMajor, k_idx, nz_idx, 1);
-            apply<float>(RandBLAS::MajorAxis::Long, 12, 19, 201, blas::Layout::ColMajor, k_idx, nz_idx, 1);
+            apply<double>(RandBLAS::MajorAxis::Long, 12, 19, 201, Layout::ColMajor, k_idx, nz_idx, 1);
+            apply<float>(RandBLAS::MajorAxis::Long, 12, 19, 201, Layout::ColMajor, k_idx, nz_idx, 1);
         }
     }
 }
@@ -205,10 +210,10 @@ TEST_F(TestRSKGES, lift_saso_rowMajor_oneThread)
     for (int64_t k_idx : {0, 1, 2}) {
         for (int64_t nz_idx: {1, 2, 3, 0}) {
             apply<double>(RandBLAS::MajorAxis::Short,
-                201, 19, 12, blas::Layout::RowMajor, k_idx, nz_idx, 1
+                201, 19, 12, Layout::RowMajor, k_idx, nz_idx, 1
             );
             apply<float>(RandBLAS::MajorAxis::Short,
-                201, 19, 12, blas::Layout::RowMajor, k_idx, nz_idx, 1
+                201, 19, 12, Layout::RowMajor, k_idx, nz_idx, 1
             );
         }
     }
@@ -218,8 +223,8 @@ TEST_F(TestRSKGES, lift_laso_rowMajor_oneThread)
 {
     for (int64_t k_idx : {0, 1, 2}) {
         for (int64_t nz_idx: {1, 2, 3, 0}) {
-            apply<double>(RandBLAS::MajorAxis::Long, 201, 19, 12, blas::Layout::RowMajor, k_idx, nz_idx, 1);
-            apply<float>(RandBLAS::MajorAxis::Long, 201, 19, 12, blas::Layout::RowMajor, k_idx, nz_idx, 1);
+            apply<double>(RandBLAS::MajorAxis::Long, 201, 19, 12, Layout::RowMajor, k_idx, nz_idx, 1);
+            apply<float>(RandBLAS::MajorAxis::Long, 201, 19, 12, Layout::RowMajor, k_idx, nz_idx, 1);
         }
     }
 }
@@ -228,8 +233,8 @@ TEST_F(TestRSKGES, lift_saso_colMajor_oneThread)
 {
     for (int64_t k_idx : {0, 1, 2}) {
         for (int64_t nz_idx: {1, 2, 3, 0}) {
-            apply<double>(RandBLAS::MajorAxis::Short, 201, 19, 12, blas::Layout::ColMajor, k_idx, nz_idx, 1);
-            apply<float>(RandBLAS::MajorAxis::Short, 201, 19, 12, blas::Layout::ColMajor, k_idx, nz_idx, 1);
+            apply<double>(RandBLAS::MajorAxis::Short, 201, 19, 12, Layout::ColMajor, k_idx, nz_idx, 1);
+            apply<float>(RandBLAS::MajorAxis::Short, 201, 19, 12, Layout::ColMajor, k_idx, nz_idx, 1);
         }
     }
 }
@@ -238,8 +243,8 @@ TEST_F(TestRSKGES, lift_laso_colMajor_oneThread)
 {
     for (int64_t k_idx : {0, 1, 2}) {
         for (int64_t nz_idx: {1, 2, 3, 0}) {
-            apply<double>(RandBLAS::MajorAxis::Long, 201, 19, 12, blas::Layout::ColMajor, k_idx, nz_idx, 1);
-            apply<float>(RandBLAS::MajorAxis::Long, 201, 19, 12, blas::Layout::ColMajor, k_idx, nz_idx, 1);
+            apply<double>(RandBLAS::MajorAxis::Long, 201, 19, 12, Layout::ColMajor, k_idx, nz_idx, 1);
+            apply<float>(RandBLAS::MajorAxis::Long, 201, 19, 12, Layout::ColMajor, k_idx, nz_idx, 1);
         }
     }
 }
@@ -262,7 +267,7 @@ TEST_F(TestRSKGES, subset_rows_s_colmajor1)
             8, 10, // (cols, rows) in S0.
             0,
             0,
-            blas::Layout::ColMajor
+            Layout::ColMajor
         );
 }
 
@@ -274,7 +279,7 @@ TEST_F(TestRSKGES, subset_rows_s_colmajor2)
             8, 10, // (cols, rows) in S0.
             0,
             3,  // The first column of S is in the forth column of S0
-            blas::Layout::ColMajor
+            Layout::ColMajor
         );
 }
 
@@ -286,7 +291,7 @@ TEST_F(TestRSKGES, subset_cols_s_colmajor1)
             3, 12, // (cols, rows) in S0.
             0,
             0,
-            blas::Layout::ColMajor
+            Layout::ColMajor
         );
 }
 
@@ -298,7 +303,7 @@ TEST_F(TestRSKGES, subset_cols_s_colmajor2)
             3, 12, // (cols, rows) in S0.
             1, // The first row of S is in the second row of S0
             0,
-            blas::Layout::ColMajor
+            Layout::ColMajor
         );
 }
 
@@ -320,7 +325,7 @@ TEST_F(TestRSKGES, subset_rows_s_rowmajor1)
             8, 10, // (cols, rows) in S0.
             0,
             0,
-            blas::Layout::RowMajor
+            Layout::RowMajor
         );
 }
 
@@ -332,7 +337,7 @@ TEST_F(TestRSKGES, subset_rows_s_rowmajor2)
             8, 10, // (cols, rows) in S0.
             0,
             3, // The first column of S is in the forth column of S0
-            blas::Layout::RowMajor
+            Layout::RowMajor
         );
 }
 
@@ -344,7 +349,7 @@ TEST_F(TestRSKGES, subset_cols_s_rowmajor1)
             3, 12, // (cols, rows) in S0.
             0,
             0,
-            blas::Layout::RowMajor
+            Layout::RowMajor
         );
 }
 
@@ -356,6 +361,6 @@ TEST_F(TestRSKGES, subset_cols_s_rowmajor2)
             3, 12, // (cols, rows) in S0.
             1, // The first row of S is in the second row of S0
             0,
-            blas::Layout::RowMajor
+            Layout::RowMajor
         );
 }

--- a/test/test_sparse_skops/test_sketch_gefrs.cc
+++ b/test/test_sparse_skops/test_sketch_gefrs.cc
@@ -22,10 +22,7 @@ class TestRSKGES : public ::testing::Test
         blas::Layout layout
     ) {
         RandBLAS::SparseDist D = {
-            .n_rows = m,
-            .n_cols = d,
-            .vec_nnz = vec_nnz,
-            .major_axis = major_axis
+            .n_rows = m, .n_cols = d, .vec_nnz = vec_nnz, .major_axis = major_axis
         };
         RandBLAS::SparseSkOp<T> S0(D, seed);
         RandBLAS::fill_sparse(S0);


### PR DESCRIPTION
Namespace changes
 * Move some sparse matrix datatypes into top-level ``RandBLAS::``.
 * Remove the ``RandBLAS_Testing`` namespace (currently only used in ``RandBLAS/test_util.hh``; move code in that namespace to more appropriate files in ``test/..``.

Testing
 * Write dedicated tests for sparse-times-dense matmul that don't rely on the tests for sparse sketching operators times dense matrices.
 * Made code more readable by adding ``using`` statements (like ``using blas::Layout`` and ``using RandBLAS::SparseSkOp``) so namespaces don't need to be specified as much.