### PR TITLE
Infrastructure for Kolmogorov-Smirnov tests, (tested!) methods for sampling with replacement, and changes to include guards

### DIFF
--- a/RandBLAS/base.hh
+++ b/RandBLAS/base.hh
@@ -27,8 +27,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //
 
-#ifndef randblas_base_hh
-#define randblas_base_hh
+#pragma once
 
 /// @file
 
@@ -212,5 +211,3 @@ std::ostream &operator<<(
 }
 
 } // end namespace RandBLAS::base
-
-#endif

--- a/RandBLAS/base.hh
+++ b/RandBLAS/base.hh
@@ -53,9 +53,18 @@
 /// code common across the project
 namespace RandBLAS {
 
+/**
+ * Stores stride information for a matrix represented as a buffer.
+ * The intended semantics for a buffer "A" and the conceptualized
+ * matrix "mat(A)" are 
+ * 
+ *  mat(A)[i, j] == A[i * inter_row_stride + j * inter_col_stride].
+ * 
+ * for all (i, j) within the bounds of mat(A).
+ */
 struct stride_64t {
-    int64_t inter_row_stride;
-    int64_t inter_col_stride;
+    int64_t inter_row_stride; // step down a column
+    int64_t inter_col_stride; // step along a row
 };
 
 inline stride_64t layout_to_strides(blas::Layout layout, int64_t ldim) {

--- a/RandBLAS/config.h.in
+++ b/RandBLAS/config.h.in
@@ -1,5 +1,4 @@
-#ifndef RandBLAS_config_h
-#define RandBLAS_config_h
+#pragma once
 
 #define RandBLAS_FULL_VERSION "@RandBLAS_FULL_VERSION@"
 #define RandBLAS_VERSION_MAJOR @RandBLAS_VERSION_MAJOR@
@@ -53,5 +52,3 @@
 //
 //   if you are linking to OpenMP.
 //
-
-#endif

--- a/RandBLAS/dense_skops.hh
+++ b/RandBLAS/dense_skops.hh
@@ -26,9 +26,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-
-#ifndef randblas_dense_hh
-#define randblas_dense_hh
+#pragma once
 
 #include "RandBLAS/base.hh"
 #include "RandBLAS/exceptions.hh"
@@ -640,5 +638,3 @@ RNGState<RNG> fill_dense(
 }
 
 }  // end namespace RandBLAS
-
-#endif

--- a/RandBLAS/exceptions.hh
+++ b/RandBLAS/exceptions.hh
@@ -29,9 +29,6 @@
 
 #pragma once
 
-#ifndef RandBLAS_EXCEPTIONS_HH
-#define RandBLAS_EXCEPTIONS_HH
-
 #include <exception>
 #include <cstdarg>
 #include <string>
@@ -164,5 +161,3 @@ inline void abort_if( bool cond, const char* func,  const char* format, ... ) {
 #endif
 
 } // namespace RandBLAS::exceptions
-
-#endif

--- a/RandBLAS/random_gen.hh
+++ b/RandBLAS/random_gen.hh
@@ -27,8 +27,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //
 
-#ifndef random_gen_hh
-#define random_gen_hh
+#pragma once
 
 /// @file
 
@@ -178,4 +177,3 @@ struct uneg11
 
 } // end of namespace r123ext
 
-#endif

--- a/RandBLAS/skge.hh
+++ b/RandBLAS/skge.hh
@@ -26,9 +26,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-
-#ifndef randblas_skge_hh
-#define randblas_skge_hh
+#pragma once
 
 #include "RandBLAS/base.hh"
 #include "RandBLAS/exceptions.hh"
@@ -1231,6 +1229,3 @@ inline void sketch_general(
 };
 
 }  // end namespace RandBLAS
-
-
-#endif

--- a/RandBLAS/sksy.hh
+++ b/RandBLAS/sksy.hh
@@ -27,8 +27,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //
 
-#ifndef randblas_sksy_hh
-#define randblas_sksy_hh
+#pragma once
 
 #include "RandBLAS/util.hh"
 #include "RandBLAS/base.hh"
@@ -538,4 +537,3 @@ inline void sketch_symmetric(
 }
 
 } // end namespace RandBLAS
-#endif

--- a/RandBLAS/skve.hh
+++ b/RandBLAS/skve.hh
@@ -26,9 +26,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-
-#ifndef randblas_skve_hh
-#define randblas_skve_hh
+#pragma once
 
 #include "RandBLAS/base.hh"
 #include "RandBLAS/exceptions.hh"
@@ -260,4 +258,3 @@ inline void sketch_vector(
 }
 
 }  // end namespace RandBLAS
-#endif

--- a/RandBLAS/sparse_data/base.hh
+++ b/RandBLAS/sparse_data/base.hh
@@ -26,9 +26,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-
-#ifndef randblas_sparse_data_hh
-#define randblas_sparse_data_hh
+#pragma once
 
 #include "RandBLAS/config.h"
 #include "RandBLAS/base.hh"
@@ -193,7 +191,3 @@ namespace RandBLAS {
     using RandBLAS::sparse_data::IndexBase;
     using RandBLAS::sparse_data::SparseMatrix;
 }
-
-
-
-#endif

--- a/RandBLAS/sparse_data/conversions.hh
+++ b/RandBLAS/sparse_data/conversions.hh
@@ -26,9 +26,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
+#pragma once
 
-#ifndef randblas_sparse_data_conversions
-#define randblas_sparse_data_conversions
 #include "RandBLAS/base.hh"
 #include "RandBLAS/exceptions.hh"
 #include "RandBLAS/sparse_data/base.hh"
@@ -209,5 +208,3 @@ void reindex_inplace(COOMatrix<T> &A, IndexBase desired) {
 }
 
 } // end namespace RandBLAS::sparse_data::conversions
-
-#endif

--- a/RandBLAS/sparse_data/coo_matrix.hh
+++ b/RandBLAS/sparse_data/coo_matrix.hh
@@ -27,8 +27,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //
 
-#ifndef randblas_sparse_data_coo
-#define randblas_sparse_data_coo
+#pragma once
+
 #include "RandBLAS/base.hh"
 #include "RandBLAS/exceptions.hh"
 #include "RandBLAS/sparse_data/base.hh"
@@ -409,4 +409,3 @@ void coo_to_dense(const COOMatrix<T> &spmat, Layout layout, T *mat) {
 
 } // end namespace RandBLAS::sparse_data::coo
 
-#endif

--- a/RandBLAS/sparse_data/coo_spmm_impl.hh
+++ b/RandBLAS/sparse_data/coo_spmm_impl.hh
@@ -27,8 +27,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //
 
-#ifndef randblas_sparse_data_coo_multiply
-#define randblas_sparse_data_coo_multiply
+#pragma once
+
 #include "RandBLAS/base.hh"
 #include "RandBLAS/exceptions.hh"
 #include "RandBLAS/sparse_data/base.hh"
@@ -163,5 +163,3 @@ static void apply_coo_left_jki_p11(
 
 
 } // end namespace
-
-#endif

--- a/RandBLAS/sparse_data/csc_matrix.hh
+++ b/RandBLAS/sparse_data/csc_matrix.hh
@@ -27,8 +27,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //
 
-#ifndef randblas_sparse_data_csc
-#define randblas_sparse_data_csc
+#pragma once
+
 #include "RandBLAS/base.hh"
 #include "RandBLAS/exceptions.hh"
 #include "RandBLAS/sparse_data/base.hh"
@@ -246,7 +246,4 @@ void dense_to_csc(Layout layout, T* mat, T abs_tol, CSCMatrix<T> &spmat) {
     return;
 }
 
-
-}
-
-#endif
+} // end namespace RandBLAS::sparse_data::csc

--- a/RandBLAS/sparse_data/csc_spmm_impl.hh
+++ b/RandBLAS/sparse_data/csc_spmm_impl.hh
@@ -27,8 +27,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //
 
-#ifndef randblas_sparse_data_csc_multiply
-#define randblas_sparse_data_csc_multiply
+#pragma once
 #include "RandBLAS/base.hh"
 #include "RandBLAS/exceptions.hh"
 #include "RandBLAS/sparse_data/base.hh"
@@ -213,5 +212,4 @@ static void apply_csc_left_kib_rowmajor_1p1(
     return;
 }
 
-}
-#endif
+} // end namespace RandBLAS::sparse_data::csc

--- a/RandBLAS/sparse_data/csr_matrix.hh
+++ b/RandBLAS/sparse_data/csr_matrix.hh
@@ -27,8 +27,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //
 
-#ifndef randblas_sparse_data_csr
-#define randblas_sparse_data_csr
+#pragma once
+
 #include "RandBLAS/base.hh"
 #include "RandBLAS/exceptions.hh"
 #include "RandBLAS/sparse_data/base.hh"
@@ -262,4 +262,3 @@ void dense_to_csr(Layout layout, T* mat, T abs_tol, CSRMatrix<T> &spmat) {
 
 
 } // end namespace RandBLAS::sparse_data::csr
-#endif

--- a/RandBLAS/sparse_data/csr_spmm_impl.hh
+++ b/RandBLAS/sparse_data/csr_spmm_impl.hh
@@ -27,8 +27,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //
 
-#ifndef randblas_sparse_data_csr_multiply
-#define randblas_sparse_data_csr_multiply
+#pragma once
+
 #include "RandBLAS/base.hh"
 #include "RandBLAS/exceptions.hh"
 #include "RandBLAS/sparse_data/base.hh"
@@ -156,5 +156,3 @@ static void apply_csr_left_ikb_rowmajor(
 }
 
 } // end namespace RandBLAS::sparse_data::csr
-
-#endif

--- a/RandBLAS/sparse_data/sksp.hh
+++ b/RandBLAS/sparse_data/sksp.hh
@@ -27,8 +27,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //
 
-#ifndef randblas_sksp_hh
-#define randblas_sksp_hh
+#pragma once
 
 #include "RandBLAS/base.hh"
 #include "RandBLAS/dense_skops.hh"
@@ -625,6 +624,3 @@ inline void sketch_sparse(
 }
 
 }  // end namespace RandBLAS
-
-
-#endif

--- a/RandBLAS/sparse_data/spmm_dispatch.hh
+++ b/RandBLAS/sparse_data/spmm_dispatch.hh
@@ -27,8 +27,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //
 
-#ifndef randblas_sparse_data_spmm_dispatch
-#define randblas_sparse_data_spmm_dispatch
+#pragma once
+
 #include "RandBLAS/base.hh"
 #include "RandBLAS/exceptions.hh"
 #include "RandBLAS/sparse_data/base.hh"
@@ -384,5 +384,3 @@ inline void spmm(blas::Layout layout, blas::Op opA, blas::Op opB, int64_t m, int
 }
 
 }
-
-#endif

--- a/RandBLAS/sparse_skops.hh
+++ b/RandBLAS/sparse_skops.hh
@@ -26,9 +26,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-
-#ifndef randblas_sparse_skops_hh
-#define randblas_sparse_skops_hh
+#pragma once
 
 #include "RandBLAS/config.h"
 #include "RandBLAS/base.hh"
@@ -483,5 +481,3 @@ static auto transpose(SKOP const &S) {
 }
 
 } // end namespace RandBLAS::sparse
-
-#endif

--- a/RandBLAS/util.hh
+++ b/RandBLAS/util.hh
@@ -58,26 +58,6 @@ void safe_scal(int64_t n, T a, T* x, int64_t inc_x) {
 }
 
 template <typename T>
-void genmat(
-	int64_t n_rows,
-	int64_t n_cols,
-	T* mat,
-	uint64_t seed)
-{
-	typedef r123::Philox2x64 CBRNG;
-	CBRNG::key_type key = {{seed}};
-	CBRNG::ctr_type ctr = {{0,0}};
-	CBRNG g;
-	uint64_t prod = n_rows * n_cols;
-	for (uint64_t i = 0; i < prod; ++i)
-	{
-		ctr[0] = i;
-		CBRNG::ctr_type rand = g(ctr, key);
-		mat[i] = r123::uneg11<T>(rand.v[0]);
-	}
-}
-
-template <typename T>
 void print_colmaj(int64_t n_rows, int64_t n_cols, T *a, char label[])
 {
 	int64_t i, j;

--- a/RandBLAS/util.hh
+++ b/RandBLAS/util.hh
@@ -288,8 +288,6 @@ RNGState<RNG> sample_indices_iid(
         }
         auto random_unif01 = uneg11_to_uneg01<TF>(rv_array[rv_index]);
         int64_t sample_index = std::lower_bound(cdf, cdf + n, random_unif01) - cdf;
-        // ^ uses binary search to set sample_index to the smallest value for which
-        //   random_unif01 < cdf[sample_index].
         samples[i] = sample_index;
         rv_index += 1;
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,12 @@ set(tmp FALSE)
 if (GTest_FOUND)
     set(tmp TRUE)
 
+    #####################################################################
+    #
+    #   Tests with dense data and wrappers
+    #
+    #####################################################################
+
     add_executable(RandBLAS_tests
         comparison.hh
         test_datastructures/test_denseskop.cc
@@ -19,12 +25,14 @@ if (GTest_FOUND)
         test_matmul_wrappers/test_sketch_vector.cc
         test_matmul_wrappers/test_sketch_symmetric.cc
     )
-    target_link_libraries(RandBLAS_tests
-        RandBLAS
-        GTest::GTest
-        GTest::Main
-    )
+    target_link_libraries(RandBLAS_tests RandBLAS GTest::GTest GTest::Main)
     gtest_discover_tests(RandBLAS_tests)
+
+    #####################################################################
+    #
+    #   Tests with sparse data
+    #
+    #####################################################################
 
     add_executable(SparseRandBLAS_tests
         comparison.hh
@@ -40,12 +48,21 @@ if (GTest_FOUND)
         test_matmul_cores/test_spmm/test_spmm_csr.cc
         test_matmul_cores/test_spmm/test_spmm_coo.cc
     )
-    target_link_libraries(SparseRandBLAS_tests
-        RandBLAS
-        GTest::GTest
-        GTest::Main
-    )
+    target_link_libraries(SparseRandBLAS_tests RandBLAS GTest::GTest GTest::Main)
     gtest_discover_tests(SparseRandBLAS_tests)
+
+    #####################################################################
+    #
+    #   Statistical tests
+    #
+    #####################################################################
+
+    add_executable(RandBLAS_stats
+        test_basic_rng/rng_common.hh
+        test_basic_rng/test_sample_indices.cc
+    )
+    target_link_libraries(RandBLAS_stats RandBLAS GTest::GTest GTest::Main)
+    gtest_discover_tests(RandBLAS_stats)
 
 endif()
 message(STATUS "Checking for regression tests ... ${tmp}")

--- a/test/comparison.hh
+++ b/test/comparison.hh
@@ -27,8 +27,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //
 
-#ifndef randblas_test_comparisons_hh
-#define randblas_test_comparisons_hh
+#pragma once
 
 #include "RandBLAS.hh"
 #include <gtest/gtest.h>
@@ -239,5 +238,3 @@ void matrices_approx_equal(
 }
 
 } // end namespace test::comparison
-
-#endif

--- a/test/test_basic_rng/rng_common.hh
+++ b/test/test_basic_rng/rng_common.hh
@@ -2,6 +2,7 @@
 
 #include "RandBLAS.hh"
 #include <vector>
+#include <array>
 
 namespace RandBLAS_StatTests {
 
@@ -31,7 +32,7 @@ const std::vector<double> significance_levels {
     0.05, 1e-2, 1e-3, 1e-4, 1e-5, 1e-6
 };
 
-const std::vector<const std::vector<double>> critical_values {{
+const std::array<const std::array<double, 22>, 6> critical_values {{{
     // significance of 0.05
     4.54266591e-01, 3.27333470e-01, 2.34240860e-01, 1.66933746e-01,
     1.18658276e-01, 8.42018587e-02, 5.96844982e-02, 4.22742678e-02,
@@ -79,7 +80,7 @@ const std::vector<const std::vector<double>> critical_values {{
     1.48735960e-02, 1.05183852e-02, 7.43818754e-03, 5.25987011e-03,
     3.71942641e-03, 2.63009921e-03, 1.85979452e-03, 1.31508999e-03,
     9.29917360e-04, 6.57555013e-04
-}};
+}}};
 
 /***
  * Returns the index in significance_levels for the "least significant" value

--- a/test/test_basic_rng/rng_common.hh
+++ b/test/test_basic_rng/rng_common.hh
@@ -127,6 +127,16 @@ std::tuple<double,int,double> critical_value_rep(int n, double sig) {
     return {cv, override_sample, override_sig};
 }
 
+template <typename TI>
+double critical_value_rep_mutator(TI &n, double &sig) {
+    int i = significance_rep(sig);
+    sig = significance_levels[i];
+    int j = sample_size_rep(n);
+    n = (TI) sample_sizes[j];
+    double cv = critical_values[i][j];
+    return cv;
+}
+
 }
 
 //

--- a/test/test_basic_rng/rng_common.hh
+++ b/test/test_basic_rng/rng_common.hh
@@ -1,0 +1,186 @@
+#pragma once
+
+#include "RandBLAS.hh"
+#include <vector>
+
+namespace RandBLAS_StatTests {
+
+//
+// MARK: constants 
+// ^ and functions to perform lookups for the constants we store.
+
+namespace KolmogorovSmirnovConstants {
+
+
+/*** From scipy.stats:  critical_value = kstwo.ppf(1-significance, sample_size) */
+
+const int SMALLEST_SAMPLE = 8;
+const int LARGEST_SAMPLE = 16777216;
+
+const std::vector<int> sample_sizes {
+          8,       16,       32,       64,      128,      256,
+        512,     1024,     2048,     4096,     8192,    16384,
+      32768,    65536,   131072,   262144,   524288,  1048576,
+    2097152,  4194304,  8388608, 16777216
+};
+
+const double WEAKEST_SIGNIFICANCE = 0.05;
+const double STRONGEST_SIGNIFICANCE = 1e-6;
+
+const std::vector<double> significance_levels {
+    0.05, 1e-2, 1e-3, 1e-4, 1e-5, 1e-6
+};
+
+const std::vector<const std::vector<double>> critical_values {{
+    // significance of 0.05
+    4.54266591e-01, 3.27333470e-01, 2.34240860e-01, 1.66933746e-01,
+    1.18658276e-01, 8.42018587e-02, 5.96844982e-02, 4.22742678e-02,
+    2.99273847e-02, 2.11791555e-02, 1.49845091e-02, 1.05999173e-02,
+    7.49739992e-03, 5.30252270e-03, 3.74997893e-03, 2.65189975e-03,
+    1.87530828e-03, 1.32610915e-03, 9.37733728e-04, 6.63094351e-04,
+    4.68886747e-04, 3.31557115e-04
+}, { 
+    // significance of 1e-2
+    5.41792524e-01, 3.92007307e-01, 2.80935776e-01, 2.00288899e-01,
+    1.42362543e-01, 1.01005285e-01, 7.15810977e-02, 5.06916722e-02,
+    3.58812433e-02, 2.53898259e-02, 1.79621350e-02, 1.27054989e-02,
+    8.98630003e-03, 6.35534434e-03, 4.49443988e-03, 3.17831443e-03,
+    2.24754012e-03, 1.58931697e-03, 1.12384982e-03, 7.94698321e-04,
+    5.61944814e-04, 3.97359107e-04
+}, {
+    // significance of 1e-3
+    6.40978605e-01, 4.67504918e-01, 3.36105510e-01, 2.39914323e-01,
+    1.70596759e-01, 1.21045341e-01, 8.57783224e-02, 6.07400729e-02,
+    4.29898739e-02, 3.04175670e-02, 2.15177021e-02, 1.52198122e-02,
+    1.07642402e-02, 7.61255632e-03, 5.38342952e-03, 3.80692734e-03,
+    2.69203739e-03, 1.90362429e-03, 1.34609876e-03, 9.51852090e-04,
+    6.73069322e-04, 4.75936005e-04
+}, {
+    // significance of 1e-4
+    7.20107998e-01, 5.30358433e-01, 3.82763541e-01, 2.73655631e-01,
+    1.94715231e-01, 1.38189709e-01, 9.79338402e-02, 6.93467436e-02,
+    4.90797287e-02, 3.47251628e-02, 2.45641333e-02, 1.73741413e-02,
+    1.22876435e-02, 8.68978729e-03, 6.14515467e-03, 4.34555112e-03,
+    3.07290290e-03, 2.17293722e-03, 1.53653188e-03, 1.08650868e-03,
+    7.68285928e-04, 5.43264318e-04
+}, {
+    // significance of 1e-5
+    7.84314235e-01, 5.84534035e-01, 4.23688590e-01, 3.03463697e-01,
+    2.16091906e-01, 1.53407046e-01, 1.08732306e-01, 7.69956230e-02,
+    5.44929246e-02, 3.85544959e-02, 2.72724540e-02, 1.92894157e-02,
+    1.36420186e-02, 9.64750036e-03, 6.82236902e-03, 4.82441714e-03,
+    3.41151342e-03, 2.41237141e-03, 1.70583756e-03, 1.20622593e-03,
+    8.52938821e-04, 6.03122960e-0
+}, {
+    // significance of 1e-6
+    8.36962528e-01, 6.32173765e-01, 4.60387149e-01, 3.30395198e-01,
+    2.35470356e-01, 1.67220735e-01, 1.18543880e-01, 8.39483725e-02,
+    5.94144379e-02, 4.20363448e-02, 2.97351313e-02, 2.10310168e-02,
+    1.48735960e-02, 1.05183852e-02, 7.43818754e-03, 5.25987011e-03,
+    3.71942641e-03, 2.63009921e-03, 1.85979452e-03, 1.31508999e-03,
+    9.29917360e-04, 6.57555013e-04
+}};
+
+/***
+ * Returns the index in significance_levels for the "least significant" value
+ * that is "more significant" than "sig".
+ * 
+ * The correctness of this function depends on significance_levels being sorted
+ * in decreasing order (which corresponds to weakest to strongest significances).
+ */
+int significance_rep(double sig) {
+    randblas_require(STRONGEST_SIGNIFICANCE <= sig && sig <= WEAKEST_SIGNIFICANCE);
+    int num_siglevels = (int) significance_levels.size();
+    for (int i = 0; i < num_siglevels; ++i) {
+        if (significance_levels[i] <= sig)
+            return i;
+    }
+    // This code shouldn't be reachable!
+    randblas_require(false);
+    return -1;
+}
+
+/***
+ * Returns the index in sample_sizes for the smallest sample size that's >= n.
+ * 
+ * The correctness of this function depends on sample_sizes being sorted in
+ * increasing order.
+ */
+int sample_size_rep(int n) {
+    randblas_require(SMALLEST_SAMPLE <= n && n <= LARGEST_SAMPLE);
+    int num_sample_sizes = (int) sample_sizes.size();
+    for (int i = 0; i < num_sample_sizes; ++i) {
+        if (sample_sizes[i] <= n)
+            return i;
+    }
+    // This code shouldn't be reachable!
+    randblas_require(false);
+    return -1;
+}
+
+std::tuple<double,int,double> critical_value_rep(int n, double sig) {
+    int i = significance_rep(sig);
+    auto override_sig = significance_levels[i];
+    int j = sample_size_rep(n);
+    auto override_sample = sample_sizes[j];
+    auto cv = critical_values[i][j];
+    return {cv, override_sample, override_sig};
+}
+
+}
+
+//
+// MARK: combinatorics
+//
+
+double log_binomial_coefficient(int64_t n, int64_t k) {
+    double result = 0.0;
+    for (int64_t i = 1; i <= k; ++i) {
+        result += std::log(static_cast<double>(n - i + 1)) - std::log(static_cast<double>(i));
+    }
+    return result;
+}
+
+
+//
+// MARK: hypergeometric 
+//
+
+/***
+ * Compute the probability mass function of the hypergeometric distribution with parameters N, K, D.
+ * Concretely ... 
+ * 
+ *      Suppose we draw D items without replacement from a set of size N that has K distinguished elements.
+ *      This function returns the probability that the sample of D items will contain observed_k elements
+ *      from the distinguished set.
+ */
+double hypergeometric_pmf(int64_t N, int64_t K, int64_t D, int64_t observed_k) {
+    randblas_require(0 <= K && K <= N);
+    randblas_require(0 <= D && D <= N);
+    randblas_require(0 <= observed_k && observed_k <= K);
+    double lognum = log_binomial_coefficient(N - K, D - observed_k) + log_binomial_coefficient(K, observed_k);
+    double logden = log_binomial_coefficient(N, D);
+    double exparg = lognum - logden;
+    double out = std::exp(exparg);
+    return out;
+}
+
+double hypergeometric_mean(int64_t N, int64_t K, int64_t D) {
+    double dN = (double) N;
+    double dK = (double) K;
+    double dD = (double) D;
+    return dD * dK / dN;
+}
+
+double hypergeometric_variance(int64_t N, int64_t K, int64_t D) {
+    double dN = (double) N;
+    double dK = (double) K;
+    double dD = (double) D;
+
+    auto t1 = dK / dN;
+    auto t2 = (dN - dK) / dN;
+    auto t3 = (dN - dD) / (dN - 1.0);
+    return dD * t1 * t2 * t3;
+}
+
+} // end namespace RandBLAS_StatTests

--- a/test/test_basic_rng/test_sample_indices.cc
+++ b/test/test_basic_rng/test_sample_indices.cc
@@ -70,7 +70,7 @@ class TestSampleIndices : public ::testing::Test
         std::vector<float> sample_cdf(N, 0.0);
         for (int64_t s : samples)
             sample_cdf[s] += 1;
-        RandBLAS::util::weights_to_cdf(sample_cdf.data(), N);
+        RandBLAS::util::weights_to_cdf(N, sample_cdf.data());
 
         for (int i = 0; i < num_samples; ++i) {
             auto diff = (double) std::abs(sample_cdf[i] - true_cdf[i]);
@@ -84,7 +84,7 @@ class TestSampleIndices : public ::testing::Test
         auto critical_value = critical_value_rep_mutator(num_samples, significance);
 
         std::vector<float> true_cdf(N, 1.0);
-        RandBLAS::util::weights_to_cdf(true_cdf.data(), N);
+        RandBLAS::util::weights_to_cdf(N, true_cdf.data());
 
         RNGState state(seed);
         std::vector<int64_t> samples(num_samples, -1);
@@ -102,11 +102,11 @@ class TestSampleIndices : public ::testing::Test
         std::vector<float> true_cdf{};
         for (int i = 0; i < N; ++i)
             true_cdf.push_back(1.0/((float)i + 1.0));
-        RandBLAS::util::weights_to_cdf(true_cdf.data(), N);
+        RandBLAS::util::weights_to_cdf(N, true_cdf.data());
 
         RNGState state(seed);
         std::vector<int64_t> samples(num_samples, -1);
-        RandBLAS::util::sample_indices_iid(true_cdf.data(), N, samples.data(), num_samples, state);
+        RandBLAS::util::sample_indices_iid(N, true_cdf.data(), num_samples, samples.data(), state);
 
         index_set_kolmogorov_smirnov_tester(samples, true_cdf, critical_value);
         return;

--- a/test/test_basic_rng/test_sample_indices.cc
+++ b/test/test_basic_rng/test_sample_indices.cc
@@ -1,0 +1,163 @@
+// Copyright, 2024. See LICENSE for copyright holder information.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// (1) Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// (2) Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// (3) Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include "RandBLAS/config.h"
+#include "RandBLAS/base.hh"
+#include "RandBLAS/util.hh"
+using RandBLAS::RNGState;
+#include "rng_common.hh"
+
+#include <algorithm>
+#include <iostream>
+#include <iterator>
+#include <random>
+#include <set>
+#include <vector>
+#include <gtest/gtest.h>
+
+
+class TestSampleIndices : public ::testing::Test
+{
+    protected:
+    
+    virtual void SetUp(){};
+
+    virtual void TearDown(){};
+
+    static void test_iid_uniform_smoke(int64_t N, int64_t k, uint32_t seed) { 
+        RNGState state(seed);
+        std::vector<int64_t> samples(k, -1);
+        RandBLAS::util::sample_indices_iid_uniform(N, samples.data(), k, state);
+        int64_t* data = samples.data();
+        for (int64_t i = 0; i < k; ++i) {
+            ASSERT_LT(data[i], N);
+            ASSERT_GE(data[i], 0);
+        }
+        return;
+    }
+
+    static void test_iid_uniform_kolmogorov_smirnov(int64_t N, double significance, int64_t num_samples, uint32_t seed) {
+        randblas_require(N <= (int64_t) 1e6);
+
+        using RandBLAS_StatTests::KolmogorovSmirnovConstants::critical_value_rep;
+        auto [critical_value, override_ns, override_sig] = critical_value_rep(num_samples, significance);
+        significance = (double) override_sig;
+        num_samples = (int64_t) override_ns;
+
+        RNGState state(seed);
+        std::vector<int64_t> samples(num_samples, -1);
+        RandBLAS::util::sample_indices_iid_uniform(N, samples.data(), num_samples, state);
+        std::vector<float> sample_cdf(N, 0.0);
+        for (int64_t s : samples)
+            sample_cdf[s] += 1;
+        RandBLAS::util::weights_to_cdf(sample_cdf.data(), N);
+
+        std::vector<float> true_cdf(N, 1.0);
+        RandBLAS::util::weights_to_cdf(true_cdf.data(), N);
+
+
+        for (int i = 0; i < num_samples; ++i) {
+            float diff = std::abs(sample_cdf[i] - true_cdf[i]);
+            ASSERT_LT(diff, critical_value);
+        }
+        return;
+    }
+    
+};
+
+
+TEST_F(TestSampleIndices, smoke_3_x_10) {
+    for (uint32_t i = 0; i < 10; ++i)
+        test_iid_uniform_smoke(3, 10, i);
+}
+
+TEST_F(TestSampleIndices, smoke_10_x_3) {
+    for (uint32_t i = 0; i < 10; ++i)
+        test_iid_uniform_smoke(10, 3, i);
+}
+
+TEST_F(TestSampleIndices, smoke_med) {
+    for (uint32_t i = 0; i < 10; ++i)
+        test_iid_uniform_smoke((int) 1e6 , 6000, i);
+}
+
+TEST_F(TestSampleIndices, smoke_big) {
+    int64_t huge_N = std::numeric_limits<int64_t>::max() / 2;
+    for (uint32_t i = 0; i < 10; ++i)
+        test_iid_uniform_smoke(huge_N, 1000, i);
+}
+
+TEST_F(TestSampleIndices, iid_uniform_ks_generous) {
+    double s = 1e-6;
+    test_iid_uniform_kolmogorov_smirnov(100,     s, 100000, 0);
+    test_iid_uniform_kolmogorov_smirnov(10000,   s, 1000,   0);
+    test_iid_uniform_kolmogorov_smirnov(1000000, s, 1000,   0);
+}
+
+TEST_F(TestSampleIndices, iid_uniform_ks_moderate) {
+    float s = 1e-4;
+    test_iid_uniform_kolmogorov_smirnov(100,     s, 100000, 0);
+    test_iid_uniform_kolmogorov_smirnov(10000,   s, 1000,   0);
+    test_iid_uniform_kolmogorov_smirnov(1000000, s, 1000,   0);
+}
+
+TEST_F(TestSampleIndices, iid_uniform_ks_skeptical) {
+    float s = 1e-2;
+    test_iid_uniform_kolmogorov_smirnov(100,     s, 100000, 0);
+    test_iid_uniform_kolmogorov_smirnov(10000,   s, 1000,   0);
+    test_iid_uniform_kolmogorov_smirnov(1000000, s, 1000,   0);
+}
+
+
+
+// class TestSampleIndices : public ::testing::Test
+// {
+//     protected:
+    
+//     virtual void SetUp(){};
+
+//     virtual void TearDown(){};
+
+//     template<typename T>
+//     static void test_basic(
+        
+//     ) { 
+//         return;
+//     }
+    
+// };
+
+
+// TEST_F(TestSampleIndices, smoke)
+// {
+//     // do something
+// }
+
+
+

--- a/test/test_datastructures/test_denseskop.cc
+++ b/test/test_datastructures/test_denseskop.cc
@@ -304,9 +304,7 @@ TEST_F(TestSubmatGeneration, diag)
 
 #if defined(RandBLAS_HAS_OpenMP)
 template <typename T, typename RNG, typename OP>
-void DenseThreadTest() {
-    int64_t m = 32;
-    int64_t n = 8;
+void DenseThreadTest(int64_t m, int64_t n) {
     int64_t d = m*n;
 
     std::vector<T> base(d);
@@ -319,10 +317,9 @@ void DenseThreadTest() {
     std::cerr << "with 1 thread: " << base << std::endl;
 
     // run with different numbers of threads, and check that the result is the same
-    int n_hyper = std::thread::hardware_concurrency();
-    int n_threads = std::max(n_hyper / 2, 3);
-
+    int n_threads = std::thread::hardware_concurrency();
     for (int i = 2; i <= n_threads; ++i) {
+        std::fill(test.begin(), test.end(), (T) 0.0);
         omp_set_num_threads(i);
         RandBLAS::dense::fill_dense_submat_impl<T,RNG,OP>(n, test.data(), m, n, 0, state);
         std::cerr << "with " << i << " threads: " << test << std::endl;
@@ -333,11 +330,19 @@ void DenseThreadTest() {
 }
 
 TEST(TestDenseThreading, UniformPhilox) {
-    DenseThreadTest<float,r123::Philox4x32,r123ext::uneg11>();
+    for (int i = 0; i < 10; ++i) {
+        DenseThreadTest<float,r123::Philox4x32,r123ext::uneg11>(32, 8);
+        DenseThreadTest<float,r123::Philox4x32,r123ext::uneg11>(1, 5);
+        DenseThreadTest<float,r123::Philox4x32,r123ext::uneg11>(5, 1);
+    }
 }
 
 TEST(TestDenseThreading, GaussianPhilox) {
-    DenseThreadTest<float,r123::Philox4x32,r123ext::boxmul>();
+    for (int i = 0; i < 10; ++i) {
+        DenseThreadTest<float,r123::Philox4x32,r123ext::boxmul>(32, 8);
+        DenseThreadTest<float,r123::Philox4x32,r123ext::boxmul>(1, 5);
+        DenseThreadTest<float,r123::Philox4x32,r123ext::boxmul>(5, 1);
+    }
 }
 #endif
 

--- a/test/test_datastructures/test_spmats/common.hh
+++ b/test/test_datastructures/test_spmats/common.hh
@@ -27,8 +27,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //
 
-#ifndef randblas_test_sparse_data_common_hh
-#define randblas_test_sparse_data_common_hh
+#pragma once
+
 #include "RandBLAS/config.h"
 #include "RandBLAS/base.hh"
 #include "RandBLAS/dense_skops.hh"
@@ -129,7 +129,4 @@ void coo_from_diag(
     return;
 }
 
-
 }
-
-#endif

--- a/test/test_matmul_cores/linop_common.hh
+++ b/test/test_matmul_cores/linop_common.hh
@@ -27,8 +27,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //
 
-#ifndef randblas_test_linop_common_hh
-#define randblas_test_linop_common_hh
+#pragma once
+
 #include "RandBLAS/config.h"
 #include "RandBLAS/base.hh"
 #include "RandBLAS/dense_skops.hh"
@@ -713,5 +713,3 @@ void test_right_apply_to_transposed(
 }
 
 } // end namespace test::linop_common
-
-#endif

--- a/test/test_matmul_cores/test_spmm/spmm_test_helpers.hh
+++ b/test/test_matmul_cores/test_spmm/spmm_test_helpers.hh
@@ -27,6 +27,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //
 
+#pragma once
+
 #include "test/test_datastructures/test_spmats/common.hh"
 #include "test/test_matmul_cores/linop_common.hh"
 #include <gtest/gtest.h>


### PR DESCRIPTION
As usual, the scope of this PR exceeded my original plans.

### Incidental, but notable changes

I removed the include-guard pattern
```c++
#ifndef <file identifier>_hh
#define <file identifier>_hh
// ... code ...
#endif
```
and replaced it with ``#pragma once`` everywhere.

### Main changes

I added three functions to ``RandBLAS/util.hh``:
* sample_indices_iid: sample with replacement from an index set according to a (nonuniform) probability distribution, as specified by its cumulative distribution function.
* weights_to_cdf: converts a buffer of nonnegative numbers into a cumulative distribution function.
* sample_indices_iid_uniform: a more efficient version of sample_indices_iid, specialized to sampling from the uniform distribution.

I added a file
> test/test_basic_rng/rng_common.hh

This file is where we'll put code that's used to construct our statistical tests. Conceptually distinct parts of the file:
 * a hard-coded statistical table for running two-sided Kolmogorov-Smirnov tests, plus functions for performing lookups in this table.
 * a section for purely combinatorial helper functions. Right now there's only one such function:``log_binomial_coefficient``.
 * a section for computing some quantities of interest for the hypergeometric distribution. The function for constructing the PMF is important since we can use it in a Kolmogorov-Smirnov test for correctness of ``repeated_fisher_yates`` (our function for sampling uniformly from an index set without replacement). Note: I haven't implemented this test yet!
 
I also added
> test/test_basic_rng/test_sample_indices.cc

Right now it only contains tests for sampling _with replacement_. It should also contain tests for sampling _without replacement_, where an empirical CDF for the hypergeometric distribution can be constructed from ``repeated_fisher_yates`` and the true CDF can be computed from ``test_basic_rng/rng_common.hh``.
