### PR TITLE
Documentation for our Error class, improved printing utilities, and tests for both of these. Selected deactivation of compiler optimizations.

### DIFF
--- a/RandBLAS/CMakeLists.txt
+++ b/RandBLAS/CMakeLists.txt
@@ -19,7 +19,7 @@ target_include_directories(RandBLAS INTERFACE
 
 target_link_libraries(RandBLAS INTERFACE ${RandBLAS_libs})
 
-set(RandBLAS_cxx_opts -Wall -Wextra)
+set(RandBLAS_cxx_opts -Wall -Wextra -Wno-comment)
 if (SANITIZE_ADDRESS)
     list(APPEND RandBLAS_cxx_opts -fsanitize=address)
     target_link_options(RandBLAS INTERFACE -fsanitize=address)

--- a/RandBLAS/base.hh
+++ b/RandBLAS/base.hh
@@ -439,3 +439,4 @@ concept SketchingOperator = requires {
 
 
 } // end namespace RandBLAS::base
+

--- a/RandBLAS/base.hh
+++ b/RandBLAS/base.hh
@@ -129,24 +129,6 @@ struct RNGState {
 
 };
 
-
-// template <typename RNG>
-// RNGState<RNG>::RNGState(
-//     const RNGState<RNG> &s
-// ) {
-//     std::memcpy(this->counter.v, s.counter.v, this->len_c * sizeof(ctr_uint));
-//     std::memcpy(this->key.v,     s.key.v,     this->len_k * sizeof(key_uint));
-// }
-
-// template <typename RNG>
-// RNGState<RNG> &RNGState<RNG>::operator=(
-//     const RNGState &s
-// ) {
-//     std::memcpy(this->counter.v, s.counter.v, this->len_c * sizeof(ctr_uint));
-//     std::memcpy(this->key.v,     s.key.v,     this->len_k * sizeof(key_uint));
-//     return *this;
-// }
-
 template <typename RNG>
 std::ostream &operator<<(
     std::ostream &out,

--- a/RandBLAS/compilers.hh
+++ b/RandBLAS/compilers.hh
@@ -1,0 +1,56 @@
+// Copyright, 2024. See LICENSE for copyright holder information.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// (1) Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// (2) Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// (3) Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+
+#pragma once
+
+#if defined(__GNUC__)
+#define RandBLAS_WARNING_COMMENT_OFF _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wcomment\"")
+#define RandBLAS_WARNING_COMMENT_ON _Pragma("GCC diagnostic pop")
+#else
+#define RandBLAS_WARNING_COMMENT_OFF
+#define RandBLAS_WARNING_COMMENT_ON
+#endif
+
+
+#ifdef __clang__
+#define RandBLAS_OPTIMIZE_OFF _Pragma("clang optimize off")
+#define RandBLAS_OPTIMIZE_ON _Pragma("clang optimize on")
+#elif defined(__GNUC__)
+#define RandBLAS_OPTIMIZE_OFF _Pragma("GCC push_options") _Pragma("GCC optimize (\"O0\")")
+#define RandBLAS_OPTIMIZE_ON _Pragma("GCC pop_options")
+#elif defined(_MSC_VER)
+#define RandBLAS_OPTIMIZE_OFF __pragma(optimize("", off))
+#define RandBLAS_OPTIMIZE_ON __pragma(optimize("", on))
+#elif defined(__INTEL_COMPILER)
+#define RandBLAS_OPTIMIZE_OFF _Pragma("optimize('', off)")
+#define RandBLAS_OPTIMIZE_ON _Pragma("optimize('', on)")
+#else
+#define RandBLAS_OPTIMIZE_OFF
+#define RandBLAS_OPTIMIZE_ON
+#endif

--- a/RandBLAS/dense_skops.hh
+++ b/RandBLAS/dense_skops.hh
@@ -41,7 +41,7 @@
 #include <string>
 #include <tuple>
 
-#include <math.h>
+#include <cmath>
 #include <typeinfo>
 
 

--- a/RandBLAS/exceptions.hh
+++ b/RandBLAS/exceptions.hh
@@ -41,27 +41,60 @@ namespace RandBLAS::exceptions {
 // ^ Use to suppress compiler warnings for unused variables in functions.
 
 // -----------------------------------------------------------------------------
-/// Exception class for BLAS errors.
+/// Minimalist exception class for RandBLAS errors.
+///
+/// @verbatim embed:rst:leading-slashes
+///  These are typically triggered by statements of the form ``randblas_require(cond)``
+///  where ``cond`` was false. The curious can examine RandBLAS/exceptions.hh
+///  for the definition of ``randblas_require``.
+///  
+///  The vast majority of errors thrown by RandBLAS are due to invalid
+///  parameters for matrix dimensions or strides. These error messages 
+///  only say what went wrong; they offer no suggestions on how to fix
+///  what went wrong or why it might have happened. Please get in touch
+///  with us on GitHub if you've having trouble understanding or resolving
+///  an error.
+///
+/// @endverbatim
+///
 class Error: public std::exception {
 public:
-    /// Constructs BLAS error
+    // Constructs RandBLAS error
     Error():
         std::exception()
     {}
 
-    /// Constructs BLAS error with message
+    // ---------------------------------------
+    /// Constructs error with message
     Error( std::string const &msg ):
         std::exception(),
         msg_( msg )
     {}
 
-    /// Constructs BLAS error with message: "msg, in function func"
+    // Constructs RandBLAS error with message: "msg, in function func"
     Error( const char* msg, const char* func ):
         std::exception(),
         msg_( std::string(msg) + ", in function " + func )
     {}
 
-    /// Returns BLAS error message
+    // ---------------------------------------------------------------
+    /// Returns a C-string representation of this error's message.
+    /// It's common to wrap this function's return value with std::string.
+    /// For example ...
+    ///
+    /// @verbatim embed:rst:leading-slashes
+    /// .. code:: c++
+    ///
+    ///     try {
+    ///         /* do something that might raise a RandBLAS error */
+    ///         randblas_require(1 < 0);
+    ///     } catch (RandBLAS::Exceptions::Error &e) {
+    ///         std::string message{e.what()};
+    ///         /* inspect the message */
+    ///         std::cout << message << std::endl;
+    ///     }
+    ///
+    /// @endverbatim
     virtual const char* what() const noexcept override
         { return msg_.c_str(); }
 

--- a/RandBLAS/random_gen.hh
+++ b/RandBLAS/random_gen.hh
@@ -37,7 +37,7 @@
 #if !defined(_GNU_SOURCE)
 #define _GNU_SOURCE
 #endif
-#include <math.h>
+#include <cmath>
 
 #if !defined(R123_NO_SINCOS) && defined(__APPLE__)
 /* MacOS X 10.10.5 (2015) doesn't have sincosf */
@@ -47,13 +47,13 @@
 
 #if R123_NO_SINCOS /* enable this if sincos and sincosf are not in the math library */
 R123_CUDA_DEVICE R123_STATIC_INLINE void sincosf(float x, float *s, float *c) {
-    *s = sinf(x);
-    *c = cosf(x);
+    *s = std::sinf(x);
+    *c = std::cosf(x);
 }
 
 R123_CUDA_DEVICE R123_STATIC_INLINE void sincos(double x, double *s, double *c) {
-    *s = sin(x);
-    *c = cos(x);
+    *s = std::sin(x);
+    *c = std::cos(x);
 }
 #endif /* sincos is not in the math library */
 

--- a/RandBLAS/random_gen.hh
+++ b/RandBLAS/random_gen.hh
@@ -70,13 +70,42 @@ static inline void sincospi(double x, double *s, double *c) {
 }
 #endif
 
+// Define macros to toggle compiler optimizations in select places.
+//
+//     Right now we only use these for Random123/boxmuller.hpp.
+//     If we need to use these macros in other places, then we can stick
+//     these definitions in some kind of dedicated file.
+//
+#ifdef __clang__
+#define RandBLAS_OPTIMIZE_OFF _Pragma("clang optimize off")
+#define RandBLAS_OPTIMIZE_ON _Pragma("clang optimize on")
+#elif defined(__GNUC__)
+#define RandBLAS_OPTIMIZE_OFF _Pragma("GCC push_options") _Pragma("GCC optimize (\"O0\")")
+#define RandBLAS_OPTIMIZE_ON _Pragma("GCC pop_options")
+#elif defined(_MSC_VER)
+#define RandBLAS_OPTIMIZE_OFF __pragma(optimize("", off))
+#define RandBLAS_OPTIMIZE_ON __pragma(optimize("", on))
+#elif defined(__INTEL_COMPILER)
+#define RandBLAS_OPTIMIZE_OFF _Pragma("optimize('', off)")
+#define RandBLAS_OPTIMIZE_ON _Pragma("optimize('', on)")
+#else
+#define RandBLAS_OPTIMIZE_OFF
+#define RandBLAS_OPTIMIZE_ON
+#endif
+
+
 #include <Random123/array.h>
 #include <Random123/philox.h>
 #include <Random123/threefry.h>
 // NOTE: we do not support Random123's AES or ARS generators.
-#pragma clang optimize off
+
+RandBLAS_OPTIMIZE_OFF
 #include <Random123/boxmuller.hpp>
-#pragma clang optimize on
+// ^ We've run into correctness issues with that file when using clang and
+//   compiling with optimization enabled. To err on the side of caution
+//   we disable compiler optimizations for clang and three other compilers.
+//
+RandBLAS_OPTIMIZE_ON
 #include <Random123/uniform.hpp>
 
 /// our extensions to random123

--- a/RandBLAS/random_gen.hh
+++ b/RandBLAS/random_gen.hh
@@ -74,7 +74,9 @@ static inline void sincospi(double x, double *s, double *c) {
 #include <Random123/philox.h>
 #include <Random123/threefry.h>
 // NOTE: we do not support Random123's AES or ARS generators.
+#pragma clang optimize off
 #include <Random123/boxmuller.hpp>
+#pragma clang optimize on
 #include <Random123/uniform.hpp>
 
 /// our extensions to random123

--- a/RandBLAS/random_gen.hh
+++ b/RandBLAS/random_gen.hh
@@ -31,6 +31,7 @@
 
 /// @file
 
+#include "compilers.hh"
 #include <Random123/features/compilerfeatures.h>
 
 // this is for sincosf
@@ -68,29 +69,6 @@ static inline void sincospi(double x, double *s, double *c) {
     const double PI = 3.1415926535897932;
     sincos(PI*x, s, c);
 }
-#endif
-
-// Define macros to toggle compiler optimizations in select places.
-//
-//     Right now we only use these for Random123/boxmuller.hpp.
-//     If we need to use these macros in other places, then we can stick
-//     these definitions in some kind of dedicated file.
-//
-#ifdef __clang__
-#define RandBLAS_OPTIMIZE_OFF _Pragma("clang optimize off")
-#define RandBLAS_OPTIMIZE_ON _Pragma("clang optimize on")
-#elif defined(__GNUC__)
-#define RandBLAS_OPTIMIZE_OFF _Pragma("GCC push_options") _Pragma("GCC optimize (\"O0\")")
-#define RandBLAS_OPTIMIZE_ON _Pragma("GCC pop_options")
-#elif defined(_MSC_VER)
-#define RandBLAS_OPTIMIZE_OFF __pragma(optimize("", off))
-#define RandBLAS_OPTIMIZE_ON __pragma(optimize("", on))
-#elif defined(__INTEL_COMPILER)
-#define RandBLAS_OPTIMIZE_OFF _Pragma("optimize('', off)")
-#define RandBLAS_OPTIMIZE_ON _Pragma("optimize('', on)")
-#else
-#define RandBLAS_OPTIMIZE_OFF
-#define RandBLAS_OPTIMIZE_ON
 #endif
 
 

--- a/RandBLAS/skge.hh
+++ b/RandBLAS/skge.hh
@@ -39,7 +39,7 @@
 #include <stdexcept>
 #include <string>
 
-#include <math.h>
+#include <cmath>
 #include <typeinfo>
 
 

--- a/RandBLAS/skve.hh
+++ b/RandBLAS/skve.hh
@@ -38,7 +38,7 @@
 #include <stdexcept>
 #include <string>
 
-#include <math.h>
+#include <cmath>
 #include <typeinfo>
 
 

--- a/RandBLAS/sparse_skops.hh
+++ b/RandBLAS/sparse_skops.hh
@@ -40,6 +40,7 @@
 #include <cstdio>
 #include <cmath>
 #include <algorithm>
+#include <unordered_map>
 
 #define MAX(a, b) (((a) < (b)) ? (b) : (a))
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))

--- a/RandBLAS/sparse_skops.hh
+++ b/RandBLAS/sparse_skops.hh
@@ -107,10 +107,8 @@ static state_t repeated_fisher_yates(
 inline double isometry_scale(Axis major_axis, int64_t vec_nnz, int64_t dim_major, int64_t dim_minor) {
     if (major_axis == Axis::Short) {
         return std::pow(vec_nnz, -0.5); 
-    } else if (major_axis == Axis::Long) {
-        return std::sqrt( ((double) dim_major) / (vec_nnz * ((double) dim_minor)) );
     } else {
-        throw std::invalid_argument("Cannot compute the isometry scale for a sparse operator with unspecified major axis.");
+        return std::sqrt( ((double) dim_major) / (vec_nnz * ((double) dim_minor)) );
     }
 }
 

--- a/RandBLAS/util.hh
+++ b/RandBLAS/util.hh
@@ -328,6 +328,10 @@ void transpose_square(T* A, int64_t n, int64_t lda) {
     return;
 }
 
+template <typename T>
+T sqrt_epsilon() {
+    return std::sqrt(std::numeric_limits<T>::epsilon());
+}
 
 // =============================================================================
 /// \fn weights_to_cdf(int64_t n, T* w, T error_if_below = -std::numeric_limits<T>::epsilon())
@@ -344,7 +348,7 @@ void transpose_square(T* A, int64_t n, int64_t lda) {
 /// On exit, \math{w} is a CDF suitable for use with sample_indices_iid.
 ///
 template <typename T>
-void weights_to_cdf(int64_t n, T* w, T error_if_below = -std::numeric_limits<T>::epsilon()) {
+void weights_to_cdf(int64_t n, T* w, T error_if_below = -sqrt_epsilon<T>()) {
     T sum = 0.0;
     for (int64_t i = 0; i < n; ++i) {
         T val = w[i];

--- a/RandBLAS/util.hh
+++ b/RandBLAS/util.hh
@@ -162,6 +162,9 @@ enum ArrayStyle : char {
     Python = 'P'
 };
 
+RandBLAS_OPTIMIZE_OFF
+// ^ It would be extra bad if a compiler somehow messed up the following function.
+
 // =============================================================================
 /// \fn print_buff_to_stream(
 ///     std::ostream &stream, int64_t n_rows, int64_t n_cols, T *A,
@@ -184,9 +187,6 @@ void print_buff_to_stream(
     std::ostream &stream, int64_t n_rows, int64_t n_cols, T *A,
     int64_t irs, int64_t ics, cout_able &label, int decimals = 8, ArrayStyle style = ArrayStyle::MATLAB
 ) {
-    RandBLAS_OPTIMIZE_OFF
-    // ^ It would be extra bad if a compiler somehow messed up this function.
-
     std::string abs_start, mid_start, mid_end, abs_end;
     if (style == ArrayStyle::MATLAB) {
         abs_start = " = [ ... \n";
@@ -218,9 +218,9 @@ void print_buff_to_stream(
         }
     }
     stream << std::endl;
-    RandBLAS_OPTIMIZE_ON
     return;
 }
+RandBLAS_OPTIMIZE_ON
 
 // =============================================================================
 /// \fn print_buff_to_stream(

--- a/examples/sparse-low-rank-approx/qrcp_matrixmarket.cc
+++ b/examples/sparse-low-rank-approx/qrcp_matrixmarket.cc
@@ -33,7 +33,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <iostream>
-#include <math.h>
+#include <cmath>
 #include <time.h>
 #include <stdlib.h>
 #include <chrono>

--- a/examples/sparse-low-rank-approx/svd_matrixmarket.cc
+++ b/examples/sparse-low-rank-approx/svd_matrixmarket.cc
@@ -34,7 +34,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <iostream>
-#include <math.h>
+#include <cmath>
 #include <time.h>
 #include <stdlib.h>
 #include <chrono>

--- a/examples/sparse-low-rank-approx/svd_rank1_plus_noise.cc
+++ b/examples/sparse-low-rank-approx/svd_rank1_plus_noise.cc
@@ -34,7 +34,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <iostream>
-#include <math.h>
+#include <cmath>
 #include <time.h>
 #include <stdlib.h>
 #include <chrono>

--- a/examples/total-least-squares/tls_dense_skop.cc
+++ b/examples/total-least-squares/tls_dense_skop.cc
@@ -35,7 +35,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <iostream>
-#include <math.h>
+#include <cmath>
 #include <time.h>
 #include <stdlib.h>
 #include <chrono>

--- a/examples/total-least-squares/tls_sparse_skop.cc
+++ b/examples/total-least-squares/tls_sparse_skop.cc
@@ -35,7 +35,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <iostream>
-#include <math.h>
+#include <cmath>
 #include <time.h>
 #include <stdlib.h>
 #include <chrono>

--- a/rtd/source/api_reference/sketch_dense.rst
+++ b/rtd/source/api_reference/sketch_dense.rst
@@ -121,5 +121,5 @@ Matrix format utility functions
 .. doxygenfunction:: RandBLAS::transpose_square(T* A, int64_t n, int64_t lda)
    :project: RandBLAS
 
-.. doxygenfunction:: RandBLAS::overwrite_triangle(blas::Layout layout, blas::Uplo to_overwrite, int64_t n, int64_t strict_offset,  T* A, int64_t lda)
+.. doxygenfunction:: RandBLAS::overwrite_triangle(blas::Layout layout, blas::Uplo to_overwrite, int64_t n, int64_t k,  T* A, int64_t lda)
    :project: RandBLAS

--- a/rtd/source/api_reference/utilities.rst
+++ b/rtd/source/api_reference/utilities.rst
@@ -25,12 +25,14 @@ Random sampling from index sets
 .. doxygenfunction:: RandBLAS::repeated_fisher_yates(int64_t k, int64_t n, int64_t r, sint_t *samples, const state_t &state)
   :project: RandBLAS 
 
-Debugging
-=========
+I/O and debugging
+=================
 
-.. doxygenfunction:: RandBLAS::print_colmaj
+.. doxygenenum:: RandBLAS::ArrayStyle
+    :project: RandBLAS
+
+.. doxygenfunction:: RandBLAS::print_buff_to_stream(std::ostream &stream, blas::Layout layout, int64_t n_rows, int64_t n_cols, T *A, int64_t lda, cout_able &label, int decimals, ArrayStyle style )
    :project: RandBLAS
 
 .. doxygenfunction:: RandBLAS::typeinfo_as_string()
    :project: RandBLAS
-

--- a/rtd/source/api_reference/utilities.rst
+++ b/rtd/source/api_reference/utilities.rst
@@ -28,6 +28,10 @@ Random sampling from index sets
 I/O and debugging
 =================
 
+.. doxygenclass:: RandBLAS::exceptions::Error
+    :project: RandBLAS
+    :members:
+
 .. doxygenenum:: RandBLAS::ArrayStyle
     :project: RandBLAS
 

--- a/rtd/source/tutorial/index.rst
+++ b/rtd/source/tutorial/index.rst
@@ -22,7 +22,7 @@ RandBLAS, at a glance
 
     1. Get your hands on a random state.
     2. Define a sketching distribution, and use the random state to sample an operator from that distribution.
-    3. Apply the operator with a function that's *almost* identical to GEMM.
+    3. Apply the operator with a function that's *almost* identical to `GEMM <https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms#Level_3>`_.
 
   To illustrate this workflow, suppose we have a 20,000-by-10,000 double-precision matrix :math:`A`  stored in column-major
   layout. Suppose also that we want to compute a sketch of the form :math:`B = AS`, where :math:`S` is a Gaussian matrix of size 10,000-by-50.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,7 +11,7 @@ if (GTest_FOUND)
     #
     #####################################################################
 
-    add_executable(RandBLAS_tests
+    add_executable(densedata_tests
         test_datastructures/test_denseskop.cc
         test_datastructures/test_sparseskop.cc
 
@@ -23,8 +23,8 @@ if (GTest_FOUND)
         test_matmul_wrappers/test_sketch_vector.cc
         test_matmul_wrappers/test_sketch_symmetric.cc
     )
-    target_link_libraries(RandBLAS_tests RandBLAS GTest::GTest GTest::Main)
-    gtest_discover_tests(RandBLAS_tests)
+    target_link_libraries(densedata_tests RandBLAS GTest::GTest GTest::Main)
+    gtest_discover_tests(densedata_tests)
 
     #####################################################################
     #
@@ -32,7 +32,7 @@ if (GTest_FOUND)
     #
     #####################################################################
 
-    add_executable(SparseRandBLAS_tests
+    add_executable(sparsedata_tests
         test_datastructures/test_spmats/test_csc.cc
         test_datastructures/test_spmats/test_csr.cc
         test_datastructures/test_spmats/test_coo.cc
@@ -44,8 +44,8 @@ if (GTest_FOUND)
 
         test_matmul_wrappers/test_sketch_sparse.cc
     )
-    target_link_libraries(SparseRandBLAS_tests RandBLAS GTest::GTest GTest::Main)
-    gtest_discover_tests(SparseRandBLAS_tests)
+    target_link_libraries(sparsedata_tests RandBLAS GTest::GTest GTest::Main)
+    gtest_discover_tests(sparsedata_tests)
 
     #####################################################################
     #
@@ -53,14 +53,14 @@ if (GTest_FOUND)
     #
     #####################################################################
 
-    add_executable(RandBLAS_stats
+    add_executable(stat_tests
         test_basic_rng/test_r123.cc
         test_basic_rng/test_discrete.cc
         test_basic_rng/test_continuous.cc
         test_basic_rng/test_distortion.cc
     )
-    target_link_libraries(RandBLAS_stats RandBLAS GTest::GTest GTest::Main)
-    gtest_discover_tests(RandBLAS_stats)
+    target_link_libraries(stat_tests RandBLAS GTest::GTest GTest::Main)
+    gtest_discover_tests(stat_tests)
     file(COPY test_basic_rng/r123_kat_vectors.txt DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
     file(COPY test_basic_rng/r123_kat_vectors.txt DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/..)
     file(COPY test_basic_rng/r123_kat_vectors.txt DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/../test/)
@@ -71,11 +71,19 @@ if (GTest_FOUND)
     #
     #####################################################################
 
-    add_executable(MetaRandBLAS_tests
-        test_handrolled_lapack.cc
-    )
-    target_link_libraries(MetaRandBLAS_tests RandBLAS GTest::GTest GTest::Main)
-    gtest_discover_tests(MetaRandBLAS_tests)
+    add_executable(meta_tests test_handrolled_lapack.cc )
+    target_link_libraries(meta_tests RandBLAS GTest::GTest GTest::Main)
+    gtest_discover_tests(meta_tests)
+
+    #####################################################################
+    #
+    #   Literally any other tests that use the Googletest framework
+    #
+    #####################################################################
+
+    add_executable(misc_tests test_io.cc test_exceptions.cc )
+    target_link_libraries(misc_tests RandBLAS GTest::GTest GTest::Main)
+    gtest_discover_tests(misc_tests)
 
 endif()
 message(STATUS "Checking for regression tests ... ${tmp}")

--- a/test/comparison.hh
+++ b/test/comparison.hh
@@ -31,7 +31,7 @@
 
 #include "RandBLAS.hh"
 #include <gtest/gtest.h>
-#include <math.h>
+#include <cmath>
 #include <cmath>
 #include <numeric>
 #include <iostream>

--- a/test/test_basic_rng/test_r123.cc
+++ b/test/test_basic_rng/test_r123.cc
@@ -37,7 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string.h>
 #include <errno.h>
 #include <assert.h>
-#include <math.h>
+#include <cmath>
 
 #include <sstream>
 #include <iostream>

--- a/test/test_datastructures/test_sparseskop.cc
+++ b/test/test_datastructures/test_sparseskop.cc
@@ -32,7 +32,7 @@
 #include <RandBLAS/util.hh>
 #include "test/comparison.hh"
 #include <gtest/gtest.h>
-#include <math.h>
+#include <cmath>
 
 using RandBLAS::RNGState;
 using RandBLAS::SignedInteger;

--- a/test/test_exceptions.cc
+++ b/test/test_exceptions.cc
@@ -1,0 +1,46 @@
+
+
+
+#include "RandBLAS/config.h"
+#include "RandBLAS/exceptions.hh"
+
+#include <string>
+#include <gtest/gtest.h>
+
+class TestExceptions : public ::testing::Test {
+    protected:
+};
+
+TEST_F(TestExceptions, randblas_require_var_arg) {
+    bool successful_raise = false;
+    try {
+        randblas_require(successful_raise);
+    } catch (RandBLAS::exceptions::Error &e) {
+        std::string message{e.what()};
+        successful_raise = message.find("successful_raise") != std::string::npos;
+    }
+    ASSERT_TRUE(successful_raise);
+}
+
+TEST_F(TestExceptions, randblas_require_expr_arg) {
+    int flag = 0;
+    try {
+        randblas_require(flag > 1);
+    } catch (RandBLAS::exceptions::Error &e) {
+        std::string message{e.what()};
+        flag = (int) message.find("flag > 1") != std::string::npos;
+    }
+    ASSERT_TRUE(flag);
+}
+
+TEST_F(TestExceptions, randblas_error_if_msg_output) {
+    bool error_trigger = true;
+    bool expect_true = false;
+    try {
+        randblas_error_if_msg(error_trigger, "Custom message.");
+    } catch (RandBLAS::exceptions::Error &e) {
+        std::string message{e.what()};
+        expect_true = message.find("Custom message.") != std::string::npos;
+    }
+    ASSERT_TRUE(expect_true);
+}

--- a/test/test_handrolled_lapack.cc
+++ b/test/test_handrolled_lapack.cc
@@ -5,11 +5,8 @@
 
 #include "RandBLAS/util.hh"
 #include "handrolled_lapack.hh"
-#include "test_basic_rng/rng_common.hh"
 #include "comparison.hh"
 #include "RandBLAS/config.h"
-#include "RandBLAS/base.hh"
-#include "RandBLAS/util.hh"
 #include "RandBLAS/dense_skops.hh"
 using RandBLAS::DenseDist;
 using RandBLAS::ScalarDist;

--- a/test/test_io.cc
+++ b/test/test_io.cc
@@ -25,6 +25,14 @@ class TestIO: public ::testing::Test {
     }
 };
 
+/***
+ * TODO: Have these "tests" actually check for correctness.
+ * Right now I just inspect them visually by running
+ * 
+ *  ctest -R TestIO --verbose
+ * 
+ */
+
 TEST_F(TestIO, test_matlab_tiny) {
     auto vec = get_pi_mat( 2, 1);
     print_buff_to_stream(std::cout, Layout::ColMajor, 1, 1, vec.data(), 1, "mat1x1", 9, ArrayStyle::MATLAB);

--- a/test/test_io.cc
+++ b/test/test_io.cc
@@ -1,0 +1,58 @@
+
+
+#include <cmath>
+#include <blas.hh>
+
+#include "RandBLAS/base.hh"
+#include "RandBLAS/util.hh"
+#include "RandBLAS/config.h"
+
+using blas::Layout;
+using RandBLAS::ArrayStyle;
+using RandBLAS::print_buff_to_stream;
+
+#include <iostream>
+#include <vector>
+#include <gtest/gtest.h>
+
+
+class TestIO: public ::testing::Test {
+    protected:
+
+    std::vector<double> get_pi_mat(int64_t n_rows, int64_t n_cols) {
+        std::vector<double> out(n_rows * n_cols, std::acos(-1.0));
+        return out;
+    }
+};
+
+TEST_F(TestIO, test_matlab_tiny) {
+    auto vec = get_pi_mat( 2, 1);
+    print_buff_to_stream(std::cout, Layout::ColMajor, 1, 1, vec.data(), 1, "mat1x1", 9, ArrayStyle::MATLAB);
+    print_buff_to_stream(std::cout, Layout::ColMajor, 2, 1, vec.data(), 2, "mat2x1", 9, ArrayStyle::MATLAB);
+    print_buff_to_stream(std::cout, Layout::ColMajor, 1, 2, vec.data(), 1, "mat1x2", 9, ArrayStyle::MATLAB);
+}
+
+TEST_F(TestIO, test_matlab_medium) {
+    auto vec = get_pi_mat( 7, 3);
+    vec[1] *= -1;
+    print_buff_to_stream(std::cout, Layout::ColMajor, 7, 3, vec.data(), 7, "Neg in first column\nmat7x3_a", 3, ArrayStyle::MATLAB);
+    print_buff_to_stream(std::cout, Layout::RowMajor, 7, 3, vec.data(), 3, "Neg in first row\nmat7x3_b", 3, ArrayStyle::MATLAB);
+    print_buff_to_stream(std::cout, Layout::RowMajor, 3, 7, vec.data(), 7, "Neg in first row\ntrans_mat7x3_a", 3, ArrayStyle::MATLAB);
+}
+
+
+TEST_F(TestIO, test_python_tiny) {
+    auto vec = get_pi_mat( 2, 1);
+    print_buff_to_stream(std::cout, Layout::ColMajor, 1, 1, vec.data(), 1, "arr1x1", 9, ArrayStyle::Python);
+    print_buff_to_stream(std::cout, Layout::ColMajor, 2, 1, vec.data(), 2, "arr2x1", 9, ArrayStyle::Python);
+    print_buff_to_stream(std::cout, Layout::ColMajor, 1, 2, vec.data(), 1, "arr1x2", 9, ArrayStyle::Python);
+}
+
+
+TEST_F(TestIO, test_python_medium) {
+    auto vec = get_pi_mat( 7, 3);
+    vec[1] *= -1;
+    print_buff_to_stream(std::cout, Layout::ColMajor, 7, 3, vec.data(), 7, "Neg in first column\nmat7x3_a", 3, ArrayStyle::Python);
+    print_buff_to_stream(std::cout, Layout::RowMajor, 7, 3, vec.data(), 3, "Neg in first row\nmat7x3_b", 3, ArrayStyle::Python);
+    print_buff_to_stream(std::cout, Layout::RowMajor, 3, 7, vec.data(), 7, "Neg in first row\ntrans_mat7x3_a", 3, ArrayStyle::Python);
+}


### PR DESCRIPTION
The PR title says most of what this changes. 

The most important change is that we disable compiler optimizations for Random123's Box-Muller transform and for our printing function. The former change was needed to resolve a failing test for RandLAPACK. The latter change is just to err on the side of caution.