### PR TITLE
Add `typename` to dependent-type defaults for clang compatibility

### DIFF
--- a/RandBLAS/sksy.hh
+++ b/RandBLAS/sksy.hh
@@ -155,7 +155,7 @@ using namespace RandBLAS::sparse;
 ///       * Leading dimension of :math:`\mat(B)` when reading from :math:`B.`
 ///
 /// @endverbatim
-template <SketchingOperator SKOP, typename T = SKOP::scalar_t>
+template <SketchingOperator SKOP, typename T = typename SKOP::scalar_t>
 inline void sketch_symmetric(
     // B = alpha*A*S + beta*B, where A is a symmetric matrix stored in the format of a general matrix.
     blas::Layout layout,
@@ -290,7 +290,7 @@ inline void sketch_symmetric(
 ///       * Leading dimension of :math:`\mat(B)` when reading from :math:`B.`
 ///
 /// @endverbatim
-template <SketchingOperator SKOP, typename T = SKOP::scalar_t>
+template <SketchingOperator SKOP, typename T = typename SKOP::scalar_t>
 inline void sketch_symmetric(
     // B = alpha*S*A + beta*B
     blas::Layout layout,
@@ -403,7 +403,7 @@ inline void sketch_symmetric(
 ///       * Leading dimension of :math:`\mat(B)` when reading from :math:`B.`
 ///
 /// @endverbatim
-template <SketchingOperator SKOP, typename T = SKOP::scalar_t>
+template <SketchingOperator SKOP, typename T = typename SKOP::scalar_t>
 inline void sketch_symmetric(
     // B = alpha*A*S + beta*B, where A is a symmetric matrix stored in the format of a general matrix.
     blas::Layout layout,
@@ -510,7 +510,7 @@ inline void sketch_symmetric(
 ///       * Leading dimension of :math:`\mat(B)` when reading from :math:`B.`
 ///
 /// @endverbatim
-template <SketchingOperator SKOP, typename T = SKOP::scalar_t>
+template <SketchingOperator SKOP, typename T = typename SKOP::scalar_t>
 inline void sketch_symmetric(
     // B = alpha*S*A + beta*B
     blas::Layout layout,

--- a/RandBLAS/skve.hh
+++ b/RandBLAS/skve.hh
@@ -137,7 +137,7 @@ using namespace RandBLAS::sparse;
 ///       * Stride between elements of y.
 ///
 /// @endverbatim
-template <SketchingOperator SKOP, typename T = SKOP::scalar_t>
+template <SketchingOperator SKOP, typename T = typename SKOP::scalar_t>
 inline void sketch_vector(
     blas::Op opS,
     int64_t d, // rows in submat(\mtxS)
@@ -229,7 +229,7 @@ inline void sketch_vector(
 ///       * Stride between elements of y.
 ///
 /// @endverbatim
-template <SketchingOperator SKOP, typename T = SKOP::scalar_t>
+template <SketchingOperator SKOP, typename T = typename SKOP::scalar_t>
 inline void sketch_vector(
     blas::Op opS,
     T alpha,

--- a/RandBLAS/sparse_data/sksp.hh
+++ b/RandBLAS/sparse_data/sksp.hh
@@ -415,7 +415,7 @@ using namespace RandBLAS::sparse_data;
 ///       * Leading dimension of :math:`\mat(B)` when reading from :math:`B`.
 ///
 /// @endverbatim
-template <SparseMatrix SpMat, typename DenseSkOp, typename T = DenseSkOp::scalar_t>
+template <SparseMatrix SpMat, typename DenseSkOp, typename T = typename DenseSkOp::scalar_t>
 inline void sketch_sparse(
     blas::Layout layout,
     blas::Op opS,
@@ -517,7 +517,7 @@ inline void sketch_sparse(
 ///       * Leading dimension of :math:`\mat(B)` when reading from :math:`B`.
 ///
 /// @endverbatim
-template <SparseMatrix SpMat, typename DenseSkOp, typename T = DenseSkOp::scalar_t>
+template <SparseMatrix SpMat, typename DenseSkOp, typename T = typename DenseSkOp::scalar_t>
 inline void sketch_sparse(
     blas::Layout layout,
     blas::Op opA,

--- a/RandBLAS/sparse_data/spmm_dispatch.hh
+++ b/RandBLAS/sparse_data/spmm_dispatch.hh
@@ -49,7 +49,7 @@
 
 namespace RandBLAS::sparse_data {
 
-template <SparseMatrix SpMat, typename T = SpMat::scalar_t>
+template <SparseMatrix SpMat, typename T = typename SpMat::scalar_t>
 void left_spmm(
     blas::Layout layout,
     blas::Op opA,
@@ -178,7 +178,7 @@ void left_spmm(
     return;
 }
 
-template <SparseMatrix SpMat, typename T = SpMat::scalar_t>
+template <SparseMatrix SpMat, typename T = typename SpMat::scalar_t>
 inline void right_spmm(
     blas::Layout layout,
     blas::Op opA,
@@ -295,7 +295,7 @@ namespace RandBLAS {
 ///       * Leading dimension of :math:`\mat(C)` when reading from :math:`C`.
 ///
 /// @endverbatim
-template <SparseMatrix SpMat, typename T = SpMat::scalar_t>
+template <SparseMatrix SpMat, typename T = typename SpMat::scalar_t>
 inline void spmm(blas::Layout layout, blas::Op opA, blas::Op opB, int64_t m, int64_t n, int64_t k, T alpha, const SpMat &A, const T *B, int64_t ldb, T beta, T *C, int64_t ldc) {
     RandBLAS::sparse_data::left_spmm(layout, opA, opB, m, n, k, alpha, A, 0, 0, B, ldb, beta, C, ldc);
     return;
@@ -373,7 +373,7 @@ inline void spmm(blas::Layout layout, blas::Op opA, blas::Op opB, int64_t m, int
 ///       * Leading dimension of :math:`\mat(C)` when reading from :math:`C`.
 ///
 /// @endverbatim
-template <SparseMatrix SpMat, typename T = SpMat::scalar_t>
+template <SparseMatrix SpMat, typename T = typename SpMat::scalar_t>
 inline void spmm(blas::Layout layout, blas::Op opA, blas::Op opB, int64_t m, int64_t n, int64_t k, T alpha, const T *A, int64_t lda, const SpMat &B, T beta, T *C, int64_t ldc) {
     RandBLAS::sparse_data::right_spmm(layout, opA, opB, m, n, k, alpha, A, lda, B, 0, 0, beta, C, ldc);
     return;

--- a/RandBLAS/sparse_skops.hh
+++ b/RandBLAS/sparse_skops.hh
@@ -660,7 +660,7 @@ using RandBLAS::SparseSkOp;
 using RandBLAS::Axis;
 using RandBLAS::sparse_data::COOMatrix;
 
-template <typename SparseSkOp, typename T = SparseSkOp::scalar_t, typename sint_t = SparseSkOp::index_t>
+template <typename SparseSkOp, typename T = typename SparseSkOp::scalar_t, typename sint_t = typename SparseSkOp::index_t>
 COOMatrix<T, sint_t> coo_view_of_skop(const SparseSkOp &S) {
     randblas_require(S.nnz > 0);
     COOMatrix<T, sint_t> A(S.n_rows, S.n_cols, S.nnz, S.vals, S.rows, S.cols);


### PR DESCRIPTION
clang and MSVC require `typename` before a dependent type name in default template arguments; GCC accepts the form without it. This adds the missing keyword at 14 sites across 5 headers so RandBLAS parses cleanly under clang.

  RandBLAS/sksy.hh                       (4 sites)
  RandBLAS/sparse_data/spmm_dispatch.hh  (4 sites)
  RandBLAS/sparse_skops.hh               (2 sites, single line)
  RandBLAS/sparse_data/sksp.hh           (2 sites)
  RandBLAS/skve.hh                       (2 sites)

spmm_dispatch.hh:445 already used the correct form (`typename T = typename SpMat1::scalar_t`) and served as the template for the fix. No functional change.