### PR TITLE
Restore host-side sincospi shim for non-CUDA builds with CUDA-aware b…

### DIFF
--- a/RandBLAS/random_gen.hh
+++ b/RandBLAS/random_gen.hh
@@ -38,6 +38,33 @@
 #include <Random123/threefry.h>
 // NOTE: we do not support Random123's AES or ARS generators.
 
+// Host-side shim for sincospi / sincospif. Random123/boxmuller.hpp calls these
+// unqualified; its own fallback definitions are gated behind
+//     `!defined(CUDART_VERSION) || CUDART_VERSION < 5000`
+// and are therefore skipped on host compiles where any dependency leaks
+// <cuda_runtime.h> into the include chain (notably blaspp's CMake config
+// transitively exports CUDA_INCLUDE_DIRS when blaspp was built with CUDA
+// support, which then poisons RandBLAS's host test compiles). Without these
+// definitions the host-compiled code fails to link.
+//
+// An earlier version of this shim was removed in PR #156 (9b73a25, 2026-03-05)
+// on the theory that CI green = unused. RandBLAS CI does not currently
+// exercise the Linux + CUDA-aware blaspp configuration where the failure
+// manifests; restoring the shim so host builds succeed on that config.
+#if !defined(__CUDACC__)
+#include <cmath>
+static inline void sincospif(float x, float *s, float *c) {
+    const float PIf = 3.1415926535897932f;
+    *s = std::sin(PIf * x);
+    *c = std::cos(PIf * x);
+}
+static inline void sincospi(double x, double *s, double *c) {
+    const double PI = 3.1415926535897932;
+    *s = std::sin(PI * x);
+    *c = std::cos(PI * x);
+}
+#endif
+
 #include <Random123/boxmuller.hpp>
 #include <Random123/uniform.hpp>
 


### PR DESCRIPTION

Reinstates global `::sincospi` and `::sincospif` definitions in `random_gen.hh`, gated `#if !defined(__CUDACC__)`. `Random123/boxmuller.hpp` calls these symbols unqualified; its own software fallback is guarded by

```cpp
#if !defined(CUDART_VERSION) || CUDART_VERSION < 5000
```

and is therefore skipped on host compiles where any dependency leaks `<cuda_runtime.h>` into the include chain. The leak path that matters in practice is **blaspp**: when blaspp is built with CUDA detection on, its CMake config transitively exports the CUDA include directories on every consumer target, which causes RandBLAS host test compiles to pick up `<cuda_runtime.h>` — thereby defining `CUDART_VERSION`, suppressing Random123's `sincospi` fallback, and leaving the calls unresolved at link time.

## Why this was removed before, and why CI didn't catch it

An earlier version of this shim was removed in #156 (9b73a25, 2026-03-05) on the theory that CI being green implied the symbols were unused. RandBLAS CI runs on Ubuntu (no spack/CUDA) and macOS (`sincospi` provided by the system); neither config exercises the Linux + spack/CUDA + CUDA-aware blaspp configuration where the failure manifests. This config is exactly what users hit when building a CUDA-aware blaspp locally as a prerequisite for GPU-enabled RandLAPACK, then building RandBLAS host-only against it.

RandLAPACK cannot patch around this because the failure occurs at the RandBLAS build step itself — long before RandLAPACK enters the dependency chain. The right home for the shim is RandBLAS, where Random123 is included.

## Verification

Full `ctest` passes **450/450** with this change on Linux + GCC 13.3 + CUDA-aware blaspp + MKL sparse.

Without the change, `all_correctness_tests` fails to link with:

```
error: 'sincospi' was not declared in this scope; did you mean 'sincosl'?
  131 |     sincospi(uneg11<double>(u0), &f.x, &f.y);
```
at `boxmuller.hpp:131`.

## Notes on what was *not* restored from the pre-#156 version

- The implementation uses `std::sin`/`std::cos` separately rather than the GNU `sincos`/`sincosf` extension, avoiding the `_GNU_SOURCE` complication from the pre-#156 version.
- The earlier version's `R123_NO_SINCOS` macOS fallback and `RandBLAS_OPTIMIZE_OFF` wrapper around the `boxmuller` include are deliberately not restored — the macOS code path appears unnecessary on modern systems, and Riley verified in #156 that the optimization toggle was not addressing a real correctness issue.