### PR TITLE
Kernel speed improvements

### DIFF
--- a/.github/actions/setup-randblas-deps/action.yml
+++ b/.github/actions/setup-randblas-deps/action.yml
@@ -39,6 +39,14 @@ runs:
             ;;
           mkl)
             sudo apt-get install -qq -y libmkl-dev
+            # Debian packages MKL headers under /usr/include/mkl and sets no
+            # MKLROOT. blaspp's MKL detection (config/mkl_version.cc) needs the
+            # headers on the include path or it never defines BLAS_HAVE_MKL, and
+            # RandBLAS's find_path(mkl_spblas.h) needs MKLROOT to point at the
+            # header dir. Discover the dir rather than hardcoding it.
+            mkl_inc="$(dirname "$(find /usr/include -name mkl_spblas.h | head -n1)")"
+            echo "MKLROOT=${mkl_inc}" >> "$GITHUB_ENV"
+            echo "CPATH=${mkl_inc}${CPATH:+:$CPATH}" >> "$GITHUB_ENV"
             ;;
           auto)
             sudo apt-get install -qq -y libopenblas-openmp-dev
@@ -94,7 +102,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}/../blaspp-install
-        key: blaspp-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cc }}-${{ inputs.blas-backend }}-${{ steps.blaspp-rev.outputs.sha }}
+        key: blaspp-mklfix1-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cc }}-${{ inputs.blas-backend }}-${{ steps.blaspp-rev.outputs.sha }}
 
     - name: build blaspp
       if: steps.blaspp-cache.outputs.cache-hit != 'true'

--- a/.github/actions/setup-randblas-deps/action.yml
+++ b/.github/actions/setup-randblas-deps/action.yml
@@ -35,8 +35,7 @@ runs:
           libgtest-dev
         case "${{ inputs.blas-backend }}" in
           openblas)
-            # ILP64 (64-bit integer) OpenBLAS to match blaspp's -Dblas_int=int64.
-            sudo apt-get install -qq -y libopenblas64-openmp-dev
+            sudo apt-get install -qq -y libopenblas-openmp-dev
             ;;
           mkl)
             sudo apt-get install -qq -y libmkl-dev
@@ -50,7 +49,7 @@ runs:
             echo "CPATH=${mkl_inc}${CPATH:+:$CPATH}" >> "$GITHUB_ENV"
             ;;
           auto)
-            sudo apt-get install -qq -y libopenblas64-openmp-dev
+            sudo apt-get install -qq -y libopenblas-openmp-dev
             ;;
           accelerate)
             echo "::error::accelerate backend is not available on Linux" >&2
@@ -103,7 +102,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}/../blaspp-install
-        key: blaspp-ilp64-mklfix1-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cc }}-${{ inputs.blas-backend }}-${{ steps.blaspp-rev.outputs.sha }}
+        key: blaspp-mklfix2-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cc }}-${{ inputs.blas-backend }}-${{ steps.blaspp-rev.outputs.sha }}
 
     - name: build blaspp
       if: steps.blaspp-cache.outputs.cache-hit != 'true'
@@ -119,9 +118,15 @@ runs:
         mkdir blaspp-build
         cd blaspp-build
         blas_arg=""
+        # ILP64 only for MKL: it makes MKL_INT 64-bit, which RandBLAS's MKL
+        # spgemm path (test_spgemm, compiled only under RandBLAS_HAS_MKL)
+        # requires to match its int64_t sparse indices. Other backends stay
+        # LP64 -- blaspp's public API is int64_t regardless, so RandBLAS is
+        # unaffected, and this avoids needing ILP64 OpenBLAS/Accelerate libs.
+        blas_int_arg=""
         case "${{ inputs.blas-backend }}" in
           openblas)   blas_arg="-Dblas=openblas" ;;
-          mkl)        blas_arg="-Dblas=mkl" ;;
+          mkl)        blas_arg="-Dblas=mkl"; blas_int_arg="-Dblas_int=int64" ;;
           accelerate) blas_arg="-Dblas=accelerate" ;;
           auto)       blas_arg="" ;;
         esac
@@ -131,7 +136,7 @@ runs:
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_INSTALL_PREFIX="$(pwd)/../blaspp-install" \
           -Dbuild_tests=OFF \
-          -Dblas_int=int64 \
+          ${blas_int_arg} \
           ${blas_arg} \
           ../blaspp
         if [[ "$(uname)" == "Darwin" ]]; then
@@ -147,7 +152,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}/../lapackpp-install
-        key: lapackpp-ilp64-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cc }}-${{ inputs.blas-backend }}-${{ steps.blaspp-rev.outputs.sha }}-${{ steps.lapackpp-rev.outputs.sha }}
+        key: lapackpp-mklfix2-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cc }}-${{ inputs.blas-backend }}-${{ steps.blaspp-rev.outputs.sha }}-${{ steps.lapackpp-rev.outputs.sha }}
 
     - name: build lapackpp
       if: inputs.install-lapackpp == 'true' && steps.lapackpp-cache.outputs.cache-hit != 'true'
@@ -162,6 +167,11 @@ runs:
         git clone --depth 1 https://github.com/icl-utk-edu/lapackpp.git
         mkdir lapackpp-build
         cd lapackpp-build
+        # Match the int width of the blaspp we link against (ILP64 only for MKL).
+        blas_int_arg=""
+        if [[ "${{ inputs.blas-backend }}" == "mkl" ]]; then
+          blas_int_arg="-Dblas_int=int64"
+        fi
         cmake \
           -DCMAKE_C_COMPILER="${CC}" \
           -DCMAKE_CXX_COMPILER="${CXX}" \
@@ -169,7 +179,7 @@ runs:
           -DCMAKE_INSTALL_PREFIX="$(pwd)/../lapackpp-install" \
           -Dblaspp_DIR="$(pwd)/../blaspp-install/lib/cmake/blaspp" \
           -Dbuild_tests=OFF \
-          -Dblas_int=int64 \
+          ${blas_int_arg} \
           ../lapackpp
         if [[ "$(uname)" == "Darwin" ]]; then
           jobs="$(sysctl -n hw.logicalcpu)"

--- a/.github/actions/setup-randblas-deps/action.yml
+++ b/.github/actions/setup-randblas-deps/action.yml
@@ -35,7 +35,8 @@ runs:
           libgtest-dev
         case "${{ inputs.blas-backend }}" in
           openblas)
-            sudo apt-get install -qq -y libopenblas-openmp-dev
+            # ILP64 (64-bit integer) OpenBLAS to match blaspp's -Dblas_int=int64.
+            sudo apt-get install -qq -y libopenblas64-openmp-dev
             ;;
           mkl)
             sudo apt-get install -qq -y libmkl-dev
@@ -49,7 +50,7 @@ runs:
             echo "CPATH=${mkl_inc}${CPATH:+:$CPATH}" >> "$GITHUB_ENV"
             ;;
           auto)
-            sudo apt-get install -qq -y libopenblas-openmp-dev
+            sudo apt-get install -qq -y libopenblas64-openmp-dev
             ;;
           accelerate)
             echo "::error::accelerate backend is not available on Linux" >&2
@@ -102,7 +103,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}/../blaspp-install
-        key: blaspp-mklfix1-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cc }}-${{ inputs.blas-backend }}-${{ steps.blaspp-rev.outputs.sha }}
+        key: blaspp-ilp64-mklfix1-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cc }}-${{ inputs.blas-backend }}-${{ steps.blaspp-rev.outputs.sha }}
 
     - name: build blaspp
       if: steps.blaspp-cache.outputs.cache-hit != 'true'
@@ -130,6 +131,7 @@ runs:
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_INSTALL_PREFIX="$(pwd)/../blaspp-install" \
           -Dbuild_tests=OFF \
+          -Dblas_int=int64 \
           ${blas_arg} \
           ../blaspp
         if [[ "$(uname)" == "Darwin" ]]; then
@@ -145,7 +147,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}/../lapackpp-install
-        key: lapackpp-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cc }}-${{ inputs.blas-backend }}-${{ steps.blaspp-rev.outputs.sha }}-${{ steps.lapackpp-rev.outputs.sha }}
+        key: lapackpp-ilp64-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cc }}-${{ inputs.blas-backend }}-${{ steps.blaspp-rev.outputs.sha }}-${{ steps.lapackpp-rev.outputs.sha }}
 
     - name: build lapackpp
       if: inputs.install-lapackpp == 'true' && steps.lapackpp-cache.outputs.cache-hit != 'true'
@@ -167,6 +169,7 @@ runs:
           -DCMAKE_INSTALL_PREFIX="$(pwd)/../lapackpp-install" \
           -Dblaspp_DIR="$(pwd)/../blaspp-install/lib/cmake/blaspp" \
           -Dbuild_tests=OFF \
+          -Dblas_int=int64 \
           ../lapackpp
         if [[ "$(uname)" == "Darwin" ]]; then
           jobs="$(sysctl -n hw.logicalcpu)"

--- a/CMake/MKL_sparse.cmake
+++ b/CMake/MKL_sparse.cmake
@@ -33,9 +33,15 @@ endif()
 
 if (_mkl_found_via_blaspp)
     # BLAS++ was built with MKL. Find the sparse BLAS header.
+    # mkl_spblas.h lives in different places depending on the MKL packaging:
+    #   - oneAPI:        $MKLROOT/include
+    #   - Debian apt:    /usr/include/mkl (and MKLROOT is usually unset)
+    # Search MKLROOT and the standard system prefixes, trying both the bare
+    # include dir and an mkl/ subdir.
     find_path(MKL_SPARSE_INCLUDE_DIR mkl_spblas.h
         HINTS ENV MKLROOT $ENV{MKLROOT}/include
-        PATH_SUFFIXES include)
+        PATHS /usr/include /usr/local/include
+        PATH_SUFFIXES include mkl include/mkl latest/include)
     if (MKL_SPARSE_INCLUDE_DIR)
         set(tmp TRUE)
         message(STATUS "  MKL sparse BLAS header found: ${MKL_SPARSE_INCLUDE_DIR}/mkl_spblas.h")

--- a/RandBLAS/sparse_data/csr_spmm_impl.hh
+++ b/RandBLAS/sparse_data/csr_spmm_impl.hh
@@ -48,6 +48,40 @@ using RandBLAS::SignedInteger;
 #define SignedInteger typename
 #endif
 
+// Core CSR SpMV accumulation:  Av[i] += alpha * sum_ell vals[ell] * v[colidxs[ell]].
+// Templated on UnitStride so the hot ColMajor case (incv == incAv == 1) drops the
+// runtime index multiplies; `if constexpr` keeps a single source for both variants.
+// The simd reduction permits FP reassociation, which breaks the serial dependence
+// on the accumulator (no effect when compiled without OpenMP -- the pragma is
+// ignored and the loop simply runs unvectorized, as with the rest of this file).
+template <bool UnitStride, typename T, SignedInteger sint_t>
+static void apply_csr_to_vector_ik_impl(
+    T alpha,
+    const T *vals, const sint_t *rowptr, const sint_t *colidxs,
+    const T *v, int64_t incv,
+    int64_t len_Av, T *Av, int64_t incAv
+) {
+    UNUSED(incv); UNUSED(incAv);
+    // ^ silence compiler complaints if UnitStride == true.
+    for (int64_t i = 0; i < len_Av; ++i) {
+        T Av_i_diff = 0.0;
+        #pragma omp simd reduction(+:Av_i_diff)
+        for (int64_t ell = rowptr[i]; ell < rowptr[i+1]; ++ell) {
+            int64_t j = colidxs[ell];
+            if constexpr (UnitStride) {
+                Av_i_diff += vals[ell] * v[j];
+            } else {
+                Av_i_diff += vals[ell] * v[j*incv];
+            }
+        }
+        if constexpr (UnitStride) {
+            Av[i] += alpha * Av_i_diff;
+        } else {
+            Av[i*incAv] += alpha * Av_i_diff;
+        }
+    }
+}
+
 template <typename T, SignedInteger sint_t = int64_t>
 static void apply_csr_to_vector_ik(
     T alpha,
@@ -62,14 +96,14 @@ static void apply_csr_to_vector_ik(
     T *Av,          // Av += alpha * A * v.
     int64_t incAv   // stride between elements of Av
 ) {
-    for (int64_t i = 0; i < len_Av; ++i) {
-        T Av_i_diff = 0.0;
-        for (int64_t ell = rowptr[i]; ell < rowptr[i+1]; ++ell) {
-            int j = colidxs[ell];
-            T Aij = vals[ell];
-            Av_i_diff += Aij * v[j*incv];
-        }
-        Av[i*incAv] += alpha * Av_i_diff;
+    // Unit stride (incv == incAv == 1) is the ColMajor case; specialize on it so
+    // the inner reduction carries no index multiplies. Other strides fall through.
+    if (incv == 1 && incAv == 1) {
+        apply_csr_to_vector_ik_impl<true>(
+            alpha, vals, rowptr, colidxs, v, incv, len_Av, Av, incAv);
+    } else {
+        apply_csr_to_vector_ik_impl<false>(
+            alpha, vals, rowptr, colidxs, v, incv, len_Av, Av, incAv);
     }
 }
 

--- a/RandBLAS/sparse_data/mkl_spmm_impl.hh
+++ b/RandBLAS/sparse_data/mkl_spmm_impl.hh
@@ -287,11 +287,6 @@ bool mkl_left_spmm(
     constexpr bool is_coo = std::is_same_v<SpMat, COOMatrix<T, sint_t>>;
     constexpr bool is_csc = std::is_same_v<SpMat, CSCMatrix<T, sint_t>>;
 
-    // MKL's mkl_sparse_d_mm does not support CSC format (returns NOT_SUPPORTED).
-    // Fall back to hand-rolled kernels for CSC matrices.
-    if constexpr (is_csc)
-        return false;
-
     // For COO matrices, RandBLAS allows A.n_rows >= d and A.n_cols >= m
     // (operating on a submatrix). MKL operates on the full matrix, so we
     // can only use MKL when dimensions match exactly and offsets are zero.
@@ -308,21 +303,40 @@ bool mkl_left_spmm(
     if (opB != blas::Op::NoTrans)
         return false;
 
-    auto h = make_mkl_handle(A);
+    // Build the MKL sparse handle and the operation to apply to it.
+    //   CSR / COO: the handle wraps A directly; the operation is opA.
+    //   CSC: mkl_sparse_?_mm does not accept CSC, but a CSC matrix's arrays ARE
+    //   a CSR matrix for A^T (transpose_as_csr shares colptr/rowidxs/vals). So
+    //   build the CSR-of-A^T handle and flip the operation (NoTrans <-> Trans),
+    //   which leaves op(A)*B unchanged. MKL supports SPARSE_OPERATION_TRANSPOSE
+    //   on CSR natively, so no explicit transpose or copy is materialized.
+    MKLSparseHandle h;
+    sparse_operation_t mkl_op;
+    if constexpr (is_csc) {
+        auto At = A.transpose();   // CSRMatrix view of A^T (shares A's arrays)
+        h = make_mkl_handle_csr(At);
+        mkl_op = (opA == blas::Op::NoTrans)
+            ? SPARSE_OPERATION_TRANSPOSE
+            : SPARSE_OPERATION_NON_TRANSPOSE;
+    } else {
+        h = make_mkl_handle(A);
+        mkl_op = to_mkl_op(opA);
+    }
+
     struct matrix_descr descr;
     descr.type = SPARSE_MATRIX_TYPE_GENERAL;
 
     sparse_status_t status;
     if constexpr (std::is_same_v<T, double>) {
         status = mkl_sparse_d_mm(
-            to_mkl_op(opA), alpha, h.handle, descr,
+            mkl_op, alpha, h.handle, descr,
             to_mkl_layout(layout),
             B, (MKL_INT)n, (MKL_INT)ldb,
             beta, C, (MKL_INT)ldc
         );
     } else if constexpr (std::is_same_v<T, float>) {
         status = mkl_sparse_s_mm(
-            to_mkl_op(opA), alpha, h.handle, descr,
+            mkl_op, alpha, h.handle, descr,
             to_mkl_layout(layout),
             B, (MKL_INT)n, (MKL_INT)ldb,
             beta, C, (MKL_INT)ldc

--- a/RandBLAS/sparse_data/spmm_dispatch.hh
+++ b/RandBLAS/sparse_data/spmm_dispatch.hh
@@ -69,21 +69,13 @@ void left_spmm(
 ) {
     using blas::Layout;
     using blas::Op;
-    // handle applying a transposed sparse matrix.
+    // Applying a transposed sparse matrix reduces to the NoTrans case on a
+    // zero-copy transpose view (CSR<->CSC, COO<->COO). MKL, when present,
+    // engages on the recursive NoTrans call: mkl_left_spmm handles all three
+    // formats -- including CSC, which it consumes as a CSR-of-transpose view --
+    // so the transposed CSR no longer needs to be pre-routed to MKL here to
+    // avoid a CSC fallback.
     if (opA == Op::Trans) {
-        // Try MKL first: it supports SPARSE_OPERATION_TRANSPOSE on CSR natively.
-        // Without this, the transpose trick below converts CSR→CSC, which MKL
-        // can't handle, causing unnecessary fallback RandBLAS-defined kernels.
-        #if defined(RandBLAS_HAS_MKL)
-        if constexpr (sizeof(typename SpMat::index_t) == sizeof(MKL_INT)) {
-            bool handled = RandBLAS::sparse_data::mkl::mkl_left_spmm(
-                layout, opA, opB, d, n, m, alpha,
-                A, ro_a, co_a, B, ldb, beta, C, ldc
-            );
-            if (handled)
-                return;
-        }
-        #endif
         auto At = A.transpose();
         left_spmm(layout, Op::NoTrans, opB, d, n, m, alpha, At, co_a, ro_a, B, ldb, beta, C, ldc);
         return;
@@ -141,7 +133,8 @@ void left_spmm(
     #if defined(RandBLAS_HAS_MKL)
     if constexpr (sizeof(typename SpMat::index_t) == sizeof(MKL_INT)) {
         // mkl_left_spmm returns false if it can't handle this case
-        // (e.g., COO with submatrix offsets, CSC format).
+        // (e.g., COO with submatrix offsets, or opB == Trans). CSC is handled
+        // via a CSR-of-transpose view inside mkl_left_spmm.
         // Beta is already applied to C above, so pass beta=1 to MKL
         // so it adds alpha*A*B to the existing (pre-scaled) C.
         bool handled = RandBLAS::sparse_data::mkl::mkl_left_spmm(

--- a/RandBLAS/testing/lapack_like.hh
+++ b/RandBLAS/testing/lapack_like.hh
@@ -61,22 +61,24 @@ void apply_reflectors(int64_t m, int64_t n, int64_t k, const T* vecs, int64_t ld
 
 template <typename T>
 int potrf_upper_sequential(int64_t n, T* A, int64_t lda) {
-    // Cache access is much better if the matrix is lower triangular.
-    // Could implement as lower triangular and then call transpose_square.
-    for (int64_t j = 0; j < n; ++j) {
-        if (A[j + j * lda] <= 0) {
-            std::cout << "Cholesky failed at index " << (j+1) << " of " << n << ".";
-            return j+1;
-        }
-        A[j + j * lda] = std::sqrt(A[j + j * lda]);
-        for (int64_t i = j + 1; i < n; ++i) {
-            A[j + i * lda] /= A[j + j * lda];
-        }
-        for (int64_t k = j + 1; k < n; ++k) {
-            for (int64_t i = k; i < n; ++i) {
-                A[k + i * lda] -= A[j + i * lda] * A[j + k * lda];
+    int64_t j, i, k;
+    for (j = 0; j < n; ++j) {
+        T* A_j = A + j*lda;                   // column j: rows 0..n-1, unit stride
+        for (i = 0; i < j; ++i) {
+            const T* A_i = A + i*lda;         // column i: already finalized
+            T s = A_j[i];
+            for (int64_t k = 0; k < i; ++k) {
+                s -= A_i[k] * A_j[k];         // dot of two column-prefixes — both stride 1
             }
+            A_j[i] = s / A_i[i];              // divide by U(i,i), the diagonal of column i
         }
+        T d = A_j[j];
+        for (k = 0; k < j; ++k)
+            d -= A_j[k] * A_j[k];             // walks down column j, stride 1
+        if (d <= 0) {
+            return j + 1;                     // leading minor of order j+1 not SPD
+        }
+        A_j[j] = std::sqrt(d);
     }
     return 0;
 }
@@ -107,7 +109,9 @@ int potrf_upper(int64_t n, T* A, int64_t lda, int64_t b = 64) {
         blas::syrk(layout, uplo, blas::Op::Trans,
             n - curr_b, curr_b, (T) -1.0, A12, lda, (T) 1.0, A22, lda
         );
-        potrf_upper(n-curr_b, A22, lda, b);
+        if (int info = potrf_upper(n-curr_b, A22, lda, b)) {
+            return info + curr_b;
+        }
     }
     return 0;
 }

--- a/examples/simple-kernel-benchmarks/spmm_performance.cc
+++ b/examples/simple-kernel-benchmarks/spmm_performance.cc
@@ -4,39 +4,44 @@
 // SPARSE-DENSE MATRIX MULTIPLICATION PERFORMANCE BENCHMARK
 // ============================================================================
 //
-// This benchmark answers four questions about RandBLAS SpMM performance:
+// Benchmarks the RandBLAS left_spmm kernels (B = S*A, with S sparse) across the
+// three sparse formats (CSR, CSC, COO) and BOTH dense-matrix layouts
+// (ColMajor, RowMajor). Driving left_spmm with both layouts is enough to
+// exercise every hand-rolled SpMM kernel, because the dispatch
+// (spmm_dispatch.hh) selects the kernel purely from (layout_opB, layout_C):
 //
-//   1. Which sparse format is best for left SpMM (B = S*A)?
-//      -> CSR, CSC, and COO are compared; CSR and COO (via MKL) tend to win.
+//   ColMajor dense -> apply_csr_jik_p11          / apply_csc_jki_p11
+//   RowMajor dense -> apply_csr_ikb_p1b_rowmajor / apply_csc_kib_1p1_rowmajor
+//   (COO delegates to the CSC kernels in both layouts, via apply_coo_via_csc)
 //
-//   2. Which sparse format is best for right SpMM (B = A*S)?
-//      -> CSC wins, because the dispatch transposes CSC to CSR and uses MKL
-//         with SPARSE_OPERATION_NON_TRANSPOSE — the fastest MKL path.
+// These are exactly the kernels that left_spmm and right_spmm TOGETHER reach.
+// right_spmm reduces to left_spmm by transposing the sparse operand (CSR<->CSC
+// view) and flipping the layout, so the old "right CSR (ColMajor)" path runs
+// the very same kernel as "left RowMajor CSC" does here (and old "right CSC" ==
+// "left RowMajor CSR"). Benchmarking left_spmm directly in both layouts hits
+// the same kernels while measuring each one without the right_spmm wrapper.
 //
-//   3. How much does MKL accelerate SpMM over hand-rolled kernels?
-//      -> For left SpMM, the benchmark runs CSR through both MKL and the
-//         hand-rolled kernel on the same data, giving a direct speedup ratio.
+// This benchmark answers:
+//   1. Which sparse format is fastest, for each dense layout?
+//   2. ColMajor vs RowMajor: how much does the dense layout matter? RowMajor
+//      routes to the BLAS-axpy-based kernels; ColMajor routes to the scalar
+//      gather (CSR) / scatter (CSC) kernels.
+//   3. (MKL builds only) How much does MKL accelerate over the hand-rolled
+//      kernels? The ColMajor table runs CSR through both left_spmm (which uses
+//      MKL when available) and the hand-rolled kernel called directly. This is
+//      the one path that does NOT go through left_spmm -- on an MKL build the
+//      dispatch always picks MKL, so the hand-rolled kernel is otherwise
+//      unreachable. It compiles out entirely when MKL is disabled.
 //
-//   4. Are left and right SpMM comparable in performance?
-//      -> The "SQUARE PROBLEMS" section uses d = m = n so both directions
-//         have identical FLOP counts and output sizes. A summary line after
-//         each config reports the best-of-each comparison.
-//
-// NOTE: This benchmarks the SpMM kernel directly (left_spmm / right_spmm),
-// not sketch_general. Any overhead from SKOP generation or sketch_general's
-// internal dispatch is not captured here. In practice SpMM dominates the
-// cost, so these results are a good proxy for sketching performance.
+// NOTE: benchmarks the SpMM kernel directly, not sketch_general. SpMM dominates
+// sketching cost, so these results are a good proxy for sketching performance.
 //
 // NOTATION:
-//   S  - Sparse matrix (m x n)
-//   A  - Dense input matrix
-//   B  - Dense result matrix
-//
-//   Left SpMM:  B(m x d) = S(m x n) * A(n x d)
-//   Right SpMM: B(d x n) = A(d x m) * S(m x n)
-//
-//   A "densify + GEMM" reference converts S to dense and calls BLAS GEMM,
-//   reporting the densify and GEMM times separately.
+//   S - sparse (m x n),  A - dense (n x d),  B - dense result (m x d)
+//   left_spmm:  B(m x d) = S(m x n) * A(n x d)
+//   The same logical A (and hence result B) is stored in BOTH ColMajor and
+//   RowMajor, so the two layouts compute the identical product and are
+//   directly comparable.
 //
 // USAGE:
 //   ./spmm_performance                             # default sweep
@@ -44,7 +49,7 @@
 //
 //   Default sweep (no arguments):
 //     Two sections, 10 trials each:
-//       1. SQUARE (d = m = n): sizes 100..2000, fair left-vs-right comparison
+//       1. SQUARE (d = m = n): sizes 100..2000
 //       2. RECTANGULAR: square S with small d, tall S, wide S
 //
 //   Single config (4+ arguments):
@@ -79,8 +84,9 @@ using blas::Layout;
 using blas::Op;
 
 // Calls the hand-rolled CSR left-multiply kernel directly, bypassing MKL.
-// Used to answer question 3 (MKL vs hand-rolled speedup). Replicates the
-// beta-scaling and kernel selection logic from spmm_dispatch.hh.
+// Used to answer question 3 (MKL vs hand-rolled speedup) on MKL builds, where
+// left_spmm would otherwise always pick MKL. Replicates the beta-scaling and
+// kernel selection logic from spmm_dispatch.hh.
 template <typename T, typename sint_t>
 void handrolled_left_spmm_csr(
     blas::Layout layout, int64_t d, int64_t n, int64_t m,
@@ -169,10 +175,20 @@ void print_densify_row(const std::string& name, long total, long dens, long gemm
               << "  (densify " << dens << " + GEMM " << gemm << ")\n";
 }
 
-// Run one complete benchmark configuration: generate matrices, time all
-// format x direction combinations, verify correctness, and print results.
+void print_table_header(const std::string& title) {
+    std::cout << "  " << title << "\n";
+    std::cout << "  " << std::setw(24) << std::left << "Kernel"
+              << std::setw(10) << std::right << "Min (us)"
+              << std::setw(10) << "Med (us)"
+              << std::setw(11) << "vs best" << "\n";
+    std::cout << "  " << std::string(55, '-') << "\n";
+}
+
+// Run one complete benchmark configuration: generate matrices, time every
+// format x layout combination through left_spmm, verify correctness, print.
 void run_config(int64_t m, int64_t n, int64_t d, double density, int num_trials) {
     using T = double;
+    namespace rbsd = RandBLAS::sparse_data;
     uint64_t seed = 12345;
 
     // Header
@@ -193,132 +209,100 @@ void run_config(int64_t m, int64_t n, int64_t d, double density, int num_trials)
 
     std::cout << "  nnz=" << S_coo.nnz << ", trials=" << num_trials << "\n\n";
 
-    // Generate dense matrices
-    auto state = next_state;
-    std::vector<T> A_left(n * d);
-    RandBLAS::DenseDist D_left(n, d);
-    state = RandBLAS::fill_dense(D_left, A_left.data(), state);
+    // One logical dense A (n x d), stored in both layouts so the ColMajor and
+    // RowMajor runs compute the identical product B = S*A.
+    //   ColMajor: A(i,j) = A_cm[i + j*n]   (ldA = n)
+    //   RowMajor: A(i,j) = A_rm[i*d + j]   (ldA = d)
+    std::vector<T> A_cm(n * d);
+    RandBLAS::DenseDist DA(n, d);
+    RandBLAS::fill_dense(DA, A_cm.data(), next_state);
+    std::vector<T> A_rm(n * d);
+    for (int64_t i = 0; i < n; ++i)
+        for (int64_t j = 0; j < d; ++j)
+            A_rm[i*d + j] = A_cm[i + j*n];
 
-    std::vector<T> A_right(d * m);
-    RandBLAS::DenseDist D_right(d, m);
-    state = RandBLAS::fill_dense(D_right, A_right.data(), state);
-
-    // Result and workspace buffers
-    std::vector<T> B_left(m * d);
-    std::vector<T> B_right(d * n);
+    // Result buffers (logical B is m x d in both layouts) and densify workspace.
+    std::vector<T> B_cm(m * d), B_rm(m * d);
     std::vector<T> S_dense(m * n);
 
-    // ---- Left SpMM: B = S * A ----
-    auto [min_l_csr, med_l_csr] = run_trials([&]() {
-        std::fill(B_left.begin(), B_left.end(), 0.0);
-        RandBLAS::sparse_data::left_spmm(Layout::ColMajor, Op::NoTrans, Op::NoTrans,
-            m, d, n, 1.0, S_csr, 0, 0, A_left.data(), n, 0.0, B_left.data(), m);
-    }, num_trials);
+    // Time left_spmm for one (format, layout): B = S * A, with A and B stored
+    // in `layout`. ldA / ldC follow from the layout (see notation above).
+    auto time_spmm = [&](const auto& S, Layout layout, std::vector<T>& B) {
+        const T* Aptr = (layout == Layout::ColMajor) ? A_cm.data() : A_rm.data();
+        int64_t ldA   = (layout == Layout::ColMajor) ? n : d;
+        int64_t ldB   = (layout == Layout::ColMajor) ? m : d;
+        return run_trials([&]() {
+            std::fill(B.begin(), B.end(), 0.0);
+            rbsd::left_spmm(layout, Op::NoTrans, Op::NoTrans, m, d, n,
+                            1.0, S, 0, 0, Aptr, ldA, 0.0, B.data(), ldB);
+        }, num_trials);
+    };
 
-    // Hand-rolled CSR: same data as above, but bypasses MKL (question 3).
-    long min_l_csr_hr = 0, med_l_csr_hr = 0;
+    // ---- ColMajor left_spmm (hits jik / jki kernels) ----
+    auto [min_cm_csr, med_cm_csr] = time_spmm(S_csr, Layout::ColMajor, B_cm);
+    auto [min_cm_csc, med_cm_csc] = time_spmm(S_csc, Layout::ColMajor, B_cm);
+    auto [min_cm_coo, med_cm_coo] = time_spmm(S_coo, Layout::ColMajor, B_cm);
+
+    // Hand-rolled CSR ColMajor: bypasses MKL for the MKL-vs-hand-rolled
+    // comparison. This is the only path that does not go through left_spmm.
     #if defined(RandBLAS_HAS_MKL)
+    long min_cm_csr_hr = 0, med_cm_csr_hr = 0;
     {
         auto [mn, md] = run_trials([&]() {
-            std::fill(B_left.begin(), B_left.end(), 0.0);
+            std::fill(B_cm.begin(), B_cm.end(), 0.0);
             handrolled_left_spmm_csr(Layout::ColMajor, m, d, n, 1.0,
-                S_csr, A_left.data(), n, 0.0, B_left.data(), m);
+                S_csr, A_cm.data(), n, 0.0, B_cm.data(), m);
         }, num_trials);
-        min_l_csr_hr = mn;
-        med_l_csr_hr = md;
+        min_cm_csr_hr = mn;
+        med_cm_csr_hr = md;
     }
     #endif
 
-    auto [min_l_csc, med_l_csc] = run_trials([&]() {
-        std::fill(B_left.begin(), B_left.end(), 0.0);
-        RandBLAS::sparse_data::left_spmm(Layout::ColMajor, Op::NoTrans, Op::NoTrans,
-            m, d, n, 1.0, S_csc, 0, 0, A_left.data(), n, 0.0, B_left.data(), m);
-    }, num_trials);
+    // ---- RowMajor left_spmm (hits ikb / kib kernels; the paths the old
+    //      right_spmm section reached, via the CSR<->CSC transpose) ----
+    auto [min_rm_csr, med_rm_csr] = time_spmm(S_csr, Layout::RowMajor, B_rm);
+    auto [min_rm_csc, med_rm_csc] = time_spmm(S_csc, Layout::RowMajor, B_rm);
+    auto [min_rm_coo, med_rm_coo] = time_spmm(S_coo, Layout::RowMajor, B_rm);
 
-    auto [min_l_coo, med_l_coo] = run_trials([&]() {
-        std::fill(B_left.begin(), B_left.end(), 0.0);
-        RandBLAS::sparse_data::left_spmm(Layout::ColMajor, Op::NoTrans, Op::NoTrans,
-            m, d, n, 1.0, S_coo, 0, 0, A_left.data(), n, 0.0, B_left.data(), m);
-    }, num_trials);
-
-    // ---- Right SpMM: B = A * S ----
-    auto [min_r_csr, med_r_csr] = run_trials([&]() {
-        std::fill(B_right.begin(), B_right.end(), 0.0);
-        RandBLAS::sparse_data::right_spmm(Layout::ColMajor, Op::NoTrans, Op::NoTrans,
-            d, n, m, 1.0, A_right.data(), d, S_csr, 0, 0, 0.0, B_right.data(), d);
-    }, num_trials);
-
-    auto [min_r_csc, med_r_csc] = run_trials([&]() {
-        std::fill(B_right.begin(), B_right.end(), 0.0);
-        RandBLAS::sparse_data::right_spmm(Layout::ColMajor, Op::NoTrans, Op::NoTrans,
-            d, n, m, 1.0, A_right.data(), d, S_csc, 0, 0, 0.0, B_right.data(), d);
-    }, num_trials);
-
-    auto [min_r_coo, med_r_coo] = run_trials([&]() {
-        std::fill(B_right.begin(), B_right.end(), 0.0);
-        RandBLAS::sparse_data::right_spmm(Layout::ColMajor, Op::NoTrans, Op::NoTrans,
-            d, n, m, 1.0, A_right.data(), d, S_coo, 0, 0, 0.0, B_right.data(), d);
-    }, num_trials);
-
-    // ---- Reference: densify + GEMM ----
-    auto [min_dens, min_gemm_left] = run_split_trials(
-        [&]() { RandBLAS::sparse_data::csr::csr_to_dense(S_csr, Layout::ColMajor, S_dense.data()); },
+    // ---- Reference: densify + GEMM, per layout ----
+    // The ColMajor reference (ref_cm) doubles as the correctness oracle.
+    std::vector<T> ref_cm(m * d);
+    auto [min_dens_cm, min_gemm_cm] = run_split_trials(
+        [&]() { rbsd::csr::csr_to_dense(S_csr, Layout::ColMajor, S_dense.data()); },
         [&]() {
-            std::fill(B_left.begin(), B_left.end(), 0.0);
+            std::fill(ref_cm.begin(), ref_cm.end(), 0.0);
             blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans,
-                       m, d, n, 1.0, S_dense.data(), m, A_left.data(), n, 0.0, B_left.data(), m);
+                       m, d, n, 1.0, S_dense.data(), m, A_cm.data(), n, 0.0, ref_cm.data(), m);
         }, num_trials);
-    long min_ref_left = min_dens + min_gemm_left;
+    long min_ref_cm = min_dens_cm + min_gemm_cm;
 
-    auto [min_dens2, min_gemm_right] = run_split_trials(
-        [&]() { RandBLAS::sparse_data::csr::csr_to_dense(S_csr, Layout::ColMajor, S_dense.data()); },
+    auto [min_dens_rm, min_gemm_rm] = run_split_trials(
+        [&]() { rbsd::csr::csr_to_dense(S_csr, Layout::RowMajor, S_dense.data()); },
         [&]() {
-            std::fill(B_right.begin(), B_right.end(), 0.0);
-            blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans,
-                       d, n, m, 1.0, A_right.data(), d, S_dense.data(), m, 0.0, B_right.data(), d);
+            std::fill(B_rm.begin(), B_rm.end(), 0.0);
+            blas::gemm(Layout::RowMajor, Op::NoTrans, Op::NoTrans,
+                       m, d, n, 1.0, S_dense.data(), n, A_rm.data(), d, 0.0, B_rm.data(), d);
         }, num_trials);
-    long min_ref_right = min_dens + min_gemm_right;
+    long min_ref_rm = min_dens_rm + min_gemm_rm;
 
-    // ---- Correctness: compare each SpMM path against densify + GEMM ----
+    // ---- Correctness: re-run each (format, layout) once, compare to ref_cm ----
     bool all_pass = true;
     int num_checks = 0;
+    std::vector<T> result(m * d);
 
-    auto check = [&](const std::string& label, auto& sparse, auto& dense_in, auto& result,
-                     int64_t r, int64_t c, int64_t k, bool is_left) {
-        // Densify this sparse matrix and compute reference via GEMM
-        std::vector<T> S_dens(m * n);
-        if constexpr (std::is_same_v<std::decay_t<decltype(sparse)>,
-                      RandBLAS::sparse_data::CSRMatrix<T, int64_t>>) {
-            RandBLAS::sparse_data::csr::csr_to_dense(sparse, Layout::ColMajor, S_dens.data());
-        } else if constexpr (std::is_same_v<std::decay_t<decltype(sparse)>,
-                             RandBLAS::sparse_data::CSCMatrix<T, int64_t>>) {
-            RandBLAS::sparse_data::csc::csc_to_dense(sparse, Layout::ColMajor, S_dens.data());
-        } else {
-            RandBLAS::sparse_data::coo::coo_to_dense(sparse, Layout::ColMajor, S_dens.data());
-        }
-
-        std::vector<T> ref(r * c, 0.0);
-        if (is_left) {
-            blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans,
-                       r, c, k, 1.0, S_dens.data(), m, dense_in.data(), n, 0.0, ref.data(), m);
-        } else {
-            blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans,
-                       r, c, k, 1.0, dense_in.data(), d, S_dens.data(), m, 0.0, ref.data(), d);
-        }
-
-        // Compute via SpMM and compare
+    auto check = [&](const std::string& label, const auto& S, Layout layout) {
+        const T* Aptr = (layout == Layout::ColMajor) ? A_cm.data() : A_rm.data();
+        int64_t ldA   = (layout == Layout::ColMajor) ? n : d;
+        int64_t ldC   = (layout == Layout::ColMajor) ? m : d;
         std::fill(result.begin(), result.end(), 0.0);
-        if (is_left) {
-            RandBLAS::sparse_data::left_spmm(Layout::ColMajor, Op::NoTrans, Op::NoTrans,
-                r, c, k, 1.0, sparse, 0, 0, dense_in.data(), n, 0.0, result.data(), m);
-        } else {
-            RandBLAS::sparse_data::right_spmm(Layout::ColMajor, Op::NoTrans, Op::NoTrans,
-                r, c, k, 1.0, dense_in.data(), d, sparse, 0, 0, 0.0, result.data(), d);
-        }
-
+        rbsd::left_spmm(layout, Op::NoTrans, Op::NoTrans, m, d, n,
+                        1.0, S, 0, 0, Aptr, ldA, 0.0, result.data(), ldC);
         double maxdiff = 0;
-        for (int64_t i = 0; i < r * c; ++i)
-            maxdiff = std::max(maxdiff, std::abs(result[i] - ref[i]));
+        for (int64_t i = 0; i < m; ++i)
+            for (int64_t j = 0; j < d; ++j) {
+                int64_t idx = (layout == Layout::ColMajor) ? (i + j*m) : (i*d + j);
+                maxdiff = std::max(maxdiff, std::abs(result[idx] - ref_cm[i + j*m]));
+            }
         num_checks++;
         if (maxdiff > 1e-10) {
             std::cout << "  FAIL: " << label << " max|diff|=" << std::scientific << maxdiff << "\n";
@@ -326,32 +310,25 @@ void run_config(int64_t m, int64_t n, int64_t d, double density, int num_trials)
         }
     };
 
-    check("left+CSR",  S_csr, A_left,  B_left,  m, d, n, true);
-    check("left+CSC",  S_csc, A_left,  B_left,  m, d, n, true);
-    check("left+COO",  S_coo, A_left,  B_left,  m, d, n, true);
-    check("right+CSR", S_csr, A_right, B_right, d, n, m, false);
-    check("right+CSC", S_csc, A_right, B_right, d, n, m, false);
-    check("right+COO", S_coo, A_right, B_right, d, n, m, false);
+    check("ColMajor+CSR", S_csr, Layout::ColMajor);
+    check("ColMajor+CSC", S_csc, Layout::ColMajor);
+    check("ColMajor+COO", S_coo, Layout::ColMajor);
+    check("RowMajor+CSR", S_csr, Layout::RowMajor);
+    check("RowMajor+CSC", S_csc, Layout::RowMajor);
+    check("RowMajor+COO", S_coo, Layout::RowMajor);
 
-    // Also verify hand-rolled CSR correctness
+    // Also verify the hand-rolled CSR path.
     #if defined(RandBLAS_HAS_MKL)
     {
-        std::vector<T> S_dens(m * n);
-        RandBLAS::sparse_data::csr::csr_to_dense(S_csr, Layout::ColMajor, S_dens.data());
-        std::vector<T> ref(m * d, 0.0);
-        blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans,
-                   m, d, n, 1.0, S_dens.data(), m, A_left.data(), n, 0.0, ref.data(), m);
-
-        std::fill(B_left.begin(), B_left.end(), 0.0);
+        std::fill(result.begin(), result.end(), 0.0);
         handrolled_left_spmm_csr(Layout::ColMajor, m, d, n, 1.0,
-            S_csr, A_left.data(), n, 0.0, B_left.data(), m);
-
+            S_csr, A_cm.data(), n, 0.0, result.data(), m);
         double maxdiff = 0;
         for (int64_t i = 0; i < m * d; ++i)
-            maxdiff = std::max(maxdiff, std::abs(B_left[i] - ref[i]));
+            maxdiff = std::max(maxdiff, std::abs(result[i] - ref_cm[i]));
         num_checks++;
         if (maxdiff > 1e-10) {
-            std::cout << "  FAIL: left+CSR(hand-rolled) max|diff|=" << std::scientific << maxdiff << "\n";
+            std::cout << "  FAIL: ColMajor+CSR(hand-rolled) max|diff|=" << std::scientific << maxdiff << "\n";
             all_pass = false;
         }
     }
@@ -364,61 +341,41 @@ void run_config(int64_t m, int64_t n, int64_t d, double density, int num_trials)
     // ---- Results tables ----
     std::cout << std::fixed << std::setprecision(2);
 
-    // Left SpMM table
+    // ColMajor table
     #if defined(RandBLAS_HAS_MKL)
-    long bl = std::min({min_l_csr, min_l_csr_hr, min_l_csc, min_l_coo});
+    long bcm = std::min({min_cm_csr, min_cm_csr_hr, min_cm_csc, min_cm_coo});
     #else
-    long bl = std::min({min_l_csr, min_l_csc, min_l_coo});
+    long bcm = std::min({min_cm_csr, min_cm_csc, min_cm_coo});
     #endif
-
-    std::cout << "  LEFT SPMM: B(" << m << "x" << d << ") = S * A\n";
-    std::cout << "  " << std::setw(24) << std::left << "Kernel"
-              << std::setw(10) << std::right << "Min (us)"
-              << std::setw(10) << "Med (us)"
-              << std::setw(11) << "vs best" << "\n";
-    std::cout << "  " << std::string(55, '-') << "\n";
-
+    print_table_header("LEFT SPMM, ColMajor dense: B(" + std::to_string(m) + "x" +
+                       std::to_string(d) + ") = S * A   (jik/jki kernels)");
     #if defined(RandBLAS_HAS_MKL)
-    print_row("CSR (MKL)",          min_l_csr,    med_l_csr,    bl);
-    print_row("CSR (hand-rolled)",  min_l_csr_hr, med_l_csr_hr, bl);
-    print_row("CSC (hand-rolled)",  min_l_csc,    med_l_csc,    bl);
-    print_row("COO (MKL)",          min_l_coo,    med_l_coo,    bl);
+    print_row("CSR (MKL)",         min_cm_csr,    med_cm_csr,    bcm);
+    print_row("CSR (hand-rolled)", min_cm_csr_hr, med_cm_csr_hr, bcm);
     #else
-    print_row("CSR (hand-rolled)",  min_l_csr, med_l_csr, bl);
-    print_row("CSC (hand-rolled)",  min_l_csc, med_l_csc, bl);
-    print_row("COO (hand-rolled)",  min_l_coo, med_l_coo, bl);
+    print_row("CSR",               min_cm_csr,    med_cm_csr,    bcm);
     #endif
-    print_densify_row("densify+GEMM", min_ref_left, min_dens, min_gemm_left, bl);
+    print_row("CSC",               min_cm_csc, med_cm_csc, bcm);
+    print_row("COO",               min_cm_coo, med_cm_coo, bcm);
+    print_densify_row("densify+GEMM", min_ref_cm, min_dens_cm, min_gemm_cm, bcm);
     std::cout << "\n";
 
-    // Right SpMM table
-    long br = std::min({min_r_csr, min_r_csc, min_r_coo});
-
-    std::cout << "  RIGHT SPMM: B(" << d << "x" << n << ") = A * S\n";
-    std::cout << "  " << std::setw(24) << std::left << "Kernel"
-              << std::setw(10) << std::right << "Min (us)"
-              << std::setw(10) << "Med (us)"
-              << std::setw(11) << "vs best" << "\n";
-    std::cout << "  " << std::string(55, '-') << "\n";
-
-    #if defined(RandBLAS_HAS_MKL)
-    print_row("CSR (MKL)",          min_r_csr, med_r_csr, br);
-    print_row("CSC (MKL via CSR)",  min_r_csc, med_r_csc, br);
-    print_row("COO (MKL)",          min_r_coo, med_r_coo, br);
-    #else
-    print_row("CSR (hand-rolled)",  min_r_csr, med_r_csr, br);
-    print_row("CSC (hand-rolled)",  min_r_csc, med_r_csc, br);
-    print_row("COO (hand-rolled)",  min_r_coo, med_r_coo, br);
-    #endif
-    print_densify_row("densify+GEMM", min_ref_right, min_dens, min_gemm_right, br);
+    // RowMajor table
+    long brm = std::min({min_rm_csr, min_rm_csc, min_rm_coo});
+    print_table_header("LEFT SPMM, RowMajor dense: B(" + std::to_string(m) + "x" +
+                       std::to_string(d) + ") = S * A   (ikb/kib kernels)");
+    print_row("CSR", min_rm_csr, med_rm_csr, brm);
+    print_row("CSC", min_rm_csc, med_rm_csc, brm);
+    print_row("COO", min_rm_coo, med_rm_coo, brm);
+    print_densify_row("densify+GEMM", min_ref_rm, min_dens_rm, min_gemm_rm, brm);
     std::cout << "\n";
 
-    // Summary: best left vs best right
-    std::cout << "  SUMMARY: best left " << bl << " us  |  best right " << br << " us  |  ";
-    if (bl <= br)
-        std::cout << "left " << std::fixed << std::setprecision(2) << (double)br / bl << "x faster\n";
+    // Summary: best ColMajor vs best RowMajor (same logical problem)
+    std::cout << "  SUMMARY: best ColMajor " << bcm << " us  |  best RowMajor " << brm << " us  |  ";
+    if (brm <= bcm)
+        std::cout << "RowMajor " << std::fixed << std::setprecision(2) << (double)bcm / brm << "x faster\n";
     else
-        std::cout << "right " << std::fixed << std::setprecision(2) << (double)bl / br << "x faster\n";
+        std::cout << "ColMajor " << std::fixed << std::setprecision(2) << (double)brm / bcm << "x faster\n";
     std::cout << "\n";
 }
 
@@ -434,8 +391,9 @@ int main(int argc, char** argv) {
 #endif
     std::cout << "\n";
     std::cout << "  S is m-by-n (sparse), A and B are dense.\n";
-    std::cout << "  Left SpMM:  B(m x d) = S(m x n) * A(n x d)\n";
-    std::cout << "  Right SpMM: B(d x n) = A(d x m) * S(m x n)\n\n";
+    std::cout << "  left_spmm:  B(m x d) = S(m x n) * A(n x d)\n";
+    std::cout << "  All kernels are reached through left_spmm; the ColMajor and\n";
+    std::cout << "  RowMajor dense layouts select the two kernel families.\n\n";
 
     if (argc >= 5) {
         // Single config mode

--- a/examples/simple-kernel-benchmarks/spmm_performance.cc
+++ b/examples/simple-kernel-benchmarks/spmm_performance.cc
@@ -4,7 +4,7 @@
 // SPARSE-DENSE MATRIX MULTIPLICATION PERFORMANCE BENCHMARK
 // ============================================================================
 //
-// Benchmarks the RandBLAS left_spmm kernels (B = S*A, with S sparse) across the
+// Benchmarks the RandBLAS left_spmm kernels (C = A*B, with A sparse) across the
 // three sparse formats (CSR, CSC, COO) and BOTH dense-matrix layouts
 // (ColMajor, RowMajor). Driving left_spmm with both layouts is enough to
 // exercise every hand-rolled SpMM kernel, because the dispatch
@@ -14,7 +14,7 @@
 //   RowMajor dense -> apply_csr_ikb_p1b_rowmajor / apply_csc_kib_1p1_rowmajor
 //   (COO delegates to the CSC kernels in both layouts, via apply_coo_via_csc)
 //
-// A fourth combination -- op(B)=Trans (computing C = S * A^T, the dense operand
+// A fourth combination -- op(B)=Trans (computing C = A * B^T, the dense operand
 // fed transposed) -- also routes to apply_csr_jik_p11 / apply_csc_jki_p11, but
 // with a STRIDED dense access (gather when C is ColMajor, strided store when C
 // is RowMajor) rather than the unit-stride NoTrans ColMajor pattern. MKL
@@ -38,16 +38,16 @@
 //      the one path that does NOT go through left_spmm -- on an MKL build the
 //      dispatch always picks MKL, so the hand-rolled kernel is otherwise
 //      unreachable. It compiles out entirely when MKL is disabled.
-//   4. op(B)=Trans (C = S * A^T): how much does the strided dense access cost
+//   4. op(B)=Trans (C = A * B^T): how much does the strided dense access cost
 //      relative to the unit-stride NoTrans path? Reported in two extra tables.
 //
 // NOTE: benchmarks the SpMM kernel directly, not sketch_general. SpMM dominates
 // sketching cost, so these results are a good proxy for sketching performance.
 //
 // NOTATION:
-//   S - sparse (m x n),  A - dense (n x d),  B - dense result (m x d)
-//   left_spmm:  B(m x d) = S(m x n) * A(n x d)
-//   The same logical A (and hence result B) is stored in BOTH ColMajor and
+//   A - sparse (m x n),  B - dense (n x d),  C - dense result (m x d)
+//   left_spmm:  C(m x d) = A(m x n) * B(n x d)
+//   The same logical B (and hence result C) is stored in BOTH ColMajor and
 //   RowMajor, so the two layouts compute the identical product and are
 //   directly comparable.
 //
@@ -58,7 +58,7 @@
 //   Default sweep (no arguments):
 //     Two sections, 10 trials each:
 //       1. SQUARE (d = m = n): sizes 100..2000
-//       2. RECTANGULAR: square S with small d, tall S, wide S
+//       2. RECTANGULAR: square A with small d, tall A, wide A
 //
 //   Single config (4+ arguments):
 //     One (m, n, d, density) configuration, default 20 trials.
@@ -94,7 +94,8 @@ using blas::Op;
 // Calls the hand-rolled CSR left-multiply kernel directly, bypassing MKL.
 // Used to answer question 3 (MKL vs hand-rolled speedup) on MKL builds, where
 // left_spmm would otherwise always pick MKL. Replicates the beta-scaling and
-// kernel selection logic from spmm_dispatch.hh.
+// kernel selection logic from spmm_dispatch.hh. Here A is sparse (CSR), B is the
+// dense input, C is the dense result -- matching the left_spmm convention.
 template <typename T, typename sint_t>
 void handrolled_left_spmm_csr(
     blas::Layout layout, int64_t d, int64_t n, int64_t m,
@@ -202,54 +203,54 @@ void run_config(int64_t m, int64_t n, int64_t d, double density, int num_trials)
     // Header
     std::string shape;
     if (m == n && d == m) shape = "all square";
-    else if (m == n) shape = "square S";
+    else if (m == n) shape = "square A";
     else if (m > n) shape = "tall";
     else shape = "wide";
 
-    std::cout << "--- S(" << m << "x" << n << "), d=" << d
+    std::cout << "--- A(" << m << "x" << n << "), d=" << d
               << ", density=" << std::setprecision(4) << density << " (" << shape << ") ---\n";
 
     // Generate one random COO matrix and convert to CSR/CSC so all three
     // formats represent the identical mathematical matrix.
-    auto [S_coo, next_state] = RandBLAS::testing::random_coo<T>(m, n, density, RandBLAS::RNGState<>(seed));
-    auto S_csr = S_coo.as_owning_csr();
-    auto S_csc = S_coo.as_owning_csc();
+    auto [A_coo, next_state] = RandBLAS::testing::random_coo<T>(m, n, density, RandBLAS::RNGState<>(seed));
+    auto A_csr = A_coo.as_owning_csr();
+    auto A_csc = A_coo.as_owning_csc();
 
-    std::cout << "  nnz=" << S_coo.nnz << ", trials=" << num_trials << "\n\n";
+    std::cout << "  nnz=" << A_coo.nnz << ", trials=" << num_trials << "\n\n";
 
-    // One logical dense A (n x d), stored in both layouts so the ColMajor and
-    // RowMajor runs compute the identical product B = S*A.
-    //   ColMajor: A(i,j) = A_cm[i + j*n]   (ldA = n)
-    //   RowMajor: A(i,j) = A_rm[i*d + j]   (ldA = d)
-    std::vector<T> A_cm(n * d);
-    RandBLAS::DenseDist DA(n, d);
-    RandBLAS::fill_dense(DA, A_cm.data(), next_state);
-    std::vector<T> A_rm(n * d);
+    // One logical dense B (n x d), stored in both layouts so the ColMajor and
+    // RowMajor runs compute the identical product C = A*B.
+    //   ColMajor: B(i,j) = B_cm[i + j*n]   (ldB = n)
+    //   RowMajor: B(i,j) = B_rm[i*d + j]   (ldB = d)
+    std::vector<T> B_cm(n * d);
+    RandBLAS::DenseDist DB(n, d);
+    RandBLAS::fill_dense(DB, B_cm.data(), next_state);
+    std::vector<T> B_rm(n * d);
     for (int64_t i = 0; i < n; ++i)
         for (int64_t j = 0; j < d; ++j)
-            A_rm[i*d + j] = A_cm[i + j*n];
+            B_rm[i*d + j] = B_cm[i + j*n];
 
-    // Result buffers (logical B is m x d in both layouts) and densify workspace.
-    std::vector<T> B_cm(m * d), B_rm(m * d);
-    std::vector<T> S_dense(m * n);
+    // Result buffers (logical C is m x d in both layouts) and densify workspace.
+    std::vector<T> C_cm(m * d), C_rm(m * d);
+    std::vector<T> A_dense(m * n);
 
-    // Time left_spmm for one (format, layout): B = S * A, with A and B stored
-    // in `layout`. ldA / ldC follow from the layout (see notation above).
-    auto time_spmm = [&](const auto& S, Layout layout, std::vector<T>& B) {
-        const T* Aptr = (layout == Layout::ColMajor) ? A_cm.data() : A_rm.data();
-        int64_t ldA   = (layout == Layout::ColMajor) ? n : d;
-        int64_t ldB   = (layout == Layout::ColMajor) ? m : d;
+    // Time left_spmm for one (format, layout): C = A * B, with B and C stored
+    // in `layout`. ldB / ldC follow from the layout (see notation above).
+    auto time_spmm = [&](const auto& A, Layout layout, std::vector<T>& C) {
+        const T* Bptr = (layout == Layout::ColMajor) ? B_cm.data() : B_rm.data();
+        int64_t ldB   = (layout == Layout::ColMajor) ? n : d;
+        int64_t ldC   = (layout == Layout::ColMajor) ? m : d;
         return run_trials([&]() {
-            std::fill(B.begin(), B.end(), 0.0);
+            std::fill(C.begin(), C.end(), 0.0);
             rbsd::left_spmm(layout, Op::NoTrans, Op::NoTrans, m, d, n,
-                            1.0, S, 0, 0, Aptr, ldA, 0.0, B.data(), ldB);
+                            1.0, A, 0, 0, Bptr, ldB, 0.0, C.data(), ldC);
         }, num_trials);
     };
 
     // ---- ColMajor left_spmm (hits jik / jki kernels) ----
-    auto [min_cm_csr, med_cm_csr] = time_spmm(S_csr, Layout::ColMajor, B_cm);
-    auto [min_cm_csc, med_cm_csc] = time_spmm(S_csc, Layout::ColMajor, B_cm);
-    auto [min_cm_coo, med_cm_coo] = time_spmm(S_coo, Layout::ColMajor, B_cm);
+    auto [min_cm_csr, med_cm_csr] = time_spmm(A_csr, Layout::ColMajor, C_cm);
+    auto [min_cm_csc, med_cm_csc] = time_spmm(A_csc, Layout::ColMajor, C_cm);
+    auto [min_cm_coo, med_cm_coo] = time_spmm(A_coo, Layout::ColMajor, C_cm);
 
     // Hand-rolled CSR ColMajor: bypasses MKL for the MKL-vs-hand-rolled
     // comparison. This is the only path that does not go through left_spmm.
@@ -257,9 +258,9 @@ void run_config(int64_t m, int64_t n, int64_t d, double density, int num_trials)
     long min_cm_csr_hr = 0, med_cm_csr_hr = 0;
     {
         auto [mn, md] = run_trials([&]() {
-            std::fill(B_cm.begin(), B_cm.end(), 0.0);
+            std::fill(C_cm.begin(), C_cm.end(), 0.0);
             handrolled_left_spmm_csr(Layout::ColMajor, m, d, n, 1.0,
-                S_csr, A_cm.data(), n, 0.0, B_cm.data(), m);
+                A_csr, B_cm.data(), n, 0.0, C_cm.data(), m);
         }, num_trials);
         min_cm_csr_hr = mn;
         med_cm_csr_hr = md;
@@ -268,54 +269,54 @@ void run_config(int64_t m, int64_t n, int64_t d, double density, int num_trials)
 
     // ---- RowMajor left_spmm (hits ikb / kib kernels; the paths the old
     //      right_spmm section reached, via the CSR<->CSC transpose) ----
-    auto [min_rm_csr, med_rm_csr] = time_spmm(S_csr, Layout::RowMajor, B_rm);
-    auto [min_rm_csc, med_rm_csc] = time_spmm(S_csc, Layout::RowMajor, B_rm);
-    auto [min_rm_coo, med_rm_coo] = time_spmm(S_coo, Layout::RowMajor, B_rm);
+    auto [min_rm_csr, med_rm_csr] = time_spmm(A_csr, Layout::RowMajor, C_rm);
+    auto [min_rm_csc, med_rm_csc] = time_spmm(A_csc, Layout::RowMajor, C_rm);
+    auto [min_rm_coo, med_rm_coo] = time_spmm(A_coo, Layout::RowMajor, C_rm);
 
-    // ---- Transposed dense (opB=Trans): C = S * A^T, dense operand fed
-    //      transposed so the SAME product S*A is computed. This routes to the
-    //      jik/jci kernels with a STRIDED dense access (incv != 1 when C is
+    // ---- Transposed dense (opB=Trans): C = A * B^T, dense operand fed
+    //      transposed so the SAME product A*B is computed. This routes to the
+    //      jik/jki kernels with a STRIDED dense access (incv != 1 when C is
     //      ColMajor, incAv != 1 when C is RowMajor) -- distinct from the
     //      unit-stride NoTrans ColMajor path, and the only sparse-NoTrans path
     //      MKL declines (so it stays hand-rolled on MKL builds).
-    //      A^T (d x n) needs no new storage: the transpose of the ColMajor n-x-d
-    //      buffer IS the RowMajor buffer, so ColMajor-A^T == A_rm, RowMajor == A_cm.
-    auto time_spmm_t = [&](const auto& S, Layout layout, std::vector<T>& B) {
-        const T* ATptr = (layout == Layout::ColMajor) ? A_rm.data() : A_cm.data();
-        int64_t ldAT   = (layout == Layout::ColMajor) ? d : n;
-        int64_t ldB    = (layout == Layout::ColMajor) ? m : d;
+    //      B^T (d x n) needs no new storage: the transpose of the ColMajor n-x-d
+    //      buffer IS the RowMajor buffer, so ColMajor-B^T == B_rm, RowMajor == B_cm.
+    auto time_spmm_t = [&](const auto& A, Layout layout, std::vector<T>& C) {
+        const T* BTptr = (layout == Layout::ColMajor) ? B_rm.data() : B_cm.data();
+        int64_t ldBT   = (layout == Layout::ColMajor) ? d : n;
+        int64_t ldC    = (layout == Layout::ColMajor) ? m : d;
         return run_trials([&]() {
-            std::fill(B.begin(), B.end(), 0.0);
+            std::fill(C.begin(), C.end(), 0.0);
             rbsd::left_spmm(layout, Op::NoTrans, Op::Trans, m, d, n,
-                            1.0, S, 0, 0, ATptr, ldAT, 0.0, B.data(), ldB);
+                            1.0, A, 0, 0, BTptr, ldBT, 0.0, C.data(), ldC);
         }, num_trials);
     };
 
-    auto [min_tcm_csr, med_tcm_csr] = time_spmm_t(S_csr, Layout::ColMajor, B_cm);
-    auto [min_tcm_csc, med_tcm_csc] = time_spmm_t(S_csc, Layout::ColMajor, B_cm);
-    auto [min_tcm_coo, med_tcm_coo] = time_spmm_t(S_coo, Layout::ColMajor, B_cm);
-    auto [min_trm_csr, med_trm_csr] = time_spmm_t(S_csr, Layout::RowMajor, B_rm);
-    auto [min_trm_csc, med_trm_csc] = time_spmm_t(S_csc, Layout::RowMajor, B_rm);
-    auto [min_trm_coo, med_trm_coo] = time_spmm_t(S_coo, Layout::RowMajor, B_rm);
+    auto [min_tcm_csr, med_tcm_csr] = time_spmm_t(A_csr, Layout::ColMajor, C_cm);
+    auto [min_tcm_csc, med_tcm_csc] = time_spmm_t(A_csc, Layout::ColMajor, C_cm);
+    auto [min_tcm_coo, med_tcm_coo] = time_spmm_t(A_coo, Layout::ColMajor, C_cm);
+    auto [min_trm_csr, med_trm_csr] = time_spmm_t(A_csr, Layout::RowMajor, C_rm);
+    auto [min_trm_csc, med_trm_csc] = time_spmm_t(A_csc, Layout::RowMajor, C_rm);
+    auto [min_trm_coo, med_trm_coo] = time_spmm_t(A_coo, Layout::RowMajor, C_rm);
 
     // ---- Reference: densify + GEMM, per layout ----
     // The ColMajor reference (ref_cm) doubles as the correctness oracle.
     std::vector<T> ref_cm(m * d);
     auto [min_dens_cm, min_gemm_cm] = run_split_trials(
-        [&]() { rbsd::csr::csr_to_dense(S_csr, Layout::ColMajor, S_dense.data()); },
+        [&]() { rbsd::csr::csr_to_dense(A_csr, Layout::ColMajor, A_dense.data()); },
         [&]() {
             std::fill(ref_cm.begin(), ref_cm.end(), 0.0);
             blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans,
-                       m, d, n, 1.0, S_dense.data(), m, A_cm.data(), n, 0.0, ref_cm.data(), m);
+                       m, d, n, 1.0, A_dense.data(), m, B_cm.data(), n, 0.0, ref_cm.data(), m);
         }, num_trials);
     long min_ref_cm = min_dens_cm + min_gemm_cm;
 
     auto [min_dens_rm, min_gemm_rm] = run_split_trials(
-        [&]() { rbsd::csr::csr_to_dense(S_csr, Layout::RowMajor, S_dense.data()); },
+        [&]() { rbsd::csr::csr_to_dense(A_csr, Layout::RowMajor, A_dense.data()); },
         [&]() {
-            std::fill(B_rm.begin(), B_rm.end(), 0.0);
+            std::fill(C_rm.begin(), C_rm.end(), 0.0);
             blas::gemm(Layout::RowMajor, Op::NoTrans, Op::NoTrans,
-                       m, d, n, 1.0, S_dense.data(), n, A_rm.data(), d, 0.0, B_rm.data(), d);
+                       m, d, n, 1.0, A_dense.data(), n, B_rm.data(), d, 0.0, C_rm.data(), d);
         }, num_trials);
     long min_ref_rm = min_dens_rm + min_gemm_rm;
 
@@ -324,23 +325,23 @@ void run_config(int64_t m, int64_t n, int64_t d, double density, int num_trials)
     int num_checks = 0;
     std::vector<T> result(m * d);
 
-    // All NoTrans and Trans paths compute the same logical product S*A, so they
+    // All NoTrans and Trans paths compute the same logical product A*B, so they
     // are all checked against the single ColMajor oracle ref_cm. For opB=Trans
-    // the dense operand is A^T (== the other layout's buffer; see timing above).
-    auto check = [&](const std::string& label, const auto& S, Layout layout, Op opB) {
-        const T* Aptr;
-        int64_t ldA;
+    // the dense operand is B^T (== the other layout's buffer; see timing above).
+    auto check = [&](const std::string& label, const auto& A, Layout layout, Op opB) {
+        const T* Bptr;
+        int64_t ldB;
         if (opB == Op::NoTrans) {
-            Aptr = (layout == Layout::ColMajor) ? A_cm.data() : A_rm.data();
-            ldA  = (layout == Layout::ColMajor) ? n : d;
+            Bptr = (layout == Layout::ColMajor) ? B_cm.data() : B_rm.data();
+            ldB  = (layout == Layout::ColMajor) ? n : d;
         } else {
-            Aptr = (layout == Layout::ColMajor) ? A_rm.data() : A_cm.data();
-            ldA  = (layout == Layout::ColMajor) ? d : n;
+            Bptr = (layout == Layout::ColMajor) ? B_rm.data() : B_cm.data();
+            ldB  = (layout == Layout::ColMajor) ? d : n;
         }
         int64_t ldC = (layout == Layout::ColMajor) ? m : d;
         std::fill(result.begin(), result.end(), 0.0);
         rbsd::left_spmm(layout, Op::NoTrans, opB, m, d, n,
-                        1.0, S, 0, 0, Aptr, ldA, 0.0, result.data(), ldC);
+                        1.0, A, 0, 0, Bptr, ldB, 0.0, result.data(), ldC);
         double maxdiff = 0;
         for (int64_t i = 0; i < m; ++i)
             for (int64_t j = 0; j < d; ++j) {
@@ -354,25 +355,25 @@ void run_config(int64_t m, int64_t n, int64_t d, double density, int num_trials)
         }
     };
 
-    check("ColMajor+CSR",      S_csr, Layout::ColMajor, Op::NoTrans);
-    check("ColMajor+CSC",      S_csc, Layout::ColMajor, Op::NoTrans);
-    check("ColMajor+COO",      S_coo, Layout::ColMajor, Op::NoTrans);
-    check("RowMajor+CSR",      S_csr, Layout::RowMajor, Op::NoTrans);
-    check("RowMajor+CSC",      S_csc, Layout::RowMajor, Op::NoTrans);
-    check("RowMajor+COO",      S_coo, Layout::RowMajor, Op::NoTrans);
-    check("ColMajor+CSR(B^T)", S_csr, Layout::ColMajor, Op::Trans);
-    check("ColMajor+CSC(B^T)", S_csc, Layout::ColMajor, Op::Trans);
-    check("ColMajor+COO(B^T)", S_coo, Layout::ColMajor, Op::Trans);
-    check("RowMajor+CSR(B^T)", S_csr, Layout::RowMajor, Op::Trans);
-    check("RowMajor+CSC(B^T)", S_csc, Layout::RowMajor, Op::Trans);
-    check("RowMajor+COO(B^T)", S_coo, Layout::RowMajor, Op::Trans);
+    check("ColMajor+CSR",      A_csr, Layout::ColMajor, Op::NoTrans);
+    check("ColMajor+CSC",      A_csc, Layout::ColMajor, Op::NoTrans);
+    check("ColMajor+COO",      A_coo, Layout::ColMajor, Op::NoTrans);
+    check("RowMajor+CSR",      A_csr, Layout::RowMajor, Op::NoTrans);
+    check("RowMajor+CSC",      A_csc, Layout::RowMajor, Op::NoTrans);
+    check("RowMajor+COO",      A_coo, Layout::RowMajor, Op::NoTrans);
+    check("ColMajor+CSR(B^T)", A_csr, Layout::ColMajor, Op::Trans);
+    check("ColMajor+CSC(B^T)", A_csc, Layout::ColMajor, Op::Trans);
+    check("ColMajor+COO(B^T)", A_coo, Layout::ColMajor, Op::Trans);
+    check("RowMajor+CSR(B^T)", A_csr, Layout::RowMajor, Op::Trans);
+    check("RowMajor+CSC(B^T)", A_csc, Layout::RowMajor, Op::Trans);
+    check("RowMajor+COO(B^T)", A_coo, Layout::RowMajor, Op::Trans);
 
     // Also verify the hand-rolled CSR path.
     #if defined(RandBLAS_HAS_MKL)
     {
         std::fill(result.begin(), result.end(), 0.0);
         handrolled_left_spmm_csr(Layout::ColMajor, m, d, n, 1.0,
-            S_csr, A_cm.data(), n, 0.0, result.data(), m);
+            A_csr, B_cm.data(), n, 0.0, result.data(), m);
         double maxdiff = 0;
         for (int64_t i = 0; i < m * d; ++i)
             maxdiff = std::max(maxdiff, std::abs(result[i] - ref_cm[i]));
@@ -397,8 +398,8 @@ void run_config(int64_t m, int64_t n, int64_t d, double density, int num_trials)
     #else
     long bcm = std::min({min_cm_csr, min_cm_csc, min_cm_coo});
     #endif
-    print_table_header("LEFT SPMM, ColMajor dense: B(" + std::to_string(m) + "x" +
-                       std::to_string(d) + ") = S * A   (jik/jki kernels)");
+    print_table_header("LEFT SPMM, ColMajor dense: C(" + std::to_string(m) + "x" +
+                       std::to_string(d) + ") = A * B   (jik/jki kernels)");
     #if defined(RandBLAS_HAS_MKL)
     print_row("CSR (MKL)",         min_cm_csr,    med_cm_csr,    bcm);
     print_row("CSR (hand-rolled)", min_cm_csr_hr, med_cm_csr_hr, bcm);
@@ -412,25 +413,25 @@ void run_config(int64_t m, int64_t n, int64_t d, double density, int num_trials)
 
     // RowMajor table
     long brm = std::min({min_rm_csr, min_rm_csc, min_rm_coo});
-    print_table_header("LEFT SPMM, RowMajor dense: B(" + std::to_string(m) + "x" +
-                       std::to_string(d) + ") = S * A   (ikb/kib kernels)");
+    print_table_header("LEFT SPMM, RowMajor dense: C(" + std::to_string(m) + "x" +
+                       std::to_string(d) + ") = A * B   (ikb/kib kernels)");
     print_row("CSR", min_rm_csr, med_rm_csr, brm);
     print_row("CSC", min_rm_csc, med_rm_csc, brm);
     print_row("COO", min_rm_coo, med_rm_coo, brm);
     print_densify_row("densify+GEMM", min_ref_rm, min_dens_rm, min_gemm_rm, brm);
     std::cout << "\n";
 
-    // Transposed-dense tables (opB=Trans -> jik/jci with strided dense access).
+    // Transposed-dense tables (opB=Trans -> jik/jki with strided dense access).
     // MKL declines opB=Trans, so these stay hand-rolled even on MKL builds.
     long btc = std::min({min_tcm_csr, min_tcm_csc, min_tcm_coo});
-    print_table_header("LEFT SPMM, transposed dense, ColMajor C: C = S * A^T   (opB=Trans -> jik/jci, strided gather)");
+    print_table_header("LEFT SPMM, transposed dense, ColMajor C: C = A * B^T   (opB=Trans -> jik/jki, strided gather)");
     print_row("CSR", min_tcm_csr, med_tcm_csr, btc);
     print_row("CSC", min_tcm_csc, med_tcm_csc, btc);
     print_row("COO", min_tcm_coo, med_tcm_coo, btc);
     std::cout << "\n";
 
     long btr = std::min({min_trm_csr, min_trm_csc, min_trm_coo});
-    print_table_header("LEFT SPMM, transposed dense, RowMajor C: C = S * A^T   (opB=Trans -> jik/jci, strided store)");
+    print_table_header("LEFT SPMM, transposed dense, RowMajor C: C = A * B^T   (opB=Trans -> jik/jki, strided store)");
     print_row("CSR", min_trm_csr, med_trm_csr, btr);
     print_row("CSC", min_trm_csc, med_trm_csc, btr);
     print_row("COO", min_trm_coo, med_trm_coo, btr);
@@ -459,8 +460,8 @@ int main(int argc, char** argv) {
     std::cout << "MKL support: DISABLED\n";
 #endif
     std::cout << "\n";
-    std::cout << "  S is m-by-n (sparse), A and B are dense.\n";
-    std::cout << "  left_spmm:  B(m x d) = S(m x n) * A(n x d)\n";
+    std::cout << "  A is m-by-n (sparse), B and C are dense.\n";
+    std::cout << "  left_spmm:  C(m x d) = A(m x n) * B(n x d)\n";
     std::cout << "  All kernels are reached through left_spmm; the ColMajor and\n";
     std::cout << "  RowMajor dense layouts select the two kernel families.\n\n";
 

--- a/examples/simple-kernel-benchmarks/spmm_performance.cc
+++ b/examples/simple-kernel-benchmarks/spmm_performance.cc
@@ -14,6 +14,12 @@
 //   RowMajor dense -> apply_csr_ikb_p1b_rowmajor / apply_csc_kib_1p1_rowmajor
 //   (COO delegates to the CSC kernels in both layouts, via apply_coo_via_csc)
 //
+// A fourth combination -- op(B)=Trans (computing C = S * A^T, the dense operand
+// fed transposed) -- also routes to apply_csr_jik_p11 / apply_csc_jki_p11, but
+// with a STRIDED dense access (gather when C is ColMajor, strided store when C
+// is RowMajor) rather than the unit-stride NoTrans ColMajor pattern. MKL
+// declines op(B)=Trans, so it is hand-rolled even on MKL builds.
+//
 // These are exactly the kernels that left_spmm and right_spmm TOGETHER reach.
 // right_spmm reduces to left_spmm by transposing the sparse operand (CSR<->CSC
 // view) and flipping the layout, so the old "right CSR (ColMajor)" path runs
@@ -32,6 +38,8 @@
 //      the one path that does NOT go through left_spmm -- on an MKL build the
 //      dispatch always picks MKL, so the hand-rolled kernel is otherwise
 //      unreachable. It compiles out entirely when MKL is disabled.
+//   4. op(B)=Trans (C = S * A^T): how much does the strided dense access cost
+//      relative to the unit-stride NoTrans path? Reported in two extra tables.
 //
 // NOTE: benchmarks the SpMM kernel directly, not sketch_general. SpMM dominates
 // sketching cost, so these results are a good proxy for sketching performance.
@@ -264,6 +272,32 @@ void run_config(int64_t m, int64_t n, int64_t d, double density, int num_trials)
     auto [min_rm_csc, med_rm_csc] = time_spmm(S_csc, Layout::RowMajor, B_rm);
     auto [min_rm_coo, med_rm_coo] = time_spmm(S_coo, Layout::RowMajor, B_rm);
 
+    // ---- Transposed dense (opB=Trans): C = S * A^T, dense operand fed
+    //      transposed so the SAME product S*A is computed. This routes to the
+    //      jik/jci kernels with a STRIDED dense access (incv != 1 when C is
+    //      ColMajor, incAv != 1 when C is RowMajor) -- distinct from the
+    //      unit-stride NoTrans ColMajor path, and the only sparse-NoTrans path
+    //      MKL declines (so it stays hand-rolled on MKL builds).
+    //      A^T (d x n) needs no new storage: the transpose of the ColMajor n-x-d
+    //      buffer IS the RowMajor buffer, so ColMajor-A^T == A_rm, RowMajor == A_cm.
+    auto time_spmm_t = [&](const auto& S, Layout layout, std::vector<T>& B) {
+        const T* ATptr = (layout == Layout::ColMajor) ? A_rm.data() : A_cm.data();
+        int64_t ldAT   = (layout == Layout::ColMajor) ? d : n;
+        int64_t ldB    = (layout == Layout::ColMajor) ? m : d;
+        return run_trials([&]() {
+            std::fill(B.begin(), B.end(), 0.0);
+            rbsd::left_spmm(layout, Op::NoTrans, Op::Trans, m, d, n,
+                            1.0, S, 0, 0, ATptr, ldAT, 0.0, B.data(), ldB);
+        }, num_trials);
+    };
+
+    auto [min_tcm_csr, med_tcm_csr] = time_spmm_t(S_csr, Layout::ColMajor, B_cm);
+    auto [min_tcm_csc, med_tcm_csc] = time_spmm_t(S_csc, Layout::ColMajor, B_cm);
+    auto [min_tcm_coo, med_tcm_coo] = time_spmm_t(S_coo, Layout::ColMajor, B_cm);
+    auto [min_trm_csr, med_trm_csr] = time_spmm_t(S_csr, Layout::RowMajor, B_rm);
+    auto [min_trm_csc, med_trm_csc] = time_spmm_t(S_csc, Layout::RowMajor, B_rm);
+    auto [min_trm_coo, med_trm_coo] = time_spmm_t(S_coo, Layout::RowMajor, B_rm);
+
     // ---- Reference: densify + GEMM, per layout ----
     // The ColMajor reference (ref_cm) doubles as the correctness oracle.
     std::vector<T> ref_cm(m * d);
@@ -290,12 +324,22 @@ void run_config(int64_t m, int64_t n, int64_t d, double density, int num_trials)
     int num_checks = 0;
     std::vector<T> result(m * d);
 
-    auto check = [&](const std::string& label, const auto& S, Layout layout) {
-        const T* Aptr = (layout == Layout::ColMajor) ? A_cm.data() : A_rm.data();
-        int64_t ldA   = (layout == Layout::ColMajor) ? n : d;
-        int64_t ldC   = (layout == Layout::ColMajor) ? m : d;
+    // All NoTrans and Trans paths compute the same logical product S*A, so they
+    // are all checked against the single ColMajor oracle ref_cm. For opB=Trans
+    // the dense operand is A^T (== the other layout's buffer; see timing above).
+    auto check = [&](const std::string& label, const auto& S, Layout layout, Op opB) {
+        const T* Aptr;
+        int64_t ldA;
+        if (opB == Op::NoTrans) {
+            Aptr = (layout == Layout::ColMajor) ? A_cm.data() : A_rm.data();
+            ldA  = (layout == Layout::ColMajor) ? n : d;
+        } else {
+            Aptr = (layout == Layout::ColMajor) ? A_rm.data() : A_cm.data();
+            ldA  = (layout == Layout::ColMajor) ? d : n;
+        }
+        int64_t ldC = (layout == Layout::ColMajor) ? m : d;
         std::fill(result.begin(), result.end(), 0.0);
-        rbsd::left_spmm(layout, Op::NoTrans, Op::NoTrans, m, d, n,
+        rbsd::left_spmm(layout, Op::NoTrans, opB, m, d, n,
                         1.0, S, 0, 0, Aptr, ldA, 0.0, result.data(), ldC);
         double maxdiff = 0;
         for (int64_t i = 0; i < m; ++i)
@@ -310,12 +354,18 @@ void run_config(int64_t m, int64_t n, int64_t d, double density, int num_trials)
         }
     };
 
-    check("ColMajor+CSR", S_csr, Layout::ColMajor);
-    check("ColMajor+CSC", S_csc, Layout::ColMajor);
-    check("ColMajor+COO", S_coo, Layout::ColMajor);
-    check("RowMajor+CSR", S_csr, Layout::RowMajor);
-    check("RowMajor+CSC", S_csc, Layout::RowMajor);
-    check("RowMajor+COO", S_coo, Layout::RowMajor);
+    check("ColMajor+CSR",      S_csr, Layout::ColMajor, Op::NoTrans);
+    check("ColMajor+CSC",      S_csc, Layout::ColMajor, Op::NoTrans);
+    check("ColMajor+COO",      S_coo, Layout::ColMajor, Op::NoTrans);
+    check("RowMajor+CSR",      S_csr, Layout::RowMajor, Op::NoTrans);
+    check("RowMajor+CSC",      S_csc, Layout::RowMajor, Op::NoTrans);
+    check("RowMajor+COO",      S_coo, Layout::RowMajor, Op::NoTrans);
+    check("ColMajor+CSR(B^T)", S_csr, Layout::ColMajor, Op::Trans);
+    check("ColMajor+CSC(B^T)", S_csc, Layout::ColMajor, Op::Trans);
+    check("ColMajor+COO(B^T)", S_coo, Layout::ColMajor, Op::Trans);
+    check("RowMajor+CSR(B^T)", S_csr, Layout::RowMajor, Op::Trans);
+    check("RowMajor+CSC(B^T)", S_csc, Layout::RowMajor, Op::Trans);
+    check("RowMajor+COO(B^T)", S_coo, Layout::RowMajor, Op::Trans);
 
     // Also verify the hand-rolled CSR path.
     #if defined(RandBLAS_HAS_MKL)
@@ -370,13 +420,32 @@ void run_config(int64_t m, int64_t n, int64_t d, double density, int num_trials)
     print_densify_row("densify+GEMM", min_ref_rm, min_dens_rm, min_gemm_rm, brm);
     std::cout << "\n";
 
-    // Summary: best ColMajor vs best RowMajor (same logical problem)
-    std::cout << "  SUMMARY: best ColMajor " << bcm << " us  |  best RowMajor " << brm << " us  |  ";
+    // Transposed-dense tables (opB=Trans -> jik/jci with strided dense access).
+    // MKL declines opB=Trans, so these stay hand-rolled even on MKL builds.
+    long btc = std::min({min_tcm_csr, min_tcm_csc, min_tcm_coo});
+    print_table_header("LEFT SPMM, transposed dense, ColMajor C: C = S * A^T   (opB=Trans -> jik/jci, strided gather)");
+    print_row("CSR", min_tcm_csr, med_tcm_csr, btc);
+    print_row("CSC", min_tcm_csc, med_tcm_csc, btc);
+    print_row("COO", min_tcm_coo, med_tcm_coo, btc);
+    std::cout << "\n";
+
+    long btr = std::min({min_trm_csr, min_trm_csc, min_trm_coo});
+    print_table_header("LEFT SPMM, transposed dense, RowMajor C: C = S * A^T   (opB=Trans -> jik/jci, strided store)");
+    print_row("CSR", min_trm_csr, med_trm_csr, btr);
+    print_row("CSC", min_trm_csc, med_trm_csc, btr);
+    print_row("COO", min_trm_coo, med_trm_coo, btr);
+    std::cout << "\n";
+
+    // Summary: best NoTrans (ColMajor vs RowMajor) and the transposed-dense cost.
+    long bnt = std::min(bcm, brm);
+    long bt  = std::min(btc, btr);
+    std::cout << "  SUMMARY: best NoTrans ColMajor " << bcm << " us  |  best NoTrans RowMajor " << brm << " us  |  ";
     if (brm <= bcm)
         std::cout << "RowMajor " << std::fixed << std::setprecision(2) << (double)bcm / brm << "x faster\n";
     else
         std::cout << "ColMajor " << std::fixed << std::setprecision(2) << (double)brm / bcm << "x faster\n";
-    std::cout << "\n";
+    std::cout << "           best transposed-dense (opB=Trans) " << bt << " us  ("
+              << std::fixed << std::setprecision(2) << (double)bt / bnt << "x vs best NoTrans)\n\n";
 }
 
 int main(int argc, char** argv) {

--- a/test/test_exceptions.cc
+++ b/test/test_exceptions.cc
@@ -28,7 +28,7 @@ TEST_F(TestExceptions, randblas_require_expr_arg) {
         randblas_require(flag > 1);
     } catch (RandBLAS::Error &e) {
         std::string message{e.what()};
-        flag = (int) message.find("flag > 1") != std::string::npos;
+        flag = message.find("flag > 1") != std::string::npos;
     }
     ASSERT_TRUE(flag);
 }


### PR DESCRIPTION
Collects sparse-SpMM kernel/benchmark work and first-class MKL sparse-BLAS support
(plus the CI plumbing to actually build and test it), Non-MKL builds and the full test suite
are unaffected throughout; the MKL sparse path is now exercised in CI for the first time.

  ## Sparse SpMM kernels
**Speed up CSR ColMajor `left_spmm` ~1.8–2×** (`5ae2093`). `apply_csr_to_vector_ik` the hot inner kernel behind `apply_csr_jik_p11`) gets a `#pragma omp simd reduction` on the inner sparse dot-product — the win is FP **reassociation** (multiple partial sums break the serial accumulator chain; isolated, this is the entire effect of ` ffast-math` on M3, while `-ffp-contract=fast` and `-mcpu=native` do nothing). A unit-stride `if constexpr` specialization (`incv==incAv==1`, the ColMajor case) drops index multiplies for another ~5–8%. Also fixes a latent `int`→`int64_t` truncation of the column index in the general-stride path. Measured (M3, density 0.01, min µs):

| config | OMP=1 | OMP=4 |
|---|---|---|
| 2000² d=200 | 3886 → 2169 | 1188 → 621 |
| 2000² d=2000 | 44197 → 22156 | 12730 → 6959 |

CSC was evaluated but its scatter kernel is latency-bound and saw no benefit, so it's left unchanged.

  ## MKL sparse BLAS
  - **Handle CSC in `mkl_left_spmm` as a CSR-of-transpose view** (`7fb84cd`).
    MKL's `mkl_sparse_?_mm` rejects CSC, so CSC previously fell back to the
    hand-rolled scatter kernel. But a CSC matrix's `(colptr, rowidxs, vals)` arrays
    *are* a CSR matrix for `Aᵀ` (exactly `transpose_as_csr`'s zero-copy view), so
    we build that CSR-of-`Aᵀ` handle and flip the MKL operation: `NoTrans → TRANSPOSE`,
    `Trans → NON_TRANSPOSE`. Nothing is copied (MKL supports `SPARSE_OPERATION_TRANSPOSE`
    on CSR natively). With CSC handled, the `opA=Trans` branch in `left_spmm` no
    longer needs to pre-route a transposed CSR to MKL to dodge a CSC fallback — that
    special case is removed; the transpose-and-recurse path now reaches MKL for
    every format.
  - **CI: build and actually test the MKL sparse path** (`02ffeaa`, `6e1e7a6`, `1290756`).
    Debian's `libmkl-dev` puts headers under `/usr/include/mkl` with no `MKLROOT`,
    so blaspp never defined `BLAS_HAVE_MKL` and RandBLAS logged
    `Checking for MKL sparse BLAS ... FALSE` — the entire `RandBLAS_HAS_MKL` path
    (spgemm + accelerated spmm, including the new CSC handling) was silently
    skipped. The `setup-randblas-deps` action now discovers the MKL header dir and
    exports `MKLROOT`/`CPATH`, `MKL_sparse.cmake`'s `find_path` handles both oneAPI
    and Debian layouts, and the MKL job builds blaspp/lapackpp as **ILP64** (so
    `MKL_INT` is 64-bit, matching RandBLAS's `int64_t` sparse indices required by
    `spgemm`'s `static_assert`). ILP64 is scoped to the MKL backend only, to avoid
    breaking the LP64 OpenBLAS jobs.

  ## SpMM benchmark — `examples/simple-kernel-benchmarks/spmm_performance.cc`
  - **Route every kernel through `left_spmm` using both dense layouts** (`568e89b`).
    The old benchmark used `left_spmm` (ColMajor) + `right_spmm` (ColMajor); since
    `right_spmm` only reaches the RowMajor kernels by transposing the sparse
    operand, the same coverage comes from `left_spmm` with ColMajor **and** RowMajor
    dense operands (ColMajor → `jik/jki`, RowMajor → `ikb/kib`; COO delegates to
    CSC). One logical dense matrix is stored in both layouts so the two are directly
    comparable against a single densify+GEMM oracle.
  - **Add `opB=Trans` (`C = A·Bᵀ`) coverage** (`6598d08`). This is the only
    `opA=NoTrans` path MKL declines, and it exercises the strided (`incv/incAv≠1`)
    branch of the CSR kernel that the unit-stride path never hits — so the kernel
    speedup above widens the measured NoTrans-vs-Trans gap. Two extra tables +
    6 correctness checks; the transposed operand reuses the existing buffers (the
    transpose of a ColMajor n×d buffer is the RowMajor buffer).
  - **Consistent `(A, B, C)` = (sparse, dense, result) notation** (`a857648`),
    matching the `left_spmm`/`spmm` API (the file previously mixed `(S, A, B)`).

  ## Misc
  - **Cache-efficiency improvement to `potrf_upper_sequential`** (`34c6dad`) in the
    test LAPACK-like helpers.
  - **Fix a `-Wsign-compare` warning** in `test_exceptions.cc` (`0bfe539`) — a
    misplaced `(int)` cast compared `find()`'s `size_type` to `npos`; swept all
    test + example sources, this was the only occurrence.

  ## Testing
  - `ctest` 429/429 on non-MKL builds (macOS + Linux OpenBLAS).
  - The MKL sparse path — `spgemm` and accelerated `spmm` including the new CSC
    handling — is now compiled and run by the `linux-gcc-mkl` (ILP64) job; this is
    the first CI coverage of `RandBLAS_HAS_MKL`.
  - CSR kernel speedup benchmarked on Apple M3 (numbers above).
