### PR TITLE
Fix bugs in undocumented sparse matrix conversion functions

### DIFF
--- a/RandBLAS/sparse_data/conversions.hh
+++ b/RandBLAS/sparse_data/conversions.hh
@@ -72,7 +72,7 @@ void csc_to_coo(CSCMatrix<T, sint_t1> &csc, COOMatrix<T, sint_t2> &coo) {
     for (int64_t j = 0; j < csc.n_cols; ++j) {
         for (int64_t i = csc.colptr[j]; i < csc.colptr[j+1]; ++i) {
             coo.vals[ell] = csc.vals[ell];
-            coo.rows[ell] = (sint_t2) i;
+            coo.rows[ell] = (sint_t2) csc.rowidxs[i];
             coo.cols[ell] = (sint_t2) j;
             ++ell;
         }
@@ -114,7 +114,7 @@ void csr_to_coo(CSRMatrix<T, sint_t1> &csr, COOMatrix<T, sint_t2> &coo) {
         for (int64_t j = csr.rowptr[i]; j < csr.rowptr[i+1]; ++j) {
             coo.vals[ell] = csr.vals[ell];
             coo.rows[ell] = (sint_t2) i;
-            coo.cols[ell] = (sint_t2) j;
+            coo.cols[ell] = (sint_t2) csr.colidxs[j];
             ++ell;
         }
     }

--- a/rtd/source/updates/index.rst
+++ b/rtd/source/updates/index.rst
@@ -11,8 +11,6 @@ RandBLAS follows `Semantic Versioning <https://semver.org>`_. Any function docum
 on this website is part of the public API. There are many functions which are not
 part of our public API, but could be added to it if there is user interest. 
 
-RandBLAS is in the 1.0.x release series. The latest version is :ref:`1.0.1 <v10x_patches>`.
-See below for a general overview of each release series.
 
 RandBLAS 1.0
 ------------

--- a/test/test_datastructures/test_spmats/test_csr.cc
+++ b/test/test_datastructures/test_spmats/test_csr.cc
@@ -34,6 +34,7 @@
 #include <vector>
 
 using namespace RandBLAS::sparse_data;
+using namespace RandBLAS::sparse_data::coo;
 using namespace RandBLAS::sparse_data::csr;
 using namespace test::test_datastructures::test_spmats;
 using namespace RandBLAS::sparse_data::conversions;
@@ -130,7 +131,33 @@ class TestCSR_Conversions : public ::testing::Test
         delete [] mat_actual;
         return;
     }
+
+    template <typename T = double>
+    static void test_csr_to_coo_band_diagonal() {
+        int64_t n = 8;
+        int64_t nnz = 32;
+        std::vector<T> vals{6, -1, -1, -1, -1, 6, -1, -1, -1, 6, -1, -1, -1, -1, 6, -1, -1, 6, -1, -100, 99, -1, 6, -1, -1, -1, 6, -1, -1, -1, -1, 6};
+        std::vector<int64_t> rowptr{0, 4, 8, 12, 16, 20, 24, 28, 32};
+        std::vector<int64_t> colidxs{0, 1, 2, 4, 0, 1, 3, 5, 0, 2, 3, 6, 1, 2, 3, 7, 0, 4, 5, 6, 1, 4, 5, 7, 2, 4, 6, 7, 3, 5, 6, 7};
+        CSRMatrix<T> A_csr(n,n,nnz,vals.data(),rowptr.data(),colidxs.data());
+        COOMatrix<T> A_coo(n,n);
+        csr_to_coo(A_csr, A_coo);
+        std::vector<T> A_dense_coo(n*n);
+        std::vector<T> A_dense_csr(n*n);
+        coo_to_dense(A_coo, Layout::ColMajor, A_dense_coo.data());
+        csr_to_dense(A_csr, Layout::ColMajor, A_dense_csr.data());
+        test::comparison::matrices_approx_equal(
+            Layout::ColMajor, Layout::ColMajor, blas::Op::NoTrans,
+            n, n, A_dense_csr.data(), n, A_dense_coo.data(), n,
+            __PRETTY_FUNCTION__, __FILE__, __LINE__
+        );
+    }
+    
 };
+
+TEST_F(TestCSR_Conversions, band) {
+    test_csr_to_coo_band_diagonal();
+}
 
 TEST_F(TestCSR_Conversions, dense_square_diagonal) {
     test_csr_to_dense_diagonal(3);


### PR DESCRIPTION
I'll add tests before merging this PR. But I want to note these necessary changes now as I'm discovering them.

A note: these functions were for converting from CSC or CSR format to COO format. Our examples which read sparse matrices from disk and run low-rank approximation algorithms were never unaffected. Those files only use conversions from COO to CSC or CSR.