### PR TITLE
Update macos-openmp GitHub actions workflow for macos-14 and higher

### DIFF
--- a/.github/workflows/openmp-macos-13.yaml
+++ b/.github/workflows/openmp-macos-13.yaml
@@ -1,0 +1,55 @@
+name: openmp-macos
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: configure OS
+        run: |
+          # os level stuff
+          set -x
+          brew install googletest llvm
+
+      - name: install BLAS++
+        run: |
+          cd ..
+          git clone https://github.com/icl-utk-edu/blaspp.git
+          mkdir blaspp-build
+          cd blaspp-build
+          cmake \
+            -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ \
+            -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=`pwd`/../blaspp-install \
+            -Dbuild_tests=OFF \
+            ../blaspp
+          make -j2 install
+
+      - name: install Random123
+        run: |
+          cd ..
+          git clone https://github.com/DEShawResearch/Random123.git
+          cd Random123/
+          mkdir -p `pwd`/../Random123-install/include
+          cp -rp include/Random123 `pwd`/../Random123-install/include/
+
+      - name: build and test RandBLAS (release)
+        run: |
+          cd ..
+          mkdir RandBLAS-build
+          cd RandBLAS-build
+          cmake \
+            -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ \
+            -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang \
+            -DCMAKE_BUILD_TYPE=Release \
+            -Dblaspp_DIR=`pwd`/../blaspp-install/lib/cmake/blaspp/ \
+            -DRandom123_DIR=`pwd`/../Random123-install/include/ \
+            -DCMAKE_INSTALL_PREFIX=`pwd`/../RandBLAS-install \
+            ../RandBLAS
+          make -j2 install
+          ctest --output-on-failure

--- a/.github/workflows/openmp-macos-13.yaml
+++ b/.github/workflows/openmp-macos-13.yaml
@@ -1,4 +1,4 @@
-name: openmp-macos
+name: openmp-macos-13
 on:
   pull_request:
   workflow_dispatch:

--- a/.github/workflows/openmp-macos.yaml
+++ b/.github/workflows/openmp-macos.yaml
@@ -14,10 +14,6 @@ jobs:
           # os level stuff
           set -x
           brew install googletest llvm
-          export CXX=/opt/homebrew/opt/llvm/bin/clang++
-          export CC=/opt/homebrew/opt/llvm/bin/clang
-          export LDFLAGS="-L/opt/homebrew/opt/llvm/lib"
-          export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
 
       - name: install BLAS++
         run: |
@@ -26,8 +22,8 @@ jobs:
           mkdir blaspp-build
           cd blaspp-build
           cmake \
-            -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ \
-            -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang \
+            -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ \
+            -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX=`pwd`/../blaspp-install \
             -Dbuild_tests=OFF \
@@ -48,8 +44,8 @@ jobs:
           mkdir RandBLAS-build
           cd RandBLAS-build
           cmake \
-            -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ \
-            -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang \
+            -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ \
+            -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang \
             -DCMAKE_BUILD_TYPE=Release \
             -Dblaspp_DIR=`pwd`/../blaspp-install/lib/cmake/blaspp/ \
             -DRandom123_DIR=`pwd`/../Random123-install/include/ \

--- a/.github/workflows/openmp-macos.yaml
+++ b/.github/workflows/openmp-macos.yaml
@@ -15,6 +15,8 @@ jobs:
           set -x
           brew install googletest llvm
           echo 'export PATH="/opt/homebrew/opt/llvm/bin:$PATH"' >> /Users/runner/.bash_profile
+          export PATH="/opt/homebrew/opt/llvm/bin:$PATH
+          # ^ For the current bash session
 
       - name: install BLAS++
         run: |

--- a/.github/workflows/openmp-macos.yaml
+++ b/.github/workflows/openmp-macos.yaml
@@ -14,9 +14,10 @@ jobs:
           # os level stuff
           set -x
           brew install googletest llvm
-          echo 'export PATH="/opt/homebrew/opt/llvm/bin:$PATH"' >> /Users/runner/.bash_profile
-          export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
-          # ^ For the current bash session
+          export CXX=/opt/homebrew/opt/llvm/bin/clang++
+          export CC=/opt/homebrew/opt/llvm/bin/clang
+          export LDFLAGS="-L/opt/homebrew/opt/llvm/lib"
+          export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
 
       - name: install BLAS++
         run: |

--- a/.github/workflows/openmp-macos.yaml
+++ b/.github/workflows/openmp-macos.yaml
@@ -1,4 +1,4 @@
-name: openmp-macos
+name: openmp-macos-latest
 on:
   pull_request:
   workflow_dispatch:

--- a/.github/workflows/openmp-macos.yaml
+++ b/.github/workflows/openmp-macos.yaml
@@ -14,6 +14,7 @@ jobs:
           # os level stuff
           set -x
           brew install googletest llvm
+          echo 'export PATH="/opt/homebrew/opt/llvm/bin:$PATH"' >> /Users/runner/.bash_profile
 
       - name: install BLAS++
         run: |

--- a/.github/workflows/openmp-macos.yaml
+++ b/.github/workflows/openmp-macos.yaml
@@ -15,7 +15,7 @@ jobs:
           set -x
           brew install googletest llvm
           echo 'export PATH="/opt/homebrew/opt/llvm/bin:$PATH"' >> /Users/runner/.bash_profile
-          export PATH="/opt/homebrew/opt/llvm/bin:$PATH
+          export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
           # ^ For the current bash session
 
       - name: install BLAS++

--- a/test/test_dense_skops/test_construction.cc
+++ b/test/test_dense_skops/test_construction.cc
@@ -461,7 +461,7 @@ class TestStateUpdate : public ::testing::Test
         RandBLAS::DenseDistName dn
     ) {
         int total = 0;
-        int buff[n_rows*n_cols];
+        int *buff = new int[n_rows*n_cols];
         auto state = RandBLAS::RNGState(key);
         auto state_copy = RandBLAS::RNGState(key);
 
@@ -486,6 +486,7 @@ class TestStateUpdate : public ::testing::Test
         }
 
         ASSERT_TRUE(total == 0);
+        delete [] buff;
     }
     
 };


### PR DESCRIPTION
The macos-openmp CI build has been failing lately. The error occurrs when trying to build blaspp:
```shell
Cloning into 'blaspp'...
-- The CXX compiler identification is unknown
CMake Error at CMakeLists.txt:[16](https://github.com/BallisticLA/RandBLAS/actions/runs/9229409689/job/25395565417?pr=89#step:4:17) (project):
  The CMAKE_CXX_COMPILER:

    /usr/local/opt/llvm/bin/clang++

  is not a full path to an existing compiler tool.

  Tell CMake where to find the compiler by setting either the environment
  variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.
```
I'm pretty sure this stems from changes to the macos-latest GitHub Actions runner. When the failing builds install the LLVM toolchain, they report using [llvm--18.1.5.arm64_sonoma.bottle.tar.gz](https://github.com/BallisticLA/RandBLAS/actions/runs/9229409689/job/25395565417?pr=89#step:3:27) and install to ``/opt/homebrew/opt/llvm/``. Compare to the successful builds, which report using [llvm--17.0.6_1.monterey.bottle.tar.gz](https://github.com/BallisticLA/RandBLAS/actions/runs/8802904796/job/24159757120#step:3:27) and install to ``/usr/local/opt/llvm/``.

~~I'm not sure if I have a fix at time of opening this PR. I'm only opening it now because I need to test potential fixes and actually run the actions.~~

My suspicion was right. The CMake configuration lines for blaspp and RandBLAS explicitly set `` /usr/local/opt/llvm/bin/clang++`` and `` /usr/local/opt/llvm/bin/clang`` for C++ and C compilers. These paths needed to be updated to reflect the new location of these compilers in the latest macos runner.

### Incidental changes
The macos-latest build showed compiler warnings about allocating dynamically-sized arrays on the stack. I've changed them to allocate on the heap (with ``T* val = new T[size]``, as opposed to ``T val[size]``).