### PR TITLE
Windows portability

### DIFF
--- a/.github/actions/setup-randblas-deps-windows/action.yml
+++ b/.github/actions/setup-randblas-deps-windows/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: "Build and install LAPACK++ for the examples workflow."
     required: false
     default: "false"
+  sanitize-address:
+    description: "Build GoogleTest with the MSVC AddressSanitizer enabled."
+    required: false
+    default: "false"
 
 outputs:
   blaspp-dir:
@@ -36,10 +40,18 @@ runs:
         key: windows-vcpkg-intel-mkl-2025.2.0-1-${{ hashFiles('.github/actions/setup-randblas-deps-windows/setup.ps1') }}
 
     - name: cache GoogleTest installation
+      if: inputs.sanitize-address != 'true'
       uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}\..\windows-deps\googletest-install
         key: windows-msvc-googletest-1.17.0-1
+
+    - name: cache AddressSanitizer GoogleTest installation
+      if: inputs.sanitize-address == 'true'
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}\..\windows-deps\googletest-asan-install
+        key: windows-msvc-googletest-asan-1.17.0-1-${{ hashFiles('.github/actions/setup-randblas-deps-windows/setup.ps1') }}
 
     - name: cache BLAS++ installation
       uses: actions/cache@v4
@@ -65,6 +77,8 @@ runs:
       shell: pwsh
       run: |
         $installLapackpp = '${{ inputs.install-lapackpp }}' -eq 'true'
+        $sanitizeAddress = '${{ inputs.sanitize-address }}' -eq 'true'
         & "${env:GITHUB_ACTION_PATH}\setup.ps1" `
           -DependencyRoot "${env:GITHUB_WORKSPACE}\..\windows-deps" `
-          -InstallLapackpp:$installLapackpp
+          -InstallLapackpp:$installLapackpp `
+          -SanitizeAddress:$sanitizeAddress

--- a/.github/actions/setup-randblas-deps-windows/action.yml
+++ b/.github/actions/setup-randblas-deps-windows/action.yml
@@ -29,29 +29,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: resolve dependency revisions
-      id: revisions
-      shell: pwsh
-      run: |
-        $ErrorActionPreference = "Stop"
-
-        function Get-RemoteHead([string] $url) {
-          $line = (& git ls-remote $url HEAD | Select-Object -First 1)
-          if ($LASTEXITCODE -ne 0 -or -not $line) {
-            throw "Could not resolve HEAD for $url"
-          }
-          return ($line -split "\s+")[0]
-        }
-
-        "blaspp=$(Get-RemoteHead 'https://github.com/icl-utk-edu/blaspp.git')" |
-          Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-        "random123=$(Get-RemoteHead 'https://github.com/DEShawResearch/Random123.git')" |
-          Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-        if ('${{ inputs.install-lapackpp }}' -eq 'true') {
-          "lapackpp=$(Get-RemoteHead 'https://github.com/icl-utk-edu/lapackpp.git')" |
-            Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-        }
-
     - name: cache vcpkg oneMKL installation
       uses: actions/cache@v4
       with:
@@ -68,20 +45,20 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}\..\windows-deps\blaspp-install
-        key: windows-msvc-blaspp-ilp64-sequential-1-${{ steps.revisions.outputs.blaspp }}-${{ hashFiles('.github/actions/setup-randblas-deps-windows/setup.ps1') }}
+        key: windows-msvc-blaspp-windows-portability-ilp64-sequential-3-${{ hashFiles('.github/actions/setup-randblas-deps-windows/setup.ps1') }}
 
     - name: cache Random123 installation
       uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}\..\windows-deps\Random123-install
-        key: windows-random123-1-${{ steps.revisions.outputs.random123 }}
+        key: windows-random123-2-${{ hashFiles('.github/actions/setup-randblas-deps-windows/setup.ps1') }}
 
     - name: cache LAPACK++ installation
       if: inputs.install-lapackpp == 'true'
       uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}\..\windows-deps\lapackpp-install
-        key: windows-msvc-lapackpp-ilp64-sequential-1-${{ steps.revisions.outputs.blaspp }}-${{ steps.revisions.outputs.lapackpp }}-${{ hashFiles('.github/actions/setup-randblas-deps-windows/setup.ps1') }}
+        key: windows-msvc-lapackpp-msvc-compatibility-blaspp-windows-portability-ilp64-sequential-3-${{ hashFiles('.github/actions/setup-randblas-deps-windows/setup.ps1') }}
 
     - name: build missing Windows dependencies
       id: setup

--- a/.github/actions/setup-randblas-deps-windows/action.yml
+++ b/.github/actions/setup-randblas-deps-windows/action.yml
@@ -1,0 +1,93 @@
+name: setup-randblas-deps-windows
+description: >
+  Provisions oneMKL through vcpkg and builds the native-MSVC dependencies used
+  by RandBLAS's Windows CI jobs.
+
+inputs:
+  install-lapackpp:
+    description: "Build and install LAPACK++ for the examples workflow."
+    required: false
+    default: "false"
+
+outputs:
+  blaspp-dir:
+    description: "Directory containing blasppConfig.cmake."
+    value: ${{ steps.setup.outputs.blaspp-dir }}
+  random123-dir:
+    description: "Directory containing the installed Random123 headers."
+    value: ${{ steps.setup.outputs.random123-dir }}
+  googletest-prefix:
+    description: "GoogleTest installation prefix."
+    value: ${{ steps.setup.outputs.googletest-prefix }}
+  lapackpp-dir:
+    description: "Directory containing lapackppConfig.cmake, when requested."
+    value: ${{ steps.setup.outputs.lapackpp-dir }}
+  mkl-root:
+    description: "Root of the vcpkg oneMKL installation."
+    value: ${{ steps.setup.outputs.mkl-root }}
+
+runs:
+  using: composite
+  steps:
+    - name: resolve dependency revisions
+      id: revisions
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = "Stop"
+
+        function Get-RemoteHead([string] $url) {
+          $line = (& git ls-remote $url HEAD | Select-Object -First 1)
+          if ($LASTEXITCODE -ne 0 -or -not $line) {
+            throw "Could not resolve HEAD for $url"
+          }
+          return ($line -split "\s+")[0]
+        }
+
+        "blaspp=$(Get-RemoteHead 'https://github.com/icl-utk-edu/blaspp.git')" |
+          Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+        "random123=$(Get-RemoteHead 'https://github.com/DEShawResearch/Random123.git')" |
+          Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+        if ('${{ inputs.install-lapackpp }}' -eq 'true') {
+          "lapackpp=$(Get-RemoteHead 'https://github.com/icl-utk-edu/lapackpp.git')" |
+            Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+        }
+
+    - name: cache vcpkg oneMKL installation
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}\..\windows-deps\vcpkg-installed
+        key: windows-vcpkg-intel-mkl-2025.2.0-1-${{ hashFiles('.github/actions/setup-randblas-deps-windows/setup.ps1') }}
+
+    - name: cache GoogleTest installation
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}\..\windows-deps\googletest-install
+        key: windows-msvc-googletest-1.17.0-1
+
+    - name: cache BLAS++ installation
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}\..\windows-deps\blaspp-install
+        key: windows-msvc-blaspp-ilp64-sequential-1-${{ steps.revisions.outputs.blaspp }}-${{ hashFiles('.github/actions/setup-randblas-deps-windows/setup.ps1') }}
+
+    - name: cache Random123 installation
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}\..\windows-deps\Random123-install
+        key: windows-random123-1-${{ steps.revisions.outputs.random123 }}
+
+    - name: cache LAPACK++ installation
+      if: inputs.install-lapackpp == 'true'
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}\..\windows-deps\lapackpp-install
+        key: windows-msvc-lapackpp-ilp64-sequential-1-${{ steps.revisions.outputs.blaspp }}-${{ steps.revisions.outputs.lapackpp }}-${{ hashFiles('.github/actions/setup-randblas-deps-windows/setup.ps1') }}
+
+    - name: build missing Windows dependencies
+      id: setup
+      shell: pwsh
+      run: |
+        $installLapackpp = '${{ inputs.install-lapackpp }}' -eq 'true'
+        & "${env:GITHUB_ACTION_PATH}\setup.ps1" `
+          -DependencyRoot "${env:GITHUB_WORKSPACE}\..\windows-deps" `
+          -InstallLapackpp:$installLapackpp

--- a/.github/actions/setup-randblas-deps-windows/setup.ps1
+++ b/.github/actions/setup-randblas-deps-windows/setup.ps1
@@ -1,0 +1,305 @@
+[CmdletBinding()]
+param(
+    [string] $DependencyRoot = "",
+    [string] $VcpkgExecutable = "",
+    [switch] $InstallLapackpp
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function Invoke-Checked {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Program,
+
+        [Parameter(Mandatory = $false)]
+        [string[]] $Arguments = @()
+    )
+
+    Write-Host "+ $Program $($Arguments -join ' ')"
+    & $Program @Arguments | Out-Host
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Program failed with exit code $LASTEXITCODE."
+    }
+}
+
+function Convert-ToCMakePath {
+    param([Parameter(Mandatory = $true)][string] $Path)
+    return $Path.Replace("\", "/")
+}
+
+function Find-PackageConfigDirectory {
+    param(
+        [Parameter(Mandatory = $true)][string] $Root,
+        [Parameter(Mandatory = $true)][string] $ConfigName
+    )
+
+    $config = Get-ChildItem -LiteralPath $Root -Recurse -File -Filter $ConfigName |
+        Select-Object -First 1
+    if (-not $config) {
+        throw "Could not find $ConfigName below $Root."
+    }
+    return $config.Directory.FullName
+}
+
+function Clone-Head {
+    param(
+        [Parameter(Mandatory = $true)][string] $Url,
+        [Parameter(Mandatory = $true)][string] $Destination,
+        [string] $Branch = ""
+    )
+
+    if (Test-Path -LiteralPath $Destination) {
+        return
+    }
+
+    $arguments = @("clone", "--depth", "1")
+    if ($Branch) {
+        $arguments += @("--branch", $Branch)
+    }
+    $arguments += @($Url, $Destination)
+    Invoke-Checked -Program "git" -Arguments $arguments
+}
+
+function Add-IncludeIfMissing {
+    param(
+        [Parameter(Mandatory = $true)][string] $Path,
+        [Parameter(Mandatory = $true)][string] $Include,
+        [Parameter(Mandatory = $true)][string] $After
+    )
+
+    $content = [IO.File]::ReadAllText($Path)
+    if ($content.Contains($Include)) {
+        return
+    }
+    if (-not $content.Contains($After)) {
+        throw "Could not locate insertion point '$After' in $Path."
+    }
+    $content = $content.Replace($After, "$After`r`n$Include")
+    [IO.File]::WriteAllText($Path, $content)
+}
+
+function Export-GitHubValue {
+    param(
+        [Parameter(Mandatory = $true)][string] $Name,
+        [Parameter(Mandatory = $true)][string] $Value
+    )
+
+    Set-Item -Path "Env:$Name" -Value $Value
+    if ($env:GITHUB_ENV) {
+        "$Name=$Value" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+    }
+    if ($env:GITHUB_OUTPUT) {
+        "$($Name.ToLowerInvariant().Replace('_', '-'))=$Value" |
+            Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+    }
+}
+
+if (-not $DependencyRoot) {
+    if ($env:GITHUB_WORKSPACE) {
+        $DependencyRoot = Join-Path (Split-Path $env:GITHUB_WORKSPACE -Parent) "windows-deps"
+    }
+    else {
+        throw "Pass -DependencyRoot when running setup.ps1 outside GitHub Actions."
+    }
+}
+
+$DependencyRoot = [IO.Path]::GetFullPath($DependencyRoot)
+if ($DependencyRoot -eq [IO.Path]::GetPathRoot($DependencyRoot)) {
+    throw "DependencyRoot must not be a filesystem root."
+}
+New-Item -ItemType Directory -Force -Path $DependencyRoot | Out-Null
+
+if (-not (Get-Command "cl.exe" -ErrorAction SilentlyContinue)) {
+    throw "MSVC is not active. Run from an x64 Native Tools prompt or initialize MSVC before invoking this script."
+}
+
+if (-not $VcpkgExecutable) {
+    $vcpkgCandidates = @()
+    if ($env:VCPKG_INSTALLATION_ROOT) {
+        $vcpkgCandidates += Join-Path $env:VCPKG_INSTALLATION_ROOT "vcpkg.exe"
+    }
+    if ($env:VCPKG_ROOT) {
+        $vcpkgCandidates += Join-Path $env:VCPKG_ROOT "vcpkg.exe"
+    }
+    $vcpkgCommand = Get-Command "vcpkg.exe" -ErrorAction SilentlyContinue
+    if ($vcpkgCommand) {
+        $vcpkgCandidates += $vcpkgCommand.Source
+    }
+    $VcpkgExecutable = $vcpkgCandidates |
+        Where-Object { Test-Path -LiteralPath $_ } |
+        Select-Object -First 1
+}
+if (-not $VcpkgExecutable) {
+    throw "Could not find vcpkg.exe. Pass -VcpkgExecutable or set VCPKG_INSTALLATION_ROOT."
+}
+
+$vcpkgInstall = Join-Path $DependencyRoot "vcpkg-installed"
+$mklRoot = Join-Path $vcpkgInstall "x64-windows"
+$mklInclude = Join-Path $mklRoot "include"
+$mklLib = Join-Path $mklRoot "lib"
+$mklBin = Join-Path $mklRoot "bin"
+$mklLibraries = @(
+    (Join-Path $mklLib "mkl_intel_ilp64_dll.lib"),
+    (Join-Path $mklLib "mkl_sequential_dll.lib"),
+    (Join-Path $mklLib "mkl_core_dll.lib")
+)
+
+if (-not (Test-Path -LiteralPath $mklLibraries[0])) {
+    Invoke-Checked -Program $VcpkgExecutable -Arguments @(
+        "install",
+        "intel-mkl:x64-windows",
+        "--x-install-root=$vcpkgInstall"
+    )
+}
+foreach ($path in @($mklInclude, $mklBin) + $mklLibraries) {
+    if (-not (Test-Path -LiteralPath $path)) {
+        throw "Expected vcpkg oneMKL path does not exist: $path"
+    }
+}
+$env:MKLROOT = $mklRoot
+$env:PATH = "$mklBin;$env:PATH"
+
+$gtestSource = Join-Path $DependencyRoot "googletest"
+$gtestBuild = Join-Path $DependencyRoot "googletest-build"
+$gtestInstall = Join-Path $DependencyRoot "googletest-install"
+if (-not (Test-Path -LiteralPath (Join-Path $gtestInstall "lib\cmake\GTest\GTestConfig.cmake"))) {
+    Clone-Head -Url "https://github.com/google/googletest.git" `
+        -Destination $gtestSource -Branch "v1.17.0"
+    Invoke-Checked -Program "cmake" -Arguments @(
+        "-S", $gtestSource,
+        "-B", $gtestBuild,
+        "-G", "NMake Makefiles",
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DCMAKE_INSTALL_PREFIX=$(Convert-ToCMakePath $gtestInstall)",
+        "-DBUILD_GMOCK=OFF",
+        "-DINSTALL_GTEST=ON"
+    )
+    Invoke-Checked -Program "cmake" -Arguments @(
+        "--build", $gtestBuild, "--target", "install"
+    )
+}
+
+$random123Source = Join-Path $DependencyRoot "Random123"
+$random123Install = Join-Path $DependencyRoot "Random123-install"
+$random123Include = Join-Path $random123Install "include"
+if (-not (Test-Path -LiteralPath (Join-Path $random123Include "Random123\philox.h"))) {
+    Clone-Head -Url "https://github.com/DEShawResearch/Random123.git" `
+        -Destination $random123Source
+    New-Item -ItemType Directory -Force -Path $random123Include | Out-Null
+    Copy-Item -LiteralPath (Join-Path $random123Source "include\Random123") `
+        -Destination $random123Include -Recurse
+}
+
+$blasppSource = Join-Path $DependencyRoot "blaspp"
+$blasppBuild = Join-Path $DependencyRoot "blaspp-build"
+$blasppInstall = Join-Path $DependencyRoot "blaspp-install"
+$blasppConfig = Get-ChildItem -LiteralPath $blasppInstall -Recurse -File `
+    -Filter "blasppConfig.cmake" -ErrorAction SilentlyContinue |
+    Select-Object -First 1
+if (-not $blasppConfig) {
+    Clone-Head -Url "https://github.com/icl-utk-edu/blaspp.git" `
+        -Destination $blasppSource
+    $blasLibraryArgument = ($mklLibraries | ForEach-Object {
+        Convert-ToCMakePath $_
+    }) -join ";"
+    Invoke-Checked -Program "cmake" -Arguments @(
+        "-S", $blasppSource,
+        "-B", $blasppBuild,
+        "-G", "NMake Makefiles",
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DCMAKE_INSTALL_PREFIX=$(Convert-ToCMakePath $blasppInstall)",
+        "-DBUILD_SHARED_LIBS=ON",
+        "-Duse_cmake_find_blas=false",
+        "-DBLAS_LIBRARIES=$blasLibraryArgument",
+        "-Dblas_int=ilp64",
+        "-Dblas_threaded=false",
+        "-Duse_openmp=false",
+        "-Dgpu_backend=none",
+        "-Dbuild_tests=OFF"
+    )
+    Invoke-Checked -Program "cmake" -Arguments @(
+        "--build", $blasppBuild, "--target", "install"
+    )
+}
+$blasppDir = Find-PackageConfigDirectory `
+    -Root $blasppInstall -ConfigName "blasppConfig.cmake"
+
+$lapackppDir = ""
+if ($InstallLapackpp) {
+    $lapackppSource = Join-Path $DependencyRoot "lapackpp"
+    $lapackppBuild = Join-Path $DependencyRoot "lapackpp-build"
+    $lapackppInstall = Join-Path $DependencyRoot "lapackpp-install"
+    $lapackppConfig = Get-ChildItem -LiteralPath $lapackppInstall -Recurse -File `
+        -Filter "lapackppConfig.cmake" -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if (-not $lapackppConfig) {
+        Clone-Head -Url "https://github.com/icl-utk-edu/lapackpp.git" `
+            -Destination $lapackppSource
+
+        # Temporary upstream compatibility patches. These are no-ops once the
+        # corresponding direct includes are present in LAPACK++ itself.
+        Add-IncludeIfMissing `
+            -Path (Join-Path $lapackppSource "include\lapack\config.h") `
+            -Include "#include <stdint.h>" `
+            -After '#include "lapack/defines.h"'
+        Add-IncludeIfMissing `
+            -Path (Join-Path $lapackppSource "src\lartg.cc") `
+            -Include "#include <complex>" `
+            -After '#include "lapack/fortran.h"'
+
+        Invoke-Checked -Program "cmake" -Arguments @(
+            "-S", $lapackppSource,
+            "-B", $lapackppBuild,
+            "-G", "NMake Makefiles",
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DCMAKE_INSTALL_PREFIX=$(Convert-ToCMakePath $lapackppInstall)",
+            "-Dblaspp_DIR=$(Convert-ToCMakePath $blasppDir)",
+            "-DBUILD_SHARED_LIBS=ON",
+            "-Dgpu_backend=none",
+            "-Dbuild_tests=OFF",
+            "-DCMAKE_CXX_FLAGS=/EHsc /D__PRETTY_FUNCTION__=__FUNCSIG__"
+        )
+        Invoke-Checked -Program "cmake" -Arguments @(
+            "--build", $lapackppBuild, "--target", "install"
+        )
+    }
+    $lapackppDir = Find-PackageConfigDirectory `
+        -Root $lapackppInstall -ConfigName "lapackppConfig.cmake"
+}
+
+$exports = [ordered]@{
+    "blaspp_DIR" = Convert-ToCMakePath $blasppDir
+    "Random123_DIR" = Convert-ToCMakePath $random123Include
+    "googletest_PREFIX" = Convert-ToCMakePath $gtestInstall
+    "MKLROOT" = Convert-ToCMakePath $mklRoot
+}
+if ($InstallLapackpp) {
+    $exports["lapackpp_DIR"] = Convert-ToCMakePath $lapackppDir
+}
+
+foreach ($entry in $exports.GetEnumerator()) {
+    Export-GitHubValue -Name $entry.Key -Value $entry.Value
+    Write-Host "$($entry.Key)=$($entry.Value)"
+}
+if ($env:GITHUB_PATH) {
+    (Convert-ToCMakePath $mklBin) |
+        Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+}
+
+# Stable output names consumed by action.yml.
+if ($env:GITHUB_OUTPUT) {
+    "blaspp-dir=$(Convert-ToCMakePath $blasppDir)" |
+        Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+    "random123-dir=$(Convert-ToCMakePath $random123Include)" |
+        Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+    "googletest-prefix=$(Convert-ToCMakePath $gtestInstall)" |
+        Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+    "mkl-root=$(Convert-ToCMakePath $mklRoot)" |
+        Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+    if ($InstallLapackpp) {
+        "lapackpp-dir=$(Convert-ToCMakePath $lapackppDir)" |
+            Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+    }
+}

--- a/.github/actions/setup-randblas-deps-windows/setup.ps1
+++ b/.github/actions/setup-randblas-deps-windows/setup.ps1
@@ -2,7 +2,8 @@
 param(
     [string] $DependencyRoot = "",
     [string] $VcpkgExecutable = "",
-    [switch] $InstallLapackpp
+    [switch] $InstallLapackpp,
+    [switch] $SanitizeAddress
 )
 
 $ErrorActionPreference = "Stop"
@@ -144,12 +145,13 @@ $env:MKLROOT = $mklRoot
 $env:PATH = "$mklBin;$env:PATH"
 
 $gtestSource = Join-Path $DependencyRoot "googletest"
-$gtestBuild = Join-Path $DependencyRoot "googletest-build"
-$gtestInstall = Join-Path $DependencyRoot "googletest-install"
+$gtestVariant = if ($SanitizeAddress) { "googletest-asan" } else { "googletest" }
+$gtestBuild = Join-Path $DependencyRoot "$gtestVariant-build"
+$gtestInstall = Join-Path $DependencyRoot "$gtestVariant-install"
 if (-not (Test-Path -LiteralPath (Join-Path $gtestInstall "lib\cmake\GTest\GTestConfig.cmake"))) {
     Clone-Head -Url "https://github.com/google/googletest.git" `
         -Destination $gtestSource -Branch "v1.17.0"
-    Invoke-Checked -Program "cmake" -Arguments @(
+    $gtestArguments = @(
         "-S", $gtestSource,
         "-B", $gtestBuild,
         "-G", "NMake Makefiles",
@@ -158,6 +160,13 @@ if (-not (Test-Path -LiteralPath (Join-Path $gtestInstall "lib\cmake\GTest\GTest
         "-DBUILD_GMOCK=OFF",
         "-DINSTALL_GTEST=ON"
     )
+    if ($SanitizeAddress) {
+        # MSVC's STL container-annotation mode must agree across every object
+        # linked into a process. Build a separate instrumented GoogleTest
+        # installation for the ASan job instead of disabling those checks.
+        $gtestArguments += "-DCMAKE_CXX_FLAGS=/fsanitize=address /Zi"
+    }
+    Invoke-Checked -Program "cmake" -Arguments $gtestArguments
     Invoke-Checked -Program "cmake" -Arguments @(
         "--build", $gtestBuild, "--target", "install"
     )

--- a/.github/actions/setup-randblas-deps-windows/setup.ps1
+++ b/.github/actions/setup-randblas-deps-windows/setup.ps1
@@ -62,24 +62,6 @@ function Clone-Head {
     Invoke-Checked -Program "git" -Arguments $arguments
 }
 
-function Add-IncludeIfMissing {
-    param(
-        [Parameter(Mandatory = $true)][string] $Path,
-        [Parameter(Mandatory = $true)][string] $Include,
-        [Parameter(Mandatory = $true)][string] $After
-    )
-
-    $content = [IO.File]::ReadAllText($Path)
-    if ($content.Contains($Include)) {
-        return
-    }
-    if (-not $content.Contains($After)) {
-        throw "Could not locate insertion point '$After' in $Path."
-    }
-    $content = $content.Replace($After, "$After`r`n$Include")
-    [IO.File]::WriteAllText($Path, $content)
-}
-
 function Export-GitHubValue {
     param(
         [Parameter(Mandatory = $true)][string] $Name,
@@ -199,8 +181,10 @@ $blasppConfig = Get-ChildItem -LiteralPath $blasppInstall -Recurse -File `
     -Filter "blasppConfig.cmake" -ErrorAction SilentlyContinue |
     Select-Object -First 1
 if (-not $blasppConfig) {
-    Clone-Head -Url "https://github.com/icl-utk-edu/blaspp.git" `
-        -Destination $blasppSource
+    Clone-Head `
+        -Url "https://github.com/RaphaelArkadyMeyerNYU/blaspp.git" `
+        -Destination $blasppSource `
+        -Branch "windows-portability"
     $blasLibraryArgument = ($mklLibraries | ForEach-Object {
         Convert-ToCMakePath $_
     }) -join ";"
@@ -235,19 +219,10 @@ if ($InstallLapackpp) {
         -Filter "lapackppConfig.cmake" -ErrorAction SilentlyContinue |
         Select-Object -First 1
     if (-not $lapackppConfig) {
-        Clone-Head -Url "https://github.com/icl-utk-edu/lapackpp.git" `
-            -Destination $lapackppSource
-
-        # Temporary upstream compatibility patches. These are no-ops once the
-        # corresponding direct includes are present in LAPACK++ itself.
-        Add-IncludeIfMissing `
-            -Path (Join-Path $lapackppSource "include\lapack\config.h") `
-            -Include "#include <stdint.h>" `
-            -After '#include "lapack/defines.h"'
-        Add-IncludeIfMissing `
-            -Path (Join-Path $lapackppSource "src\lartg.cc") `
-            -Include "#include <complex>" `
-            -After '#include "lapack/fortran.h"'
+        Clone-Head `
+            -Url "https://github.com/RaphaelArkadyMeyerNYU/lapackpp.git" `
+            -Destination $lapackppSource `
+            -Branch "msvc-compatibility"
 
         Invoke-Checked -Program "cmake" -Arguments @(
             "-S", $lapackppSource,
@@ -258,8 +233,7 @@ if ($InstallLapackpp) {
             "-Dblaspp_DIR=$(Convert-ToCMakePath $blasppDir)",
             "-DBUILD_SHARED_LIBS=ON",
             "-Dgpu_backend=none",
-            "-Dbuild_tests=OFF",
-            "-DCMAKE_CXX_FLAGS=/EHsc /D__PRETTY_FUNCTION__=__FUNCSIG__"
+            "-Dbuild_tests=OFF"
         )
         Invoke-Checked -Program "cmake" -Arguments @(
             "--build", $lapackppBuild, "--target", "install"

--- a/.github/scripts/windows/run-ci.ps1
+++ b/.github/scripts/windows/run-ci.ps1
@@ -69,6 +69,7 @@ if ($SetupDependencies) {
     $setupArguments = @{
         DependencyRoot = $DependencyRoot
         InstallLapackpp = ($Task -eq "Examples")
+        SanitizeAddress = $SanitizeAddress
     }
     if ($VcpkgExecutable) {
         $setupArguments["VcpkgExecutable"] = $VcpkgExecutable

--- a/.github/scripts/windows/run-ci.ps1
+++ b/.github/scripts/windows/run-ci.ps1
@@ -1,0 +1,198 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("CoreOpenMP", "CoreSerial", "Downstream", "Examples")]
+    [string] $Task,
+
+    [string] $SourceRoot = "",
+    [string] $WorkRoot = "",
+    [string] $DependencyRoot = "",
+    [string] $VcpkgExecutable = "",
+    [switch] $SetupDependencies
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function Invoke-Checked {
+    param(
+        [Parameter(Mandatory = $true)][string] $Program,
+        [Parameter(Mandatory = $false)][string[]] $Arguments = @()
+    )
+
+    Write-Host "+ $Program $($Arguments -join ' ')"
+    & $Program @Arguments | Out-Host
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Program failed with exit code $LASTEXITCODE."
+    }
+}
+
+function Convert-ToCMakePath {
+    param([Parameter(Mandatory = $true)][string] $Path)
+    return $Path.Replace("\", "/")
+}
+
+function Require-EnvironmentVariable {
+    param([Parameter(Mandatory = $true)][string] $Name)
+    $value = [Environment]::GetEnvironmentVariable($Name)
+    if (-not $value) {
+        throw "Required environment variable $Name is not set."
+    }
+    return $value
+}
+
+if (-not $SourceRoot) {
+    if ($env:GITHUB_WORKSPACE) {
+        $SourceRoot = $env:GITHUB_WORKSPACE
+    }
+    else {
+        $SourceRoot = [IO.Path]::GetFullPath(
+            (Join-Path $PSScriptRoot "..\..\..")
+        )
+    }
+}
+$SourceRoot = [IO.Path]::GetFullPath($SourceRoot)
+
+if (-not $WorkRoot) {
+    $WorkRoot = Join-Path (Split-Path $SourceRoot -Parent) "RandBLAS-windows-ci"
+}
+$WorkRoot = [IO.Path]::GetFullPath($WorkRoot)
+New-Item -ItemType Directory -Force -Path $WorkRoot | Out-Null
+
+if ($SetupDependencies) {
+    if (-not $DependencyRoot) {
+        $DependencyRoot = Join-Path $WorkRoot "dependencies"
+    }
+    $setupScript = Join-Path $SourceRoot `
+        ".github\actions\setup-randblas-deps-windows\setup.ps1"
+    $setupArguments = @{
+        DependencyRoot = $DependencyRoot
+        InstallLapackpp = ($Task -eq "Examples")
+    }
+    if ($VcpkgExecutable) {
+        $setupArguments["VcpkgExecutable"] = $VcpkgExecutable
+    }
+    & $setupScript @setupArguments
+}
+
+$blasppDir = Require-EnvironmentVariable "blaspp_DIR"
+$random123Dir = Require-EnvironmentVariable "Random123_DIR"
+$mklRoot = Require-EnvironmentVariable "MKLROOT"
+$mklBin = Join-Path $mklRoot "bin"
+if (-not (Test-Path -LiteralPath $mklBin)) {
+    throw "oneMKL runtime directory does not exist: $mklBin"
+}
+$env:PATH = "$mklBin;$env:PATH"
+
+function Install-RandBLAS {
+    param(
+        [Parameter(Mandatory = $true)][string] $Name,
+        [Parameter(Mandatory = $true)][bool] $BuildTests,
+        [Parameter(Mandatory = $true)][bool] $UseOpenMP,
+        [bool] $UseNativeDependencyPaths = $false
+    )
+
+    $build = Join-Path $WorkRoot "$Name-build"
+    $install = Join-Path $WorkRoot "$Name-install"
+    $configuredBlasppDir = $blasppDir
+    $configuredRandom123Dir = $random123Dir
+    if ($UseNativeDependencyPaths) {
+        $configuredBlasppDir = $blasppDir.Replace("/", "\")
+        $configuredRandom123Dir = $random123Dir.Replace("/", "\")
+    }
+    $arguments = @(
+        "-S", $SourceRoot,
+        "-B", $build,
+        "-G", "NMake Makefiles",
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DCMAKE_INSTALL_PREFIX=$(Convert-ToCMakePath $install)",
+        "-Dblaspp_DIR=$configuredBlasppDir",
+        "-DRandom123_DIR=$configuredRandom123Dir",
+        "-DBUILD_TESTS=$(if ($BuildTests) { 'ON' } else { 'OFF' })"
+    )
+    if ($BuildTests) {
+        $gtestPrefix = Require-EnvironmentVariable "googletest_PREFIX"
+        $arguments += "-DCMAKE_PREFIX_PATH=$gtestPrefix"
+    }
+    if (-not $UseOpenMP) {
+        $arguments += "-DCMAKE_DISABLE_FIND_PACKAGE_OpenMP=TRUE"
+    }
+
+    Invoke-Checked -Program "cmake" -Arguments $arguments
+    Invoke-Checked -Program "cmake" -Arguments @(
+        "--build", $build, "--target", "install"
+    )
+    return @{
+        Build = $build
+        Install = $install
+    }
+}
+
+switch ($Task) {
+    "CoreOpenMP" {
+        $randblas = Install-RandBLAS `
+            -Name "core-openmp" -BuildTests $true -UseOpenMP $true
+        $env:OMP_NUM_THREADS = "1"
+        Invoke-Checked -Program "ctest" -Arguments @(
+            "--test-dir", $randblas.Build, "--output-on-failure"
+        )
+        $env:OMP_NUM_THREADS = "4"
+        Invoke-Checked -Program "ctest" -Arguments @(
+            "--test-dir", $randblas.Build, "--output-on-failure"
+        )
+    }
+
+    "CoreSerial" {
+        $randblas = Install-RandBLAS `
+            -Name "core-serial" -BuildTests $true -UseOpenMP $false
+        Remove-Item Env:OMP_NUM_THREADS -ErrorAction SilentlyContinue
+        Invoke-Checked -Program "ctest" -Arguments @(
+            "--test-dir", $randblas.Build, "--output-on-failure"
+        )
+    }
+
+    "Downstream" {
+        $randblas = Install-RandBLAS `
+            -Name "downstream-library" -BuildTests $false -UseOpenMP $true `
+            -UseNativeDependencyPaths $true
+        $build = Join-Path $WorkRoot "downstream-consumer-build"
+
+        # Deliberately omit blaspp_DIR and Random123_DIR. This makes the smoke
+        # test exercise the native-backslash dependency paths recorded by
+        # RandBLASConfig.cmake and currently reproduce the known \U parse bug.
+        Invoke-Checked -Program "cmake" -Arguments @(
+            "-S", (Join-Path $SourceRoot "test\downstream"),
+            "-B", $build,
+            "-G", "NMake Makefiles",
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DCMAKE_PREFIX_PATH=$(Convert-ToCMakePath $randblas.Install)"
+        )
+        Invoke-Checked -Program "cmake" -Arguments @(
+            "--build", $build, "--target", "smoke"
+        )
+        Invoke-Checked -Program (Join-Path $build "smoke.exe")
+    }
+
+    "Examples" {
+        $lapackppDir = Require-EnvironmentVariable "lapackpp_DIR"
+        $randblas = Install-RandBLAS `
+            -Name "examples-library" -BuildTests $false -UseOpenMP $true
+        $build = Join-Path $WorkRoot "examples-build"
+        $randblasDir = Join-Path $randblas.Install "lib\cmake\RandBLAS"
+
+        # Pass external dependency directories explicitly here so the examples
+        # job can probe example portability independently of the downstream
+        # package-path smoke test.
+        Invoke-Checked -Program "cmake" -Arguments @(
+            "-S", (Join-Path $SourceRoot "examples"),
+            "-B", $build,
+            "-G", "NMake Makefiles",
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DRandBLAS_DIR=$(Convert-ToCMakePath $randblasDir)",
+            "-Dblaspp_DIR=$blasppDir",
+            "-DRandom123_DIR=$random123Dir",
+            "-Dlapackpp_DIR=$lapackppDir"
+        )
+        Invoke-Checked -Program "cmake" -Arguments @("--build", $build)
+    }
+}

--- a/.github/scripts/windows/run-ci.ps1
+++ b/.github/scripts/windows/run-ci.ps1
@@ -8,7 +8,8 @@ param(
     [string] $WorkRoot = "",
     [string] $DependencyRoot = "",
     [string] $VcpkgExecutable = "",
-    [switch] $SetupDependencies
+    [switch] $SetupDependencies,
+    [switch] $SanitizeAddress
 )
 
 $ErrorActionPreference = "Stop"
@@ -89,7 +90,8 @@ function Install-RandBLAS {
         [Parameter(Mandatory = $true)][string] $Name,
         [Parameter(Mandatory = $true)][bool] $BuildTests,
         [Parameter(Mandatory = $true)][bool] $UseOpenMP,
-        [bool] $UseNativeDependencyPaths = $false
+        [bool] $UseNativeDependencyPaths = $false,
+        [bool] $SanitizeAddress = $false
     )
 
     $build = Join-Path $WorkRoot "$Name-build"
@@ -117,6 +119,9 @@ function Install-RandBLAS {
     if (-not $UseOpenMP) {
         $arguments += "-DCMAKE_DISABLE_FIND_PACKAGE_OpenMP=TRUE"
     }
+    if ($SanitizeAddress) {
+        $arguments += "-DSANITIZE_ADDRESS=ON"
+    }
 
     Invoke-Checked -Program "cmake" -Arguments $arguments
     Invoke-Checked -Program "cmake" -Arguments @(
@@ -131,7 +136,8 @@ function Install-RandBLAS {
 switch ($Task) {
     "CoreOpenMP" {
         $randblas = Install-RandBLAS `
-            -Name "core-openmp" -BuildTests $true -UseOpenMP $true
+            -Name "core-openmp" -BuildTests $true -UseOpenMP $true `
+            -SanitizeAddress:$SanitizeAddress
         $env:OMP_NUM_THREADS = "1"
         Invoke-Checked -Program "ctest" -Arguments @(
             "--test-dir", $randblas.Build, "--output-on-failure"
@@ -144,7 +150,8 @@ switch ($Task) {
 
     "CoreSerial" {
         $randblas = Install-RandBLAS `
-            -Name "core-serial" -BuildTests $true -UseOpenMP $false
+            -Name "core-serial" -BuildTests $true -UseOpenMP $false `
+            -SanitizeAddress:$SanitizeAddress
         Remove-Item Env:OMP_NUM_THREADS -ErrorAction SilentlyContinue
         Invoke-Checked -Program "ctest" -Arguments @(
             "--test-dir", $randblas.Build, "--output-on-failure"

--- a/.github/scripts/windows/run-ci.ps1
+++ b/.github/scripts/windows/run-ci.ps1
@@ -159,7 +159,7 @@ switch ($Task) {
 
         # Deliberately omit blaspp_DIR and Random123_DIR. This makes the smoke
         # test exercise the native-backslash dependency paths recorded by
-        # RandBLASConfig.cmake and currently reproduce the known \U parse bug.
+        # RandBLASConfig.cmake and guards their generated-path normalization.
         Invoke-Checked -Program "cmake" -Arguments @(
             "-S", (Join-Path $SourceRoot "test\downstream"),
             "-B", $build,

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -248,8 +248,13 @@ jobs:
         include:
           - label: openmp-release
             openmp: true
+            sanitize_address: false
           - label: serial-release
             openmp: false
+            sanitize_address: false
+          - label: serial-release-asan
+            openmp: false
+            sanitize_address: true
 
     steps:
       - uses: actions/checkout@v4
@@ -266,7 +271,10 @@ jobs:
         shell: pwsh
         run: |
           $openmp = '${{ matrix.openmp }}' -eq 'true'
+          $sanitizeAddress = '${{ matrix.sanitize_address }}' -eq 'true'
           $task = if ($openmp) { "CoreOpenMP" } else { "CoreSerial" }
+          $workName = if ($sanitizeAddress) { "$task-ASan" } else { $task }
           & "$env:GITHUB_WORKSPACE/.github/scripts/windows/run-ci.ps1" `
             -Task $task `
-            -WorkRoot "$env:GITHUB_WORKSPACE/../RandBLAS-windows-ci-$task"
+            -WorkRoot "$env:GITHUB_WORKSPACE/../RandBLAS-windows-ci-$workName" `
+            -SanitizeAddress:$sanitizeAddress

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -238,3 +238,35 @@ jobs:
         shell: bash
         working-directory: ${{ github.workspace }}/../RandBLAS-build
         run: ctest --output-on-failure
+
+  windows-build:
+    name: windows-msvc-mkl-ilp64-${{ matrix.label }}
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: openmp-release
+            openmp: true
+          - label: serial-release
+            openmp: false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: initialize MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      - name: setup native Windows dependencies
+        uses: ./.github/actions/setup-randblas-deps-windows
+
+      - name: run native Windows core validation
+        shell: pwsh
+        run: |
+          $openmp = '${{ matrix.openmp }}' -eq 'true'
+          $task = if ($openmp) { "CoreOpenMP" } else { "CoreSerial" }
+          & "$env:GITHUB_WORKSPACE/.github/scripts/windows/run-ci.ps1" `
+            -Task $task `
+            -WorkRoot "$env:GITHUB_WORKSPACE/../RandBLAS-windows-ci-$task"

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -266,6 +266,8 @@ jobs:
 
       - name: setup native Windows dependencies
         uses: ./.github/actions/setup-randblas-deps-windows
+        with:
+          sanitize-address: ${{ matrix.sanitize_address }}
 
       - name: run native Windows core validation
         shell: pwsh

--- a/.github/workflows/downstream-consumer.yml
+++ b/.github/workflows/downstream-consumer.yml
@@ -53,3 +53,24 @@ jobs:
             ..
           make -j"$(nproc)"
           ./smoke
+
+  windows-find-package-smoke:
+    name: windows-msvc-find-package
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: initialize MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      - name: setup native Windows dependencies
+        uses: ./.github/actions/setup-randblas-deps-windows
+
+      - name: run installed-package smoke test
+        shell: pwsh
+        run: |
+          & "$env:GITHUB_WORKSPACE/.github/scripts/windows/run-ci.ps1" `
+            -Task Downstream `
+            -WorkRoot "$env:GITHUB_WORKSPACE/../RandBLAS-windows-ci-downstream"

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -54,3 +54,26 @@ jobs:
             -DRandom123_DIR="${Random123_DIR}" \
             ..
           make -j"$(nproc)"
+
+  windows-build-examples:
+    name: windows-msvc-mkl-ilp64-examples
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: initialize MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      - name: setup native Windows dependencies (with LAPACK++)
+        uses: ./.github/actions/setup-randblas-deps-windows
+        with:
+          install-lapackpp: "true"
+
+      - name: build examples
+        shell: pwsh
+        run: |
+          & "$env:GITHUB_WORKSPACE/.github/scripts/windows/run-ci.ps1" `
+            -Task Examples `
+            -WorkRoot "$env:GITHUB_WORKSPACE/../RandBLAS-windows-ci-examples"

--- a/CMake/OpenMP.cmake
+++ b/CMake/OpenMP.cmake
@@ -1,5 +1,22 @@
 message(STATUS "Checking for OpenMP ... ")
+
+# MSVC's ordinary /openmp mode does not support the omp simd directive used by
+# the sparse kernels. Recent MSVC versions provide it through
+# /openmp:experimental. Allow callers to override this setting explicitly.
+if (MSVC AND NOT DEFINED OpenMP_CXX_FLAGS)
+    set(OpenMP_CXX_FLAGS "/openmp:experimental" CACHE STRING
+        "OpenMP compiler flags for C++")
+endif()
+
 find_package(OpenMP COMPONENTS CXX)
+
+# FindOpenMP may replace OpenMP_CXX_FLAGS while probing the compiler. Ensure
+# the imported target used by RandBLAS carries the SIMD-capable MSVC option.
+if (MSVC AND OpenMP_CXX_FOUND AND TARGET OpenMP::OpenMP_CXX)
+    set_property(TARGET OpenMP::OpenMP_CXX PROPERTY
+        INTERFACE_COMPILE_OPTIONS "/openmp:experimental")
+    set(OpenMP_CXX_FLAGS "/openmp:experimental")
+endif()
 
 set(tmp FALSE)
 if (OpenMP_CXX_FOUND)

--- a/CMake/RandBLASConfig.cmake.in
+++ b/CMake/RandBLASConfig.cmake.in
@@ -23,7 +23,22 @@ find_dependency(Random123)
 # OpenMP
 set(RandBLAS_HAS_OpenMP @RandBLAS_HAS_OpenMP@)
 if (RandBLAS_HAS_OpenMP)
+    # MSVC's standard /openmp mode does not support the omp simd directive
+    # used by RandBLAS's sparse kernels.
+    if (MSVC AND NOT DEFINED OpenMP_CXX_FLAGS)
+        set(OpenMP_CXX_FLAGS "/openmp:experimental" CACHE STRING
+            "OpenMP compiler flags for C++")
+    endif()
+
     find_dependency(OpenMP COMPONENTS CXX)
+
+    # FindOpenMP may retain a previously detected /openmp setting. Ensure that
+    # consumers of the installed package receive the SIMD-capable MSVC mode.
+    if (MSVC AND OpenMP_CXX_FOUND AND TARGET OpenMP::OpenMP_CXX)
+        set_property(TARGET OpenMP::OpenMP_CXX PROPERTY
+            INTERFACE_COMPILE_OPTIONS "/openmp:experimental")
+        set(OpenMP_CXX_FLAGS "/openmp:experimental")
+    endif()
 endif()
 
 # MKL sparse BLAS

--- a/CMake/RandBLASConfig.cmake.in
+++ b/CMake/RandBLASConfig.cmake.in
@@ -10,13 +10,13 @@ set(RandBLAS_COMMIT_HASH "@RandBLAS_COMMIT_HASH@")
 
 # BLAS++
 if (NOT blaspp_DIR)
-    set(blaspp_DIR @blaspp_DIR@)
+    set(blaspp_DIR "@RandBLAS_CONFIG_BLASPP_DIR@")
 endif ()
 find_dependency(blaspp)
 
 # Random123
 if (NOT Random123_DIR)
-    set(Random123_DIR @Random123_DIR@)
+    set(Random123_DIR "@RandBLAS_CONFIG_RANDOM123_DIR@")
 endif ()
 find_dependency(Random123)
 

--- a/CMake/RuntimeDLLs.cmake
+++ b/CMake/RuntimeDLLs.cmake
@@ -1,0 +1,19 @@
+# Native Windows builds use TARGET_RUNTIME_DLLS to stage imported shared-library
+# dependencies beside executables. This generator expression requires CMake 3.21.
+if (WIN32 AND CMAKE_VERSION VERSION_LESS 3.21)
+    message(FATAL_ERROR "RandBLAS native Windows builds require CMake 3.21 or later.")
+endif()
+
+function(randblas_stage_runtime_dlls target)
+    if (WIN32)
+        add_custom_command(
+            TARGET ${target}
+            POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    $<TARGET_RUNTIME_DLLS:${target}>
+                    $<TARGET_FILE_DIR:${target}>
+            COMMAND_EXPAND_LISTS
+            VERBATIM
+        )
+    endif()
+endfunction()

--- a/CMake/rb_config.cmake
+++ b/CMake/rb_config.cmake
@@ -1,3 +1,9 @@
+# Values substituted into an installed CMake package file must use CMake path
+# syntax. In particular, native Windows backslashes would otherwise be parsed
+# as escape sequences when a downstream project loads RandBLASConfig.cmake.
+file(TO_CMAKE_PATH "${blaspp_DIR}" RandBLAS_CONFIG_BLASPP_DIR)
+file(TO_CMAKE_PATH "${Random123_DIR}" RandBLAS_CONFIG_RANDOM123_DIR)
+
 configure_file(CMake/RandBLASConfig.cmake.in
     ${CMAKE_INSTALL_LIBDIR}/cmake/RandBLAS/RandBLASConfig.cmake @ONLY)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake")
 enable_testing()
 include(rb_build_options)
 include(rb_version)
+include(RuntimeDLLs)
 
 # find dependencies
 find_package(blaspp REQUIRED)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,13 +1,13 @@
 
 # Installing and using RandBLAS
 
-This guide has five sections.
+This guide has four main sections and a native-Windows appendix.
 
 Sections 1 through 3 describe how to build and install RandBLAS using CMake.
 
 Section 4 explains how to use RandBLAS in other CMake projects.
 
-Section 5 concludes with extra tips.
+Appendix A follows the same general flow for a native Windows build with MSVC.
 
 If you want a TL;DR version of this guide, refer to one of the following.
  * Our GitHub Actions to [workflow files](https://github.com/BallisticLA/RandBLAS/tree/main/.github/workflows).
@@ -41,7 +41,7 @@ mkdir blaspp-build
 cd blaspp-build
 cmake -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=`pwd`/../blaspp-install \
-    -DCMAKE_BINARY_DIR=`pwd` \ 
+    -DCMAKE_BINARY_DIR=`pwd` \
     -Dbuild_tests=OFF \
     ../blaspp
 make -j install
@@ -66,9 +66,9 @@ RandBLAS does not strictly require OpenMP, but it needs OpenMP to quickly
 sample dense sketching operators and to quickly perform any sparse matrix computations.
 
 RandBLAS' CMake configuration step should automatically detect if OpenMP is available.
-Sometimes the CMake configuration will fail to recognize OpenMP even if it's 
+Sometimes the CMake configuration will fail to recognize OpenMP even if it's
 on your system. This is especially common with the default system compilers on macOS
-(you can execute ``gcc`` or ``g++`` on macOS, but those are just aliased to 
+(you can execute ``gcc`` or ``g++`` on macOS, but those are just aliased to
 limited versions of ``clang`` and ``clang++``). See [this GitHub issue comment](https://github.com/BallisticLA/RandBLAS/issues/86#issue-2248281376)
 for more info.
 
@@ -143,4 +143,198 @@ set(myproject_cxx_source my_project.cc)
 add_executable(my_project ${myproject_cxx_source})
 target_include_directories(myproject PUBLIC ${Random123_DIR})
 target_link_libraries(myproject PUBLIC RandBLAS blaspp lapackpp)
+```
+
+
+## Appendix A. Native Windows installation with MSVC
+
+This appendix gives a native Windows recipe; it does not use WSL. It follows
+the same dependency, build, and downstream-use flow as the main guide. The
+commands use `C:/randblas-work` as a replaceable workspace root and keep source,
+build, and install directories separate.
+
+Run the commands from an **x64 Native Tools Command Prompt for Visual Studio**.
+The recipe uses the NMake generator, so `cmake --build` is serial and does not
+need `--parallel`.
+
+### A.1. Required dependencies: MSVC, oneMKL, BLAS++, and Random123
+
+Install the following tools first:
+
+* Visual Studio 2022 or Build Tools with **Desktop development with C++**;
+* Git;
+* CMake 3.24 or later;
+* vcpkg.
+
+Create the workspace directories:
+
+```bat
+mkdir C:\randblas-work
+mkdir C:\randblas-work\src
+mkdir C:\randblas-work\build
+mkdir C:\randblas-work\install
+```
+
+The following command assumes vcpkg is installed at `C:\vcpkg`. Adjust that
+path if necessary. Install the oneMKL port into a dedicated dependency prefix:
+
+```bat
+C:\vcpkg\vcpkg.exe install intel-mkl:x64-windows ^
+  --x-install-root=C:\randblas-work\vcpkg-installed
+
+set "MKLROOT=C:\randblas-work\vcpkg-installed\x64-windows"
+set "PATH=%MKLROOT%\bin;%PATH%"
+```
+
+Build a shared, sequential, ILP64 BLAS++:
+
+```bat
+git clone --branch windows-portability ^
+  https://github.com/RaphaelArkadyMeyerNYU/blaspp.git ^
+  C:\randblas-work\src\blaspp
+
+cmake --fresh ^
+  -S C:/randblas-work/src/blaspp ^
+  -B C:/randblas-work/build/blaspp ^
+  -G "NMake Makefiles" ^
+  -DCMAKE_BUILD_TYPE=Release ^
+  -DCMAKE_INSTALL_PREFIX=C:/randblas-work/install/blaspp ^
+  -DBUILD_SHARED_LIBS=ON ^
+  -Duse_cmake_find_blas=false ^
+  -DBLAS_LIBRARIES="C:/randblas-work/vcpkg-installed/x64-windows/lib/mkl_intel_ilp64_dll.lib;C:/randblas-work/vcpkg-installed/x64-windows/lib/mkl_sequential_dll.lib;C:/randblas-work/vcpkg-installed/x64-windows/lib/mkl_core_dll.lib" ^
+  -Dblas_int=ilp64 ^
+  -Dblas_threaded=false ^
+  -Duse_openmp=false ^
+  -Dgpu_backend=none ^
+  -Dbuild_tests=OFF
+
+cmake --build C:/randblas-work/build/blaspp --target install
+```
+
+Random123 is header-only. Copy its public headers into a stable installation
+prefix so the installed RandBLAS package does not depend on retaining the
+Random123 source checkout:
+
+```bat
+git clone https://github.com/DEShawResearch/Random123.git ^
+  C:\randblas-work\src\Random123
+
+cmake -E make_directory C:/randblas-work/install/Random123/include
+cmake -E copy_directory ^
+  C:/randblas-work/src/Random123/include/Random123 ^
+  C:/randblas-work/install/Random123/include/Random123
+```
+
+### A.2. Optional dependencies: GoogleTest and OpenMP
+
+GoogleTest is needed only to build and run the RandBLAS test suite. A minimal
+installation can omit GoogleMock:
+
+```bat
+git clone --branch v1.17.0 ^
+  https://github.com/google/googletest.git ^
+  C:\randblas-work\src\googletest
+
+cmake --fresh ^
+  -S C:/randblas-work/src/googletest ^
+  -B C:/randblas-work/build/googletest ^
+  -G "NMake Makefiles" ^
+  -DCMAKE_BUILD_TYPE=Release ^
+  -DCMAKE_INSTALL_PREFIX=C:/randblas-work/install/googletest ^
+  -DBUILD_GMOCK=OFF ^
+  -DINSTALL_GTEST=ON
+
+cmake --build C:/randblas-work/build/googletest --target install
+```
+
+MSVC supplies OpenMP support. RandBLAS's CMake configuration automatically
+selects `/openmp:experimental` under MSVC because its sparse kernels use
+`#pragma omp simd`. No OpenMP flag needs to be added manually.
+
+OpenMP is optional. To request a serial build explicitly, add
+`-DCMAKE_DISABLE_FIND_PACKAGE_OpenMP=TRUE` to the RandBLAS configuration
+command in the next section.
+
+### A.3. Building, installing, and testing RandBLAS
+
+Clone RandBLAS, configure it against the installed BLAS++ and the Random123
+headers, and enable the test suite:
+
+```bat
+git clone https://github.com/BallisticLA/RandBLAS.git ^
+  C:\randblas-work\src\RandBLAS
+
+cmake --fresh ^
+  -S C:/randblas-work/src/RandBLAS ^
+  -B C:/randblas-work/build/RandBLAS ^
+  -G "NMake Makefiles" ^
+  -DCMAKE_BUILD_TYPE=Release ^
+  -DCMAKE_INSTALL_PREFIX=C:/randblas-work/install/RandBLAS ^
+  -Dblaspp_DIR=C:/randblas-work/install/blaspp/blaspp ^
+  -DRandom123_DIR=C:/randblas-work/install/Random123/include ^
+  -DCMAKE_PREFIX_PATH=C:/randblas-work/install/googletest ^
+  -DBUILD_TESTS=ON
+
+cmake --build C:/randblas-work/build/RandBLAS --target install
+
+ctest --test-dir C:/randblas-work/build/RandBLAS --output-on-failure
+```
+
+The exact location of `blasppConfig.cmake` can vary between BLAS++ revisions.
+The value of `blaspp_DIR` must be the directory containing that file. If the
+path above does not exist, locate the installed file with:
+
+```bat
+dir C:\randblas-work\install\blaspp\blasppConfig.cmake /s /b
+```
+
+Similarly, `CMAKE_PREFIX_PATH` points at the GoogleTest installation prefix,
+not directly at `GTestConfig.cmake`.
+
+AddressSanitizer is optional. Add `-DSANITIZE_ADDRESS=ON` to configure an
+instrumented build. This requires the optional **C++ AddressSanitizer**
+component from the Visual Studio Installer.
+
+### A.4. Using the installed package
+
+The CMake target remains the same on every platform:
+
+```cmake
+cmake_minimum_required(VERSION 3.24)
+project(my_randblas_project LANGUAGES CXX)
+
+find_package(RandBLAS REQUIRED)
+
+add_executable(myexec main.cc)
+target_link_libraries(myexec PRIVATE RandBLAS)
+```
+
+Configure and build that consumer by pointing `CMAKE_PREFIX_PATH` at the
+RandBLAS installation:
+
+```bat
+cmake --fresh ^
+  -S C:/path/to/my_randblas_project ^
+  -B C:/path/to/my_randblas_project-build ^
+  -G "NMake Makefiles" ^
+  -DCMAKE_BUILD_TYPE=Release ^
+  -DCMAKE_PREFIX_PATH=C:/randblas-work/install/RandBLAS
+
+cmake --build C:/path/to/my_randblas_project-build
+```
+
+The installed `RandBLASConfig.cmake` records the BLAS++ and Random123 locations
+used to build RandBLAS, so ordinary consumers should not need to supply those
+paths again.
+
+Repository-owned tests copy imported dependency DLLs beside their executables.
+An arbitrary downstream application is responsible for its own deployment.
+When running the example consumer above from the build tree, ensure that the
+oneMKL and BLAS++ runtime directories are on `PATH`, or copy the required DLLs
+beside the executable:
+
+```bat
+set "PATH=C:\randblas-work\vcpkg-installed\x64-windows\bin;C:\randblas-work\install\blaspp\bin;%PATH%"
+
+C:\path\to\my_randblas_project-build\myexec.exe
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -293,7 +293,11 @@ not directly at `GTestConfig.cmake`.
 
 AddressSanitizer is optional. Add `-DSANITIZE_ADDRESS=ON` to configure an
 instrumented build. This requires the optional **C++ AddressSanitizer**
-component from the Visual Studio Installer.
+component from the Visual Studio Installer. When tests are enabled, configure
+and install a separate ASan-enabled copy of GoogleTest by adding
+`-DCMAKE_CXX_FLAGS="/fsanitize=address /Zi"` to the GoogleTest CMake command.
+Then set `CMAKE_PREFIX_PATH` to that GoogleTest installation when configuring
+the sanitized RandBLAS build.
 
 ### A.4. Using the installed package
 

--- a/RandBLAS/CMakeLists.txt
+++ b/RandBLAS/CMakeLists.txt
@@ -70,7 +70,10 @@ if (SANITIZE_ADDRESS)
         # instrumented object, so /fsanitize=address is a compile option rather
         # than a raw link.exe option.
         target_compile_options(RandBLAS INTERFACE
-            $<BUILD_INTERFACE:/fsanitize=address>)
+            $<BUILD_INTERFACE:/fsanitize=address>
+            $<BUILD_INTERFACE:/Zi>)
+        target_link_options(RandBLAS INTERFACE
+            $<BUILD_INTERFACE:/DEBUG>)
     elseif (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
         target_compile_options(RandBLAS INTERFACE
             $<BUILD_INTERFACE:-fsanitize=address>)

--- a/RandBLAS/CMakeLists.txt
+++ b/RandBLAS/CMakeLists.txt
@@ -29,10 +29,7 @@ target_compile_options(RandBLAS INTERFACE
 # functions, which are unavailable in the MSVC runtime. Select Random123's
 # portable separate-sine-and-cosine fallback for native MSVC consumers.
 target_compile_definitions(RandBLAS INTERFACE
-  $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:R123_NO_SINCOS=1>
-  # BLAS++ currently uses GCC/Clang's __PRETTY_FUNCTION__ in a public header.
-  # Map it to the equivalent MSVC function-signature intrinsic.
-  $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:__PRETTY_FUNCTION__=__FUNCSIG__>)
+  $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:R123_NO_SINCOS=1>)
 
 
 target_include_directories(RandBLAS INTERFACE
@@ -58,8 +55,32 @@ target_compile_options(RandBLAS INTERFACE
     $<BUILD_INTERFACE:$<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/W4>>)
 
 if (SANITIZE_ADDRESS)
-    target_compile_options(RandBLAS INTERFACE $<BUILD_INTERFACE:-fsanitize=address>)
-    target_link_options(RandBLAS    INTERFACE $<BUILD_INTERFACE:-fsanitize=address>)
+    if (MSVC)
+        include(CheckCXXCompilerFlag)
+        check_cxx_compiler_flag(
+            "/fsanitize=address"
+            RANDBLAS_MSVC_ADDRESS_SANITIZER_SUPPORTED)
+        if (NOT RANDBLAS_MSVC_ADDRESS_SANITIZER_SUPPORTED)
+            message(FATAL_ERROR
+                "SANITIZE_ADDRESS=ON requires an MSVC toolchain with "
+                "/fsanitize=address support and its AddressSanitizer runtime "
+                "libraries installed.")
+        endif()
+        # MSVC records the required AddressSanitizer runtime in each
+        # instrumented object, so /fsanitize=address is a compile option rather
+        # than a raw link.exe option.
+        target_compile_options(RandBLAS INTERFACE
+            $<BUILD_INTERFACE:/fsanitize=address>)
+    elseif (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        target_compile_options(RandBLAS INTERFACE
+            $<BUILD_INTERFACE:-fsanitize=address>)
+        target_link_options(RandBLAS INTERFACE
+            $<BUILD_INTERFACE:-fsanitize=address>)
+    else()
+        message(FATAL_ERROR
+            "SANITIZE_ADDRESS=ON is not supported with "
+            "${CMAKE_CXX_COMPILER_ID}.")
+    endif()
 endif()
 
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/../RandBLAS.hh"

--- a/RandBLAS/CMakeLists.txt
+++ b/RandBLAS/CMakeLists.txt
@@ -25,6 +25,12 @@ target_compile_options(RandBLAS INTERFACE
   $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/EHsc>
   $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/Zc:__cplusplus>)
 
+# Random123's boxmuller.hpp otherwise calls the nonstandard sincos/sincosf
+# functions, which are unavailable in the MSVC runtime. Select Random123's
+# portable separate-sine-and-cosine fallback for native MSVC consumers.
+target_compile_definitions(RandBLAS INTERFACE
+  $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:R123_NO_SINCOS=1>)
+
 
 target_include_directories(RandBLAS INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/RandBLAS/CMakeLists.txt
+++ b/RandBLAS/CMakeLists.txt
@@ -29,7 +29,10 @@ target_compile_options(RandBLAS INTERFACE
 # functions, which are unavailable in the MSVC runtime. Select Random123's
 # portable separate-sine-and-cosine fallback for native MSVC consumers.
 target_compile_definitions(RandBLAS INTERFACE
-  $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:R123_NO_SINCOS=1>)
+  $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:R123_NO_SINCOS=1>
+  # BLAS++ currently uses GCC/Clang's __PRETTY_FUNCTION__ in a public header.
+  # Map it to the equivalent MSVC function-signature intrinsic.
+  $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:__PRETTY_FUNCTION__=__FUNCSIG__>)
 
 
 target_include_directories(RandBLAS INTERFACE

--- a/RandBLAS/CMakeLists.txt
+++ b/RandBLAS/CMakeLists.txt
@@ -17,6 +17,14 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/config.h
 add_library(RandBLAS INTERFACE)
 target_compile_features(RandBLAS INTERFACE cxx_std_20)
 
+# RandBLAS is header-only, so these MSVC requirements must propagate to every
+# translation unit that includes its headers. /Zc:__cplusplus makes MSVC report
+# the selected language standard correctly (which Random123 inspects), while
+# /EHsc enables standard C++ exception-unwind semantics for code using the API.
+target_compile_options(RandBLAS INTERFACE
+  $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/EHsc>
+  $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/Zc:__cplusplus>)
+
 
 target_include_directories(RandBLAS INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/RandBLAS/CMakeLists.txt
+++ b/RandBLAS/CMakeLists.txt
@@ -32,10 +32,13 @@ endif()
 target_link_libraries(RandBLAS INTERFACE ${RandBLAS_libs})
 
 # Build-time only: warning and sanitizer flags should not leak into the installed target.
+# Use each compiler family's warning options without passing Unix-style flags
+# to MSVC. Keep -Wno-comment for GNU/Clang builds.
 target_compile_options(RandBLAS INTERFACE
-    $<BUILD_INTERFACE:-Wall>
-    $<BUILD_INTERFACE:-Wextra>
-    $<BUILD_INTERFACE:-Wno-comment>)
+    $<BUILD_INTERFACE:$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang>:-Wall>>
+    $<BUILD_INTERFACE:$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang>:-Wextra>>
+    $<BUILD_INTERFACE:$<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang>:-Wno-comment>>
+    $<BUILD_INTERFACE:$<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/W4>>)
 
 if (SANITIZE_ADDRESS)
     target_compile_options(RandBLAS INTERFACE $<BUILD_INTERFACE:-fsanitize=address>)

--- a/RandBLAS/testing/comparison.hh
+++ b/RandBLAS/testing/comparison.hh
@@ -36,6 +36,16 @@
 #include <string>
 #include "RandBLAS.hh"
 
+// Compiler-specific spellings for the function signature printed in test
+// failure diagnostics. Keep this test utility out of the installed RandBLAS
+// target's compiler definitions.
+#if defined(_MSC_VER)
+    #define RANDBLAS_TEST_FUNCTION_SIGNATURE __FUNCSIG__
+#elif defined(__GNUC__) || defined(__clang__)
+    #define RANDBLAS_TEST_FUNCTION_SIGNATURE __PRETTY_FUNCTION__
+#else
+    #define RANDBLAS_TEST_FUNCTION_SIGNATURE __func__
+#endif
 
 namespace RandBLAS::testing {
 

--- a/RandBLAS/testing/comparison.hh
+++ b/RandBLAS/testing/comparison.hh
@@ -40,11 +40,11 @@
 // failure diagnostics. Keep this test utility out of the installed RandBLAS
 // target's compiler definitions.
 #if defined(_MSC_VER)
-    #define RANDBLAS_TEST_FUNCTION_SIGNATURE __FUNCSIG__
+    #define __RANDBLAS_PRETTY_FUNCTION__ __FUNCSIG__
 #elif defined(__GNUC__) || defined(__clang__)
-    #define RANDBLAS_TEST_FUNCTION_SIGNATURE __PRETTY_FUNCTION__
+    #define __RANDBLAS_PRETTY_FUNCTION__ __PRETTY_FUNCTION__
 #else
-    #define RANDBLAS_TEST_FUNCTION_SIGNATURE __func__
+    #define __RANDBLAS_PRETTY_FUNCTION__ __func__
 #endif
 
 namespace RandBLAS::testing {

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.12)
 
 project(examples)
 
+include("${CMAKE_CURRENT_LIST_DIR}/../CMake/RuntimeDLLs.cmake")
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
@@ -34,7 +36,7 @@ target_include_directories(
     tls_dense_skop PUBLIC ${Random123_DIR}
 )
 target_link_libraries(
-    tls_dense_skop PUBLIC RandBLAS blaspp lapackpp 
+    tls_dense_skop PUBLIC RandBLAS blaspp lapackpp
 )
 
 set(
@@ -47,7 +49,7 @@ target_include_directories(
     tls_sparse_skop PUBLIC ${Random123_DIR}
 )
 target_link_libraries(
-    tls_sparse_skop PUBLIC RandBLAS blaspp lapackpp 
+    tls_sparse_skop PUBLIC RandBLAS blaspp lapackpp
 )
 
 add_executable(
@@ -112,5 +114,14 @@ target_link_libraries(
     sketch_general_performance PUBLIC RandBLAS blaspp lapackpp
 )
 
-
-
+foreach(example_target IN ITEMS
+    tls_dense_skop
+    tls_sparse_skop
+    slra_svd_synthetic
+    slra_svd_fmm
+    slra_qrcp
+    spmm_performance
+    sketch_general_performance
+)
+    randblas_stage_runtime_dlls(${example_target})
+endforeach()

--- a/examples/sparse-low-rank-approx/qrcp_matrixmarket.cc
+++ b/examples/sparse-low-rank-approx/qrcp_matrixmarket.cc
@@ -31,7 +31,6 @@
 #include <lapack.hh>
 #include <omp.h>
 #include <stdio.h>
-#include <unistd.h>
 #include <iostream>
 #include <cmath>
 #include <time.h>

--- a/examples/sparse-low-rank-approx/svd_matrixmarket.cc
+++ b/examples/sparse-low-rank-approx/svd_matrixmarket.cc
@@ -198,7 +198,7 @@ void qb_to_svd(int64_t m, int64_t n, int64_t k, T* Q, T* svals, int64_t ldq, T* 
 
     // update Q = Q U.
     bool allocate_more_work = extra_work_size < m*k;
-    T* more_work = (allocate_more_work) ? new T[m*k] : (work + k*(k+1)); 
+    T* more_work = (allocate_more_work) ? new T[m*k] : (work + k*k);
     lapack::lacpy(MatrixType::General, m, k, Q, ldq, more_work, m);
     blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, k, k, 1.0, more_work, m, U, k, 0.0, Q, ldq);
 

--- a/examples/sparse-low-rank-approx/svd_matrixmarket.cc
+++ b/examples/sparse-low-rank-approx/svd_matrixmarket.cc
@@ -32,7 +32,6 @@
 #include <lapack.hh>
 #include <omp.h>
 #include <stdio.h>
-#include <unistd.h>
 #include <iostream>
 #include <cmath>
 #include <time.h>

--- a/examples/sparse-low-rank-approx/svd_rank1_plus_noise.cc
+++ b/examples/sparse-low-rank-approx/svd_rank1_plus_noise.cc
@@ -32,7 +32,6 @@
 #include <lapack.hh>
 #include <omp.h>
 #include <stdio.h>
-#include <unistd.h>
 #include <iostream>
 #include <cmath>
 #include <time.h>

--- a/examples/sparse-low-rank-approx/svd_rank1_plus_noise.cc
+++ b/examples/sparse-low-rank-approx/svd_rank1_plus_noise.cc
@@ -281,7 +281,7 @@ void qb_to_svd(int64_t m, int64_t n, int64_t k, T* Q, T* svals, int64_t ldq, T* 
     lapack::gesdd(Job::OverwriteVec, k, n, B, ldb, svals, U, k, nullptr, k);
 
     // update Q = Q U.
-    T* more_work = work + k*(k+1);
+    T* more_work = work + k*k;
     bool allocate_more_work = extra_work_size < m*k;
     if (allocate_more_work)
         more_work = new T[m*k];

--- a/examples/total-least-squares/tls_dense_skop.cc
+++ b/examples/total-least-squares/tls_dense_skop.cc
@@ -33,12 +33,12 @@
 
 #include <omp.h>
 #include <stdio.h>
-#include <unistd.h>
 #include <iostream>
 #include <cmath>
 #include <time.h>
 #include <stdlib.h>
 #include <chrono>
+#include <vector>
 
 using std::chrono::high_resolution_clock;
 using std::chrono::duration_cast;
@@ -47,8 +47,8 @@ using std::chrono::milliseconds;
 
 
 void init_noisy_data(int64_t m, int64_t n, int64_t d, double* AB){
-    double target_x[n*d];
-    double eps[m*d];
+    std::vector<double> target_x(n*d);
+    std::vector<double> eps(m*d);
     for (int i = 0; i < n; i++) {  
         target_x[i] = 1;   // Target X is the vector of 1's
     }
@@ -59,9 +59,9 @@ void init_noisy_data(int64_t m, int64_t n, int64_t d, double* AB){
     RandBLAS::RNGState state1(1);
 
     RandBLAS::fill_dense(Dist_A, AB, state);  //Fill A to be a random gaussian
-    RandBLAS::fill_dense(Dist_eps, eps, state1);  //Fill A to be a random gaussian
+    RandBLAS::fill_dense(Dist_eps, eps.data(), state1);  //Fill A to be a random gaussian
 
-    blas::gemm(blas::Layout::ColMajor, blas::Op::NoTrans, blas::Op::NoTrans, m, d, n, 1, AB, m, target_x, n, 0, &AB[m*n], m);
+    blas::gemm(blas::Layout::ColMajor, blas::Op::NoTrans, blas::Op::NoTrans, m, d, n, 1, AB, m, target_x.data(), n, 0, &AB[m*n], m);
 
     for (int i = 0; i < m*d; i++){
         AB[m*n + i] += eps[i];   // Add Gaussian Noise to right hand side

--- a/examples/total-least-squares/tls_sparse_skop.cc
+++ b/examples/total-least-squares/tls_sparse_skop.cc
@@ -33,12 +33,12 @@
 
 #include <omp.h>
 #include <stdio.h>
-#include <unistd.h>
 #include <iostream>
 #include <cmath>
 #include <time.h>
 #include <stdlib.h>
 #include <chrono>
+#include <vector>
 
 using std::chrono::high_resolution_clock;
 using std::chrono::duration_cast;
@@ -49,8 +49,8 @@ using std::chrono::milliseconds;
 //TODO: Have the user choose between dense and sketch sketching operator (4 nnz per col)
 
 void init_noisy_data(int64_t m, int64_t n, int64_t d, double* AB){
-    double target_x[n*d];
-    double eps[m*d];
+    std::vector<double> target_x(n*d);
+    std::vector<double> eps(m*d);
     for (int i = 0; i < n; i++) {  
         target_x[i] = 1;   // Target X is the vector of 1's
     }
@@ -61,9 +61,9 @@ void init_noisy_data(int64_t m, int64_t n, int64_t d, double* AB){
     RandBLAS::RNGState state1(1);
 
     RandBLAS::fill_dense(Dist_A, AB, state);  //Fill A to be a random gaussian
-    RandBLAS::fill_dense(Dist_eps, eps, state1);  //Fill A to be a random gaussian
+    RandBLAS::fill_dense(Dist_eps, eps.data(), state1);  //Fill A to be a random gaussian
 
-    blas::gemm(blas::Layout::ColMajor, blas::Op::NoTrans, blas::Op::NoTrans, m, d, n, 1, AB, m, target_x, n, 0, &AB[m*n], m);
+    blas::gemm(blas::Layout::ColMajor, blas::Op::NoTrans, blas::Op::NoTrans, m, d, n, 1, AB, m, target_x.data(), n, 0, &AB[m*n], m);
 
     for (int i = 0; i < m*d; i++){
         AB[m*n + i] += eps[i];   // Add Gaussian Noise to right hand side

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,6 +25,7 @@ if (GTest_FOUND)
     )
     add_executable(densedata_tests ${DENSEDATA_SOURCES})
     target_link_libraries(densedata_tests RandBLAS GTest::GTest GTest::Main)
+    randblas_stage_runtime_dlls(densedata_tests)
     gtest_discover_tests(densedata_tests)
 
     #####################################################################
@@ -49,6 +50,7 @@ if (GTest_FOUND)
     )
     add_executable(sparsedata_tests ${SPARSEDATA_SOURCES})
     target_link_libraries(sparsedata_tests RandBLAS GTest::GTest GTest::Main)
+    randblas_stage_runtime_dlls(sparsedata_tests)
     gtest_discover_tests(sparsedata_tests)
 
     #####################################################################
@@ -68,6 +70,7 @@ if (GTest_FOUND)
     # Bake the KAT vector path in at compile time so the test is cwd-independent.
     target_compile_definitions(stat_tests PRIVATE
         KAT_VECTORS_PATH="${CMAKE_CURRENT_SOURCE_DIR}/basic_rng/r123_kat_vectors.txt")
+    randblas_stage_runtime_dlls(stat_tests)
     gtest_discover_tests(stat_tests)
 
     #####################################################################
@@ -79,6 +82,7 @@ if (GTest_FOUND)
     set(META_SOURCES meta/test_lapack_like.cc meta/test_sparse_data_generators.cc meta/test_comparison.cc)
     add_executable(meta_tests ${META_SOURCES})
     target_link_libraries(meta_tests RandBLAS GTest::GTest GTest::Main)
+    randblas_stage_runtime_dlls(meta_tests)
     gtest_discover_tests(meta_tests)
 
     #####################################################################
@@ -90,6 +94,7 @@ if (GTest_FOUND)
     set(MISC_SOURCES test_io.cc test_exceptions.cc)
     add_executable(misc_tests ${MISC_SOURCES})
     target_link_libraries(misc_tests RandBLAS GTest::GTest GTest::Main)
+    randblas_stage_runtime_dlls(misc_tests)
     gtest_discover_tests(misc_tests)
 
     #####################################################################
@@ -104,9 +109,11 @@ if (GTest_FOUND)
         ${MISC_SOURCES}
     )
     target_link_libraries(all_correctness_tests RandBLAS GTest::GTest GTest::Main)
+    randblas_stage_runtime_dlls(all_correctness_tests)
 
 endif()
 message(STATUS "Checking for regression tests ... ${tmp}")
 
 add_executable(test_rng_speed basic_rng/benchmark_speed.cc)
 target_link_libraries(test_rng_speed RandBLAS)
+randblas_stage_runtime_dlls(test_rng_speed)

--- a/test/basic_rng/test_discrete.cc
+++ b/test/basic_rng/test_discrete.cc
@@ -323,7 +323,7 @@ class TestSampleIndices : public ::testing::Test
         auto ctr_onecall = t.counter.v[0];
         EXPECT_EQ( ctr_onecall, ctr_twocall );
 
-        auto msg = RandBLAS::testing::buffs_approx_equal(onecall.data(), twocall.data(), r_total*k, __PRETTY_FUNCTION__, __FILE__, __LINE__);
+        auto msg = RandBLAS::testing::buffs_approx_equal(onecall.data(), twocall.data(), r_total*k, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
         if (msg.size() > 0) {
             FAIL() << msg;
         }

--- a/test/basic_rng/test_discrete.cc
+++ b/test/basic_rng/test_discrete.cc
@@ -323,7 +323,7 @@ class TestSampleIndices : public ::testing::Test
         auto ctr_onecall = t.counter.v[0];
         EXPECT_EQ( ctr_onecall, ctr_twocall );
 
-        auto msg = RandBLAS::testing::buffs_approx_equal(onecall.data(), twocall.data(), r_total*k, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
+        auto msg = RandBLAS::testing::buffs_approx_equal(onecall.data(), twocall.data(), r_total*k, __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__);
         if (msg.size() > 0) {
             FAIL() << msg;
         }

--- a/test/datastructures/test_coo_matrix.cc
+++ b/test/datastructures/test_coo_matrix.cc
@@ -88,7 +88,7 @@ class TestCOO : public ::testing::Test {
         coo_to_dense(A, 1, n, expect.data());
 
         auto msg = RandBLAS::testing::buffs_approx_equal(actual.data(), expect.data(), n * n,
-            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+            __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -331,7 +331,7 @@ class Test_SkOp_to_COO : public ::testing::Test {
         coo_to_dense(A, Layout::ColMajor, A_dense.data());
     
         auto msg = RandBLAS::testing::buffs_approx_equal(S_dense.data(), A_dense.data(), d * m,
-            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+            __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;

--- a/test/datastructures/test_coo_matrix.cc
+++ b/test/datastructures/test_coo_matrix.cc
@@ -88,7 +88,7 @@ class TestCOO : public ::testing::Test {
         coo_to_dense(A, 1, n, expect.data());
 
         auto msg = RandBLAS::testing::buffs_approx_equal(actual.data(), expect.data(), n * n,
-            __PRETTY_FUNCTION__, __FILE__, __LINE__
+            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -331,7 +331,7 @@ class Test_SkOp_to_COO : public ::testing::Test {
         coo_to_dense(A, Layout::ColMajor, A_dense.data());
     
         auto msg = RandBLAS::testing::buffs_approx_equal(S_dense.data(), A_dense.data(), d * m,
-            __PRETTY_FUNCTION__, __FILE__, __LINE__
+            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;

--- a/test/datastructures/test_csc_matrix.cc
+++ b/test/datastructures/test_csc_matrix.cc
@@ -68,7 +68,7 @@ class TestCSC_Conversions : public ::testing::Test {
 
         // check equivalence of dn_mat and dn_mat_recon
         auto msg = RandBLAS::testing::buffs_approx_equal(dn_mat, dn_mat_recon, m * n,
-            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+            __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -104,7 +104,7 @@ class TestCSC_Conversions : public ::testing::Test {
         auto msg = RandBLAS::testing::matrices_approx_equal(
             Layout::ColMajor, Layout::ColMajor, blas::Op::NoTrans,
             m, n, mat_expect, m, mat_actual, m,
-            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+            __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -131,7 +131,7 @@ class TestCSC_Conversions : public ::testing::Test {
         auto msg = RandBLAS::testing::matrices_approx_equal(
             Layout::ColMajor, Layout::ColMajor, blas::Op::NoTrans,
             n, n, A_dense_csc.data(), n, A_dense_coo.data(), n,
-            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+            __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;

--- a/test/datastructures/test_csc_matrix.cc
+++ b/test/datastructures/test_csc_matrix.cc
@@ -68,7 +68,7 @@ class TestCSC_Conversions : public ::testing::Test {
 
         // check equivalence of dn_mat and dn_mat_recon
         auto msg = RandBLAS::testing::buffs_approx_equal(dn_mat, dn_mat_recon, m * n,
-            __PRETTY_FUNCTION__, __FILE__, __LINE__
+            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -104,7 +104,7 @@ class TestCSC_Conversions : public ::testing::Test {
         auto msg = RandBLAS::testing::matrices_approx_equal(
             Layout::ColMajor, Layout::ColMajor, blas::Op::NoTrans,
             m, n, mat_expect, m, mat_actual, m,
-            __PRETTY_FUNCTION__, __FILE__, __LINE__
+            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -131,7 +131,7 @@ class TestCSC_Conversions : public ::testing::Test {
         auto msg = RandBLAS::testing::matrices_approx_equal(
             Layout::ColMajor, Layout::ColMajor, blas::Op::NoTrans,
             n, n, A_dense_csc.data(), n, A_dense_coo.data(), n,
-            __PRETTY_FUNCTION__, __FILE__, __LINE__
+            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;

--- a/test/datastructures/test_csr_matrix.cc
+++ b/test/datastructures/test_csr_matrix.cc
@@ -68,7 +68,7 @@ class TestCSR_Conversions : public ::testing::Test
         for (int i = 0; i < n; ++i)
             eye[i + n*i] = 1.0 + (T) i;
         auto msg = RandBLAS::testing::buffs_approx_equal(mat, eye, n * n,
-            __PRETTY_FUNCTION__, __FILE__, __LINE__
+            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -96,7 +96,7 @@ class TestCSR_Conversions : public ::testing::Test
 
         // check equivalence of dn_mat and dn_mat_recon
         auto msg = RandBLAS::testing::buffs_approx_equal(dn_mat, dn_mat_recon, m * n,
-            __PRETTY_FUNCTION__, __FILE__, __LINE__
+            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -132,7 +132,7 @@ class TestCSR_Conversions : public ::testing::Test
         auto msg = RandBLAS::testing::matrices_approx_equal(
             Layout::ColMajor, Layout::ColMajor, blas::Op::NoTrans,
             m, n, mat_expect, m, mat_actual, m,
-            __PRETTY_FUNCTION__, __FILE__, __LINE__
+            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -160,7 +160,7 @@ class TestCSR_Conversions : public ::testing::Test
         auto msg = RandBLAS::testing::matrices_approx_equal(
             Layout::ColMajor, Layout::ColMajor, blas::Op::NoTrans,
             n, n, A_dense_csr.data(), n, A_dense_coo.data(), n,
-            __PRETTY_FUNCTION__, __FILE__, __LINE__
+            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;

--- a/test/datastructures/test_csr_matrix.cc
+++ b/test/datastructures/test_csr_matrix.cc
@@ -68,7 +68,7 @@ class TestCSR_Conversions : public ::testing::Test
         for (int i = 0; i < n; ++i)
             eye[i + n*i] = 1.0 + (T) i;
         auto msg = RandBLAS::testing::buffs_approx_equal(mat, eye, n * n,
-            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+            __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -96,7 +96,7 @@ class TestCSR_Conversions : public ::testing::Test
 
         // check equivalence of dn_mat and dn_mat_recon
         auto msg = RandBLAS::testing::buffs_approx_equal(dn_mat, dn_mat_recon, m * n,
-            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+            __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -132,7 +132,7 @@ class TestCSR_Conversions : public ::testing::Test
         auto msg = RandBLAS::testing::matrices_approx_equal(
             Layout::ColMajor, Layout::ColMajor, blas::Op::NoTrans,
             m, n, mat_expect, m, mat_actual, m,
-            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+            __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -160,7 +160,7 @@ class TestCSR_Conversions : public ::testing::Test
         auto msg = RandBLAS::testing::matrices_approx_equal(
             Layout::ColMajor, Layout::ColMajor, blas::Op::NoTrans,
             n, n, A_dense_csr.data(), n, A_dense_coo.data(), n,
-            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+            __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;

--- a/test/datastructures/test_denseskop.cc
+++ b/test/datastructures/test_denseskop.cc
@@ -371,7 +371,7 @@ class TestFillAxis : public::testing::Test
         auto msg = RandBLAS::testing::matrices_approx_equal(
             S_wide.layout, S_tall.layout, blas::Op::Trans, short_dim, long_dim,
             S_wide.buff, lds_wide, S_tall.buff, lds_tall,
-            __PRETTY_FUNCTION__, __FILE__, __LINE__
+            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;

--- a/test/datastructures/test_denseskop.cc
+++ b/test/datastructures/test_denseskop.cc
@@ -371,7 +371,7 @@ class TestFillAxis : public::testing::Test
         auto msg = RandBLAS::testing::matrices_approx_equal(
             S_wide.layout, S_tall.layout, blas::Op::Trans, short_dim, long_dim,
             S_wide.buff, lds_wide, S_tall.buff, lds_tall,
-            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+            __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;

--- a/test/datastructures/test_sparseskop.cc
+++ b/test/datastructures/test_sparseskop.cc
@@ -135,15 +135,15 @@ class TestSparseSkOpConstruction : public ::testing::Test
         auto S = new SparseSkOp(sd, state, next_state, -1, vals.data(), rows.data(), cols.data());
         // check that nothing has changed
         std::string msg;
-        msg = RandBLAS::testing::buffs_approx_equal(rows.data(), rows_copy.data(), sd.full_nnz, __PRETTY_FUNCTION__, __FILE__, __LINE__, (sint_t) 0, (sint_t) 0);
+        msg = RandBLAS::testing::buffs_approx_equal(rows.data(), rows_copy.data(), sd.full_nnz, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__, (sint_t) 0, (sint_t) 0);
         if (msg.size() > 0) {
             FAIL() << msg;
         }
-        msg = RandBLAS::testing::buffs_approx_equal(cols.data(), cols_copy.data(), sd.full_nnz, __PRETTY_FUNCTION__, __FILE__, __LINE__, (sint_t) 0, (sint_t) 0);
+        msg = RandBLAS::testing::buffs_approx_equal(cols.data(), cols_copy.data(), sd.full_nnz, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__, (sint_t) 0, (sint_t) 0);
         if (msg.size() > 0) {
             FAIL() << msg;
         }
-        msg = RandBLAS::testing::buffs_approx_equal(vals.data(), vals_copy.data(), sd.full_nnz, __PRETTY_FUNCTION__, __FILE__, __LINE__, (T) 0, (T) 0);
+        msg = RandBLAS::testing::buffs_approx_equal(vals.data(), vals_copy.data(), sd.full_nnz, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__, (T) 0, (T) 0);
         if (msg.size() > 0) {
             FAIL() << msg;
         }
@@ -159,15 +159,15 @@ class TestSparseSkOpConstruction : public ::testing::Test
         }
         // delete S, and make sure the rows,cols,vals are unchanged from before the deletion.
         delete S;
-        msg = RandBLAS::testing::buffs_approx_equal(rows.data(), rows_copy.data(), sd.full_nnz, __PRETTY_FUNCTION__, __FILE__, __LINE__, (sint_t) 0, (sint_t) 0);
+        msg = RandBLAS::testing::buffs_approx_equal(rows.data(), rows_copy.data(), sd.full_nnz, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__, (sint_t) 0, (sint_t) 0);
         if (msg.size() > 0) {
             FAIL() << msg;
         }
-        msg = RandBLAS::testing::buffs_approx_equal(cols.data(), cols_copy.data(), sd.full_nnz, __PRETTY_FUNCTION__, __FILE__, __LINE__, (sint_t) 0, (sint_t) 0);
+        msg = RandBLAS::testing::buffs_approx_equal(cols.data(), cols_copy.data(), sd.full_nnz, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__, (sint_t) 0, (sint_t) 0);
         if (msg.size() > 0) {
             FAIL() << msg;
         }
-        msg = RandBLAS::testing::buffs_approx_equal(vals.data(), vals_copy.data(), sd.full_nnz, __PRETTY_FUNCTION__, __FILE__, __LINE__, (T) 0, (T) 0);
+        msg = RandBLAS::testing::buffs_approx_equal(vals.data(), vals_copy.data(), sd.full_nnz, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__, (T) 0, (T) 0);
         if (msg.size() > 0) {
             FAIL() << msg;
         }
@@ -190,19 +190,19 @@ class TestSparseSkOpConstruction : public ::testing::Test
         EXPECT_TRUE(actual_next == expect_next);
         std::string msg;
         msg = RandBLAS::testing::buffs_approx_equal(
-            vals.data(), S.vals, nnz, __PRETTY_FUNCTION__, __FILE__, __LINE__
+            vals.data(), S.vals, nnz, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
         }
         msg = RandBLAS::testing::buffs_approx_equal(
-            rows.data(), S.rows, nnz,  __PRETTY_FUNCTION__, __FILE__, __LINE__
+            rows.data(), S.rows, nnz,  RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
         }
         msg = RandBLAS::testing::buffs_approx_equal(
-            cols.data(), S.cols, nnz,  __PRETTY_FUNCTION__, __FILE__, __LINE__
+            cols.data(), S.cols, nnz,  RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -270,7 +270,7 @@ class TestSparseSkOpConstruction : public ::testing::Test
         }
         std::string msg = RandBLAS::testing::buffs_approx_equal(
             dense_sub.data(), dense_oracle.data(), n_rows_sub * n_cols_sub,
-            __PRETTY_FUNCTION__, __FILE__, __LINE__
+            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;

--- a/test/datastructures/test_sparseskop.cc
+++ b/test/datastructures/test_sparseskop.cc
@@ -135,15 +135,15 @@ class TestSparseSkOpConstruction : public ::testing::Test
         auto S = new SparseSkOp(sd, state, next_state, -1, vals.data(), rows.data(), cols.data());
         // check that nothing has changed
         std::string msg;
-        msg = RandBLAS::testing::buffs_approx_equal(rows.data(), rows_copy.data(), sd.full_nnz, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__, (sint_t) 0, (sint_t) 0);
+        msg = RandBLAS::testing::buffs_approx_equal(rows.data(), rows_copy.data(), sd.full_nnz, __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__, (sint_t) 0, (sint_t) 0);
         if (msg.size() > 0) {
             FAIL() << msg;
         }
-        msg = RandBLAS::testing::buffs_approx_equal(cols.data(), cols_copy.data(), sd.full_nnz, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__, (sint_t) 0, (sint_t) 0);
+        msg = RandBLAS::testing::buffs_approx_equal(cols.data(), cols_copy.data(), sd.full_nnz, __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__, (sint_t) 0, (sint_t) 0);
         if (msg.size() > 0) {
             FAIL() << msg;
         }
-        msg = RandBLAS::testing::buffs_approx_equal(vals.data(), vals_copy.data(), sd.full_nnz, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__, (T) 0, (T) 0);
+        msg = RandBLAS::testing::buffs_approx_equal(vals.data(), vals_copy.data(), sd.full_nnz, __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__, (T) 0, (T) 0);
         if (msg.size() > 0) {
             FAIL() << msg;
         }
@@ -159,15 +159,15 @@ class TestSparseSkOpConstruction : public ::testing::Test
         }
         // delete S, and make sure the rows,cols,vals are unchanged from before the deletion.
         delete S;
-        msg = RandBLAS::testing::buffs_approx_equal(rows.data(), rows_copy.data(), sd.full_nnz, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__, (sint_t) 0, (sint_t) 0);
+        msg = RandBLAS::testing::buffs_approx_equal(rows.data(), rows_copy.data(), sd.full_nnz, __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__, (sint_t) 0, (sint_t) 0);
         if (msg.size() > 0) {
             FAIL() << msg;
         }
-        msg = RandBLAS::testing::buffs_approx_equal(cols.data(), cols_copy.data(), sd.full_nnz, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__, (sint_t) 0, (sint_t) 0);
+        msg = RandBLAS::testing::buffs_approx_equal(cols.data(), cols_copy.data(), sd.full_nnz, __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__, (sint_t) 0, (sint_t) 0);
         if (msg.size() > 0) {
             FAIL() << msg;
         }
-        msg = RandBLAS::testing::buffs_approx_equal(vals.data(), vals_copy.data(), sd.full_nnz, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__, (T) 0, (T) 0);
+        msg = RandBLAS::testing::buffs_approx_equal(vals.data(), vals_copy.data(), sd.full_nnz, __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__, (T) 0, (T) 0);
         if (msg.size() > 0) {
             FAIL() << msg;
         }
@@ -190,19 +190,19 @@ class TestSparseSkOpConstruction : public ::testing::Test
         EXPECT_TRUE(actual_next == expect_next);
         std::string msg;
         msg = RandBLAS::testing::buffs_approx_equal(
-            vals.data(), S.vals, nnz, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+            vals.data(), S.vals, nnz, __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
         }
         msg = RandBLAS::testing::buffs_approx_equal(
-            rows.data(), S.rows, nnz,  RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+            rows.data(), S.rows, nnz,  __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
         }
         msg = RandBLAS::testing::buffs_approx_equal(
-            cols.data(), S.cols, nnz,  RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+            cols.data(), S.cols, nnz,  __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -270,7 +270,7 @@ class TestSparseSkOpConstruction : public ::testing::Test
         }
         std::string msg = RandBLAS::testing::buffs_approx_equal(
             dense_sub.data(), dense_oracle.data(), n_rows_sub * n_cols_sub,
-            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+            __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;

--- a/test/datastructures/test_spmat_conversions.cc
+++ b/test/datastructures/test_spmat_conversions.cc
@@ -63,7 +63,7 @@ class TestSparseTranspose : public ::testing::Test
         std::string msg;
         msg = RandBLAS::testing::matrices_approx_equal(
             layout, blas::Op::Trans, m, n, A_dense.data(), m, At_dense.data(), n,
-            __PRETTY_FUNCTION__, __FILE__, __LINE__
+            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -75,7 +75,7 @@ class TestSparseTranspose : public ::testing::Test
         csc_to_dense(At_csc_copy, layout, At_dense.data());
         msg = RandBLAS::testing::matrices_approx_equal(
             layout, blas::Op::Trans, m, n, A_dense.data(), m, At_dense.data(), n,
-            __PRETTY_FUNCTION__, __FILE__, __LINE__
+            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -97,7 +97,7 @@ class TestSparseTranspose : public ::testing::Test
         csr_to_dense(At_csr_view, layout, At_dense.data());
         msg = RandBLAS::testing::matrices_approx_equal(
             layout, blas::Op::Trans, m, n, A_dense.data(), m, At_dense.data(), n,
-            __PRETTY_FUNCTION__, __FILE__, __LINE__
+            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -110,7 +110,7 @@ class TestSparseTranspose : public ::testing::Test
         csr_to_dense(At_csr_copy, layout, At_dense.data());
         msg = RandBLAS::testing::matrices_approx_equal(
             layout, blas::Op::Trans, m, n, A_dense.data(), m, At_dense.data(), n,
-            __PRETTY_FUNCTION__, __FILE__, __LINE__
+            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;

--- a/test/datastructures/test_spmat_conversions.cc
+++ b/test/datastructures/test_spmat_conversions.cc
@@ -63,7 +63,7 @@ class TestSparseTranspose : public ::testing::Test
         std::string msg;
         msg = RandBLAS::testing::matrices_approx_equal(
             layout, blas::Op::Trans, m, n, A_dense.data(), m, At_dense.data(), n,
-            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+            __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -75,7 +75,7 @@ class TestSparseTranspose : public ::testing::Test
         csc_to_dense(At_csc_copy, layout, At_dense.data());
         msg = RandBLAS::testing::matrices_approx_equal(
             layout, blas::Op::Trans, m, n, A_dense.data(), m, At_dense.data(), n,
-            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+            __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -97,7 +97,7 @@ class TestSparseTranspose : public ::testing::Test
         csr_to_dense(At_csr_view, layout, At_dense.data());
         msg = RandBLAS::testing::matrices_approx_equal(
             layout, blas::Op::Trans, m, n, A_dense.data(), m, At_dense.data(), n,
-            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+            __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -110,7 +110,7 @@ class TestSparseTranspose : public ::testing::Test
         csr_to_dense(At_csr_copy, layout, At_dense.data());
         msg = RandBLAS::testing::matrices_approx_equal(
             layout, blas::Op::Trans, m, n, A_dense.data(), m, At_dense.data(), n,
-            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+            __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;

--- a/test/downstream/CMakeLists.txt
+++ b/test/downstream/CMakeLists.txt
@@ -7,6 +7,8 @@
 cmake_minimum_required(VERSION 3.11)
 project(randblas_downstream_smoke CXX)
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../CMake/RuntimeDLLs.cmake")
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -14,3 +16,4 @@ find_package(RandBLAS REQUIRED)
 
 add_executable(smoke main.cc)
 target_link_libraries(smoke PRIVATE RandBLAS)
+randblas_stage_runtime_dlls(smoke)

--- a/test/linops/linop_common.hh
+++ b/test/linops/linop_common.hh
@@ -87,7 +87,7 @@ void test_left_apply_to_random(
     // check the result
     auto msg = RandBLAS::testing::buffs_approx_equal<T>(
         B0.data(), B1.data(), E.data(), d * n,
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
     );
     if (msg.size() > 0) {
         FAIL() << msg;
@@ -142,7 +142,7 @@ void test_left_apply_submatrix_to_eye(
         d1, m1,
         B.data(), ldb,
         &expect[offset], ld_expect,
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
     );
     if (msg.size() > 0) {
         FAIL() << msg;
@@ -177,7 +177,7 @@ void test_left_apply_transpose_to_eye(
     auto msg = RandBLAS::testing::matrices_approx_equal(
         layout, Op::Trans, d, m,
         B.data(), ldb, S_dense.data(), lds,
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
     );
     if (msg.size() > 0) {
         FAIL() << msg;
@@ -222,7 +222,7 @@ void test_left_apply_to_submatrix(
     );
     auto msg = RandBLAS::testing::buffs_approx_equal(
         B0.data(), B1.data(), E.data(), d * n,
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
     );
     if (msg.size() > 0) {
         FAIL() << msg;
@@ -263,7 +263,7 @@ void test_left_apply_to_transposed(
     );
     auto msg = RandBLAS::testing::buffs_approx_equal(
         B0.data(), B1.data(), E.data(), d * n,
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
     );
     if (msg.size() > 0) {
         FAIL() << msg;
@@ -304,7 +304,7 @@ void test_right_apply_to_random(
 
     auto msg = RandBLAS::testing::buffs_approx_equal<T>(
         B0.data(), B1.data(), E.data(), m * d,
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
     );
     if (msg.size() > 0) {
         FAIL() << msg;
@@ -344,7 +344,7 @@ void test_right_apply_submatrix_to_eye(
 
     auto msg = RandBLAS::testing::matrices_approx_equal(
         layout, Op::NoTrans, n, d, B.data(), ldb, &expect[offset], ld_expect,
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
     );
     if (msg.size() > 0) {
         FAIL() << msg;
@@ -372,7 +372,7 @@ void test_right_apply_transpose_to_eye(
     auto msg = RandBLAS::testing::matrices_approx_equal(
         layout, Op::Trans, n, d,
         B.data(), ldb, S_dense.data(), lds,
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
     );
     if (msg.size() > 0) {
         FAIL() << msg;
@@ -409,7 +409,7 @@ void test_right_apply_to_submatrix(
     );
     auto msg = RandBLAS::testing::buffs_approx_equal(
         B0.data(), B1.data(), E.data(), d * m,
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
     );
     if (msg.size() > 0) {
         FAIL() << msg;
@@ -441,7 +441,7 @@ void test_right_apply_to_transposed(
     );
     auto msg = RandBLAS::testing::buffs_approx_equal(
         B0.data(), B1.data(), E.data(), m * d,
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
     );
     if (msg.size() > 0) {
         FAIL() << msg;

--- a/test/linops/linop_common.hh
+++ b/test/linops/linop_common.hh
@@ -87,7 +87,7 @@ void test_left_apply_to_random(
     // check the result
     auto msg = RandBLAS::testing::buffs_approx_equal<T>(
         B0.data(), B1.data(), E.data(), d * n,
-        __PRETTY_FUNCTION__, __FILE__, __LINE__
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
     );
     if (msg.size() > 0) {
         FAIL() << msg;
@@ -142,7 +142,7 @@ void test_left_apply_submatrix_to_eye(
         d1, m1,
         B.data(), ldb,
         &expect[offset], ld_expect,
-        __PRETTY_FUNCTION__, __FILE__, __LINE__
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
     );
     if (msg.size() > 0) {
         FAIL() << msg;
@@ -177,7 +177,7 @@ void test_left_apply_transpose_to_eye(
     auto msg = RandBLAS::testing::matrices_approx_equal(
         layout, Op::Trans, d, m,
         B.data(), ldb, S_dense.data(), lds,
-        __PRETTY_FUNCTION__, __FILE__, __LINE__
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
     );
     if (msg.size() > 0) {
         FAIL() << msg;
@@ -222,7 +222,7 @@ void test_left_apply_to_submatrix(
     );
     auto msg = RandBLAS::testing::buffs_approx_equal(
         B0.data(), B1.data(), E.data(), d * n,
-        __PRETTY_FUNCTION__, __FILE__, __LINE__
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
     );
     if (msg.size() > 0) {
         FAIL() << msg;
@@ -263,7 +263,7 @@ void test_left_apply_to_transposed(
     );
     auto msg = RandBLAS::testing::buffs_approx_equal(
         B0.data(), B1.data(), E.data(), d * n,
-        __PRETTY_FUNCTION__, __FILE__, __LINE__
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
     );
     if (msg.size() > 0) {
         FAIL() << msg;
@@ -304,7 +304,7 @@ void test_right_apply_to_random(
 
     auto msg = RandBLAS::testing::buffs_approx_equal<T>(
         B0.data(), B1.data(), E.data(), m * d,
-        __PRETTY_FUNCTION__, __FILE__, __LINE__
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
     );
     if (msg.size() > 0) {
         FAIL() << msg;
@@ -344,7 +344,7 @@ void test_right_apply_submatrix_to_eye(
 
     auto msg = RandBLAS::testing::matrices_approx_equal(
         layout, Op::NoTrans, n, d, B.data(), ldb, &expect[offset], ld_expect,
-        __PRETTY_FUNCTION__, __FILE__, __LINE__
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
     );
     if (msg.size() > 0) {
         FAIL() << msg;
@@ -372,7 +372,7 @@ void test_right_apply_transpose_to_eye(
     auto msg = RandBLAS::testing::matrices_approx_equal(
         layout, Op::Trans, n, d,
         B.data(), ldb, S_dense.data(), lds,
-        __PRETTY_FUNCTION__, __FILE__, __LINE__
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
     );
     if (msg.size() > 0) {
         FAIL() << msg;
@@ -409,7 +409,7 @@ void test_right_apply_to_submatrix(
     );
     auto msg = RandBLAS::testing::buffs_approx_equal(
         B0.data(), B1.data(), E.data(), d * m,
-        __PRETTY_FUNCTION__, __FILE__, __LINE__
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
     );
     if (msg.size() > 0) {
         FAIL() << msg;
@@ -441,7 +441,7 @@ void test_right_apply_to_transposed(
     );
     auto msg = RandBLAS::testing::buffs_approx_equal(
         B0.data(), B1.data(), E.data(), m * d,
-        __PRETTY_FUNCTION__, __FILE__, __LINE__
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
     );
     if (msg.size() > 0) {
         FAIL() << msg;

--- a/test/linops/test_lskges.cc
+++ b/test/linops/test_lskges.cc
@@ -624,7 +624,7 @@ class TestLSKGES_SubmatrixPath : public ::testing::Test {
             (T) 1.0, S_new, S_ro, S_co, A.data(), lda, (T) 0.0, B_new.data(), ldb);
 
         auto msg = RandBLAS::testing::buffs_approx_equal(
-            B_new.data(), B_old.data(), d1 * n, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+            B_new.data(), B_old.data(), d1 * n, __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;

--- a/test/linops/test_lskges.cc
+++ b/test/linops/test_lskges.cc
@@ -624,7 +624,7 @@ class TestLSKGES_SubmatrixPath : public ::testing::Test {
             (T) 1.0, S_new, S_ro, S_co, A.data(), lda, (T) 0.0, B_new.data(), ldb);
 
         auto msg = RandBLAS::testing::buffs_approx_equal(
-            B_new.data(), B_old.data(), d1 * n, __PRETTY_FUNCTION__, __FILE__, __LINE__
+            B_new.data(), B_old.data(), d1 * n, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;

--- a/test/linops/test_rskges.cc
+++ b/test/linops/test_rskges.cc
@@ -435,7 +435,7 @@ class TestRSKGES_SubmatrixPath : public ::testing::Test {
             (T) 1.0, A.data(), lda, S_new, S_ro, S_co, (T) 0.0, B_new.data(), ldb);
 
         auto msg = RandBLAS::testing::buffs_approx_equal(
-            B_new.data(), B_old.data(), m * d1, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+            B_new.data(), B_old.data(), m * d1, __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;

--- a/test/linops/test_rskges.cc
+++ b/test/linops/test_rskges.cc
@@ -435,7 +435,7 @@ class TestRSKGES_SubmatrixPath : public ::testing::Test {
             (T) 1.0, A.data(), lda, S_new, S_ro, S_co, (T) 0.0, B_new.data(), ldb);
 
         auto msg = RandBLAS::testing::buffs_approx_equal(
-            B_new.data(), B_old.data(), m * d1, __PRETTY_FUNCTION__, __FILE__, __LINE__
+            B_new.data(), B_old.data(), m * d1, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;

--- a/test/linops/test_sketch_sparse.cc
+++ b/test/linops/test_sketch_sparse.cc
@@ -71,7 +71,7 @@ void test_left_transposed_sketch_of_eye(
     auto msg = RandBLAS::testing::matrices_approx_equal(
         layout, Op::Trans, d, m,
         B.data(), ldb, S_dense.data(), lds,
-        __PRETTY_FUNCTION__, __FILE__, __LINE__
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
     );
     if (msg.size() > 0) {
         FAIL() << msg;
@@ -121,7 +121,7 @@ void test_left_submat_sketch_of_eye(
         d1, m1,
         B.data(), ldb,
         &expect[offset], ld_expect,
-        __PRETTY_FUNCTION__, __FILE__, __LINE__
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
     );
     if (msg.size() > 0) {
         FAIL() << msg;
@@ -150,7 +150,7 @@ void test_right_transposed_sketch_of_eye(
     auto msg = RandBLAS::testing::matrices_approx_equal(
         layout, Op::Trans, n, d,
         B.data(), ldb, S_dense.data(), lds,
-        __PRETTY_FUNCTION__, __FILE__, __LINE__
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
     );
     if (msg.size() > 0) {
         FAIL() << msg;
@@ -191,7 +191,7 @@ void test_right_submat_sketch_of_eye(
 
     auto msg = RandBLAS::testing::matrices_approx_equal(
         layout, Op::NoTrans, n, d, B.data(), ldb, &expect[offset], ld_expect,
-        __PRETTY_FUNCTION__, __FILE__, __LINE__
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
     );
     if (msg.size() > 0) {
         FAIL() << msg;

--- a/test/linops/test_sketch_sparse.cc
+++ b/test/linops/test_sketch_sparse.cc
@@ -71,7 +71,7 @@ void test_left_transposed_sketch_of_eye(
     auto msg = RandBLAS::testing::matrices_approx_equal(
         layout, Op::Trans, d, m,
         B.data(), ldb, S_dense.data(), lds,
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
     );
     if (msg.size() > 0) {
         FAIL() << msg;
@@ -121,7 +121,7 @@ void test_left_submat_sketch_of_eye(
         d1, m1,
         B.data(), ldb,
         &expect[offset], ld_expect,
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
     );
     if (msg.size() > 0) {
         FAIL() << msg;
@@ -150,7 +150,7 @@ void test_right_transposed_sketch_of_eye(
     auto msg = RandBLAS::testing::matrices_approx_equal(
         layout, Op::Trans, n, d,
         B.data(), ldb, S_dense.data(), lds,
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
     );
     if (msg.size() > 0) {
         FAIL() << msg;
@@ -191,7 +191,7 @@ void test_right_submat_sketch_of_eye(
 
     auto msg = RandBLAS::testing::matrices_approx_equal(
         layout, Op::NoTrans, n, d, B.data(), ldb, &expect[offset], ld_expect,
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
     );
     if (msg.size() > 0) {
         FAIL() << msg;

--- a/test/linops/test_sketch_symmetric.cc
+++ b/test/linops/test_sketch_symmetric.cc
@@ -110,7 +110,7 @@ class TestSketchSymmetric : public ::testing::Test {
 
         auto msg = RandBLAS::testing::matrices_approx_equal(
             S.layout, blas::Op::NoTrans, rows_out, cols_out, B_actual.data(), ldb, B_expect.data(), ldb,
-            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+            __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -152,7 +152,7 @@ class TestSketchSymmetric : public ::testing::Test {
 
         auto msg = RandBLAS::testing::matrices_approx_equal(
             layout_B, blas::Op::NoTrans, rows_out, cols_out, B_actual.data(), ldb, B_expect.data(), ldb,
-            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+            __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;

--- a/test/linops/test_sketch_symmetric.cc
+++ b/test/linops/test_sketch_symmetric.cc
@@ -110,7 +110,7 @@ class TestSketchSymmetric : public ::testing::Test {
 
         auto msg = RandBLAS::testing::matrices_approx_equal(
             S.layout, blas::Op::NoTrans, rows_out, cols_out, B_actual.data(), ldb, B_expect.data(), ldb,
-            __PRETTY_FUNCTION__, __FILE__, __LINE__
+            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -152,7 +152,7 @@ class TestSketchSymmetric : public ::testing::Test {
 
         auto msg = RandBLAS::testing::matrices_approx_equal(
             layout_B, blas::Op::NoTrans, rows_out, cols_out, B_actual.data(), ldb, B_expect.data(), ldb,
-            __PRETTY_FUNCTION__, __FILE__, __LINE__
+            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;

--- a/test/linops/test_sketch_vector.cc
+++ b/test/linops/test_sketch_vector.cc
@@ -74,7 +74,7 @@ class TestSketchVector : public ::testing::Test
         blas::gemv(S.layout, blas::Op::NoTrans, d, m, (T)1.0, S.buff, lds, x, incx, (T)0.0, y_expect, incy); 
  
         auto msg = RandBLAS::testing::buffs_approx_equal(d, y_actual, incy, y_expect, incy,
-                __PRETTY_FUNCTION__, __FILE__, __LINE__
+                RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -110,7 +110,7 @@ class TestSketchVector : public ::testing::Test
         
         // Compare entrywise results of sketching with sketch_vector and using gemv
         auto msg = RandBLAS::testing::buffs_approx_equal(d, y_actual, incy, y_expect, incy,
-                __PRETTY_FUNCTION__, __FILE__, __LINE__
+                RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -147,7 +147,7 @@ class TestSketchVector : public ::testing::Test
         RandBLAS::sketch_vector(blas::Op::Trans, m, d, (T)1.0, S_tall, 0, 0, x, incx, (T)0.0, y_tall, incy);
         
         auto msg = RandBLAS::testing::buffs_approx_equal(d, y_wide, incy, y_tall, incy,
-                __PRETTY_FUNCTION__, __FILE__, __LINE__
+                RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -183,7 +183,7 @@ class TestSketchVector : public ::testing::Test
 
         // Compare entrywise results of sketching with sketch_vector and using gemv
         auto msg = RandBLAS::testing::buffs_approx_equal(d, y_actual, incy, y_expect, incy,
-                __PRETTY_FUNCTION__, __FILE__, __LINE__
+                RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;

--- a/test/linops/test_sketch_vector.cc
+++ b/test/linops/test_sketch_vector.cc
@@ -74,7 +74,7 @@ class TestSketchVector : public ::testing::Test
         blas::gemv(S.layout, blas::Op::NoTrans, d, m, (T)1.0, S.buff, lds, x, incx, (T)0.0, y_expect, incy); 
  
         auto msg = RandBLAS::testing::buffs_approx_equal(d, y_actual, incy, y_expect, incy,
-                RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+                __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -110,7 +110,7 @@ class TestSketchVector : public ::testing::Test
         
         // Compare entrywise results of sketching with sketch_vector and using gemv
         auto msg = RandBLAS::testing::buffs_approx_equal(d, y_actual, incy, y_expect, incy,
-                RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+                __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -147,7 +147,7 @@ class TestSketchVector : public ::testing::Test
         RandBLAS::sketch_vector(blas::Op::Trans, m, d, (T)1.0, S_tall, 0, 0, x, incx, (T)0.0, y_tall, incy);
         
         auto msg = RandBLAS::testing::buffs_approx_equal(d, y_wide, incy, y_tall, incy,
-                RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+                __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -183,7 +183,7 @@ class TestSketchVector : public ::testing::Test
 
         // Compare entrywise results of sketching with sketch_vector and using gemv
         auto msg = RandBLAS::testing::buffs_approx_equal(d, y_actual, incy, y_expect, incy,
-                RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+                __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;

--- a/test/linops/test_sparse_trsm.cc
+++ b/test/linops/test_sparse_trsm.cc
@@ -128,7 +128,7 @@ class TestSptrsm : public ::testing::Test
         
         T atol = RandBLAS::sqrt_epsilon<T>();
         T rtol = atol;
-        auto msg = RandBLAS::testing::buffs_approx_equal(k*n, rhs_copy.data(), 1, ref_ptr, 1, __PRETTY_FUNCTION__, __FILE__, __LINE__, atol, rtol);
+        auto msg = RandBLAS::testing::buffs_approx_equal(k*n, rhs_copy.data(), 1, ref_ptr, 1, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__, atol, rtol);
         if (msg.size() > 0) {
             FAIL() << msg;
         }
@@ -159,7 +159,7 @@ class TestSptrsm : public ::testing::Test
         // }
         T atol = RandBLAS::sqrt_epsilon<T>();
         T rtol = atol;
-        auto msg = RandBLAS::testing::buffs_approx_equal(k*n, rhs_copy.data(), 1, ref_ptr, 1, __PRETTY_FUNCTION__, __FILE__, __LINE__, atol, rtol);
+        auto msg = RandBLAS::testing::buffs_approx_equal(k*n, rhs_copy.data(), 1, ref_ptr, 1, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__, atol, rtol);
         if (msg.size() > 0) {
             FAIL() << msg;
         }

--- a/test/linops/test_sparse_trsm.cc
+++ b/test/linops/test_sparse_trsm.cc
@@ -128,7 +128,7 @@ class TestSptrsm : public ::testing::Test
         
         T atol = RandBLAS::sqrt_epsilon<T>();
         T rtol = atol;
-        auto msg = RandBLAS::testing::buffs_approx_equal(k*n, rhs_copy.data(), 1, ref_ptr, 1, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__, atol, rtol);
+        auto msg = RandBLAS::testing::buffs_approx_equal(k*n, rhs_copy.data(), 1, ref_ptr, 1, __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__, atol, rtol);
         if (msg.size() > 0) {
             FAIL() << msg;
         }
@@ -159,7 +159,7 @@ class TestSptrsm : public ::testing::Test
         // }
         T atol = RandBLAS::sqrt_epsilon<T>();
         T rtol = atol;
-        auto msg = RandBLAS::testing::buffs_approx_equal(k*n, rhs_copy.data(), 1, ref_ptr, 1, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__, atol, rtol);
+        auto msg = RandBLAS::testing::buffs_approx_equal(k*n, rhs_copy.data(), 1, ref_ptr, 1, __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__, atol, rtol);
         if (msg.size() > 0) {
             FAIL() << msg;
         }

--- a/test/linops/test_spgemm.cc
+++ b/test/linops/test_spgemm.cc
@@ -149,7 +149,7 @@ class TestSpGEMM : public ::testing::Test {
 
         auto msg = RandBLAS::testing::buffs_approx_equal(
             C_actual.data(), C_ref.data(), E.data(), m * n,
-            __PRETTY_FUNCTION__, __FILE__, __LINE__
+            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;

--- a/test/linops/test_spgemm.cc
+++ b/test/linops/test_spgemm.cc
@@ -149,7 +149,7 @@ class TestSpGEMM : public ::testing::Test {
 
         auto msg = RandBLAS::testing::buffs_approx_equal(
             C_actual.data(), C_ref.data(), E.data(), m * n,
-            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+            __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;

--- a/test/linops/test_spmm/test_spmm_csr.cc
+++ b/test/linops/test_spmm/test_spmm_csr.cc
@@ -438,7 +438,7 @@ protected:
         T rtol = std::sqrt(std::numeric_limits<T>::epsilon());
         auto msg = RandBLAS::testing::buffs_approx_equal(
             C_actual.data(), C_ref.data(), m * n,
-            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__,
+            __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__,
             atol, rtol
         );
         if (msg.size() > 0) {

--- a/test/linops/test_spmm/test_spmm_csr.cc
+++ b/test/linops/test_spmm/test_spmm_csr.cc
@@ -438,7 +438,7 @@ protected:
         T rtol = std::sqrt(std::numeric_limits<T>::epsilon());
         auto msg = RandBLAS::testing::buffs_approx_equal(
             C_actual.data(), C_ref.data(), m * n,
-            __PRETTY_FUNCTION__, __FILE__, __LINE__,
+            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__,
             atol, rtol
         );
         if (msg.size() > 0) {

--- a/test/meta/test_comparison.cc
+++ b/test/meta/test_comparison.cc
@@ -54,13 +54,13 @@ TEST_F(TestApproxEqualScalar, bool_fail_outside_tols) {
 // string-returning overload
 
 TEST_F(TestApproxEqualScalar, string_pass_returns_empty) {
-    auto msg = approx_equal(1.0, 1.0, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
+    auto msg = approx_equal(1.0, 1.0, __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__);
     EXPECT_TRUE(msg.empty());
 }
 
 TEST_F(TestApproxEqualScalar, string_fail_returns_nonempty) {
     int line = __LINE__ + 1;
-    auto msg = approx_equal(1.0, 2.0, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, line);
+    auto msg = approx_equal(1.0, 2.0, __RANDBLAS_PRETTY_FUNCTION__, __FILE__, line);
     EXPECT_FALSE(msg.empty());
     // error string should reference the file and line number
     EXPECT_NE(msg.find(__FILE__), std::string::npos);
@@ -71,14 +71,14 @@ TEST_F(TestApproxEqualScalar, string_respects_custom_atol) {
     // 0.0 and 1e-4 are far apart by default tolerances but within a large atol
     double A = 0.0, B = 1e-4;
     double large_atol = 1.0;
-    auto msg = approx_equal(A, B, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__, large_atol);
+    auto msg = approx_equal(A, B, __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__, large_atol);
     EXPECT_TRUE(msg.empty());
 }
 
 TEST_F(TestApproxEqualScalar, string_respects_custom_rtol) {
     double A = 1.0, B = 1.1;   // 10% relative difference
     double large_rtol = 0.5;   // 50% rtol → should pass
-    auto msg = approx_equal(A, B, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__,
+    auto msg = approx_equal(A, B, __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__,
         std::numeric_limits<double>::epsilon(), large_rtol);
     EXPECT_TRUE(msg.empty());
 }
@@ -91,14 +91,14 @@ class TestBuffsApproxEqualContiguous : public ::testing::Test {};
 TEST_F(TestBuffsApproxEqualContiguous, pass_all_equal) {
     std::vector<double> a = {1.0, 2.0, 3.0, 4.0};
     auto msg = buffs_approx_equal(a.data(), a.data(), (int64_t)a.size(),
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__);
     EXPECT_TRUE(msg.empty());
 }
 
 TEST_F(TestBuffsApproxEqualContiguous, pass_empty_buffer) {
     std::vector<double> a = {};
     auto msg = buffs_approx_equal(a.data(), a.data(), (int64_t)0,
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__);
     EXPECT_TRUE(msg.empty());
 }
 
@@ -106,7 +106,7 @@ TEST_F(TestBuffsApproxEqualContiguous, fail_first_element) {
     std::vector<double> actual = {99.0, 2.0, 3.0, 4.0};
     std::vector<double> expect = { 1.0, 2.0, 3.0, 4.0};
     auto msg = buffs_approx_equal(actual.data(), expect.data(), (int64_t)actual.size(),
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__);
     EXPECT_FALSE(msg.empty());
     EXPECT_NE(msg.find("index 0"), std::string::npos);
 }
@@ -115,7 +115,7 @@ TEST_F(TestBuffsApproxEqualContiguous, fail_middle_element) {
     std::vector<double> actual = {1.0, 2.0, 99.0, 4.0};
     std::vector<double> expect = {1.0, 2.0,  3.0, 4.0};
     auto msg = buffs_approx_equal(actual.data(), expect.data(), (int64_t)actual.size(),
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__);
     EXPECT_FALSE(msg.empty());
     EXPECT_NE(msg.find("index 2"), std::string::npos);
 }
@@ -126,7 +126,7 @@ TEST_F(TestBuffsApproxEqualContiguous, pass_custom_atol) {
     std::vector<double> expect = {1.0, 1.0};
     double large_atol = 1.0;
     auto msg = buffs_approx_equal(actual.data(), expect.data(), (int64_t)actual.size(),
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__, large_atol);
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__, large_atol);
     EXPECT_TRUE(msg.empty());
 }
 
@@ -138,7 +138,7 @@ class TestBuffsApproxEqualStrided : public ::testing::Test {};
 TEST_F(TestBuffsApproxEqualStrided, pass_all_equal_stride1) {
     std::vector<double> a = {1.0, 2.0, 3.0};
     auto msg = buffs_approx_equal((int64_t)3, a.data(), (int64_t)1, a.data(), (int64_t)1,
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__);
     EXPECT_TRUE(msg.empty());
 }
 
@@ -149,7 +149,7 @@ TEST_F(TestBuffsApproxEqualStrided, pass_stride2_ignored_odd_elements) {
     // size=3, inc_actual=2, inc_expect=2: accesses indices 0,2,4 in each
     auto msg = buffs_approx_equal((int64_t)3,
         actual.data(), (int64_t)2, expect.data(), (int64_t)2,
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__);
     EXPECT_TRUE(msg.empty());
 }
 
@@ -159,7 +159,7 @@ TEST_F(TestBuffsApproxEqualStrided, fail_strided_element_mentions_logical_index)
     std::vector<double> expect = {1.0, 0.0, 2.0, 0.0,  3.0, 0.0};
     auto msg = buffs_approx_equal((int64_t)3,
         actual.data(), (int64_t)2, expect.data(), (int64_t)2,
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__);
     EXPECT_FALSE(msg.empty());
     EXPECT_NE(msg.find("index 2"), std::string::npos);
 }
@@ -170,7 +170,7 @@ TEST_F(TestBuffsApproxEqualStrided, fail_different_inc_actual_and_inc_expect) {
     std::vector<double> expect = {1.0, 2.0};           // logical: 1.0, 2.0
     auto msg = buffs_approx_equal((int64_t)2,
         actual.data(), (int64_t)2, expect.data(), (int64_t)1,
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__);
     EXPECT_FALSE(msg.empty());
     EXPECT_NE(msg.find("index 1"), std::string::npos);
 }
@@ -185,7 +185,7 @@ TEST_F(TestBuffsApproxEqualBounded, pass_all_within_bounds) {
     std::vector<double> expect = {1.0, 2.0, 3.0};
     std::vector<double> bounds = {0.2, 0.3, 0.4};   // all errors < bounds
     auto msg = buffs_approx_equal(actual.data(), expect.data(), bounds.data(),
-        (int64_t)actual.size(), RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
+        (int64_t)actual.size(), __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__);
     EXPECT_TRUE(msg.empty());
 }
 
@@ -194,7 +194,7 @@ TEST_F(TestBuffsApproxEqualBounded, fail_at_index_1) {
     std::vector<double> expect = {1.0,  2.0, 3.0};
     std::vector<double> bounds = {0.5,  0.5, 0.5};   // index 1 error = 97, far exceeds bound
     auto msg = buffs_approx_equal(actual.data(), expect.data(), bounds.data(),
-        (int64_t)actual.size(), RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
+        (int64_t)actual.size(), __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__);
     EXPECT_FALSE(msg.empty());
     EXPECT_NE(msg.find("index 1"), std::string::npos);
 }
@@ -205,7 +205,7 @@ TEST_F(TestBuffsApproxEqualBounded, pass_heterogeneous_bounds) {
     std::vector<double> expect = {1.0,  2.0,   3.0};
     std::vector<double> bounds = {0.02, 0.002, 0.0002};
     auto msg = buffs_approx_equal(actual.data(), expect.data(), bounds.data(),
-        (int64_t)actual.size(), RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
+        (int64_t)actual.size(), __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__);
     EXPECT_TRUE(msg.empty());
 }
 
@@ -236,7 +236,7 @@ TEST_F(TestMatricesApproxEqual, pass_colmajor_notrans) {
     auto msg = matrices_approx_equal(
         blas::Layout::ColMajor, blas::Op::NoTrans,
         M, N, A.data(), M, A.data(), M,
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__);
     EXPECT_TRUE(msg.empty());
 }
 
@@ -245,7 +245,7 @@ TEST_F(TestMatricesApproxEqual, pass_rowmajor_notrans) {
     auto msg = matrices_approx_equal(
         blas::Layout::RowMajor, blas::Op::NoTrans,
         M, N, A.data(), N, A.data(), N,
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__);
     EXPECT_TRUE(msg.empty());
 }
 
@@ -257,7 +257,7 @@ TEST_F(TestMatricesApproxEqual, fail_colmajor_notrans_mentions_index) {
     auto msg = matrices_approx_equal(
         blas::Layout::ColMajor, blas::Op::NoTrans,
         M, N, A.data(), M, B.data(), M,
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__);
     EXPECT_FALSE(msg.empty());
     EXPECT_NE(msg.find("(1, 2)"), std::string::npos);
 }
@@ -271,7 +271,7 @@ TEST_F(TestMatricesApproxEqual, pass_colmajor_trans) {
     auto msg = matrices_approx_equal(
         blas::Layout::ColMajor, blas::Op::Trans,
         M, N, A.data(), M, B.data(), N,
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__);
     EXPECT_TRUE(msg.empty());
 }
 
@@ -286,7 +286,7 @@ TEST_F(TestMatricesApproxEqual, fail_colmajor_trans) {
     auto msg = matrices_approx_equal(
         blas::Layout::ColMajor, blas::Op::Trans,
         M, N, A.data(), M, B.data(), N,
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__);
     EXPECT_FALSE(msg.empty());
 }
 
@@ -298,7 +298,7 @@ TEST_F(TestMatricesApproxEqual, pass_mixed_layouts) {
         blas::Layout::ColMajor, blas::Layout::RowMajor,
         blas::Op::NoTrans,
         M, N, A.data(), M, B.data(), N,
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__);
     EXPECT_TRUE(msg.empty());
 }
 
@@ -311,7 +311,7 @@ TEST_F(TestMatricesApproxEqual, fail_mixed_layouts) {
         blas::Layout::ColMajor, blas::Layout::RowMajor,
         blas::Op::NoTrans,
         M, N, A.data(), M, B.data(), N,
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__);
     EXPECT_FALSE(msg.empty());
 }
 
@@ -321,7 +321,7 @@ TEST_F(TestMatricesApproxEqual, pass_single_layout_delegates) {
     auto msg = matrices_approx_equal(
         blas::Layout::ColMajor, blas::Op::NoTrans,
         M, N, A.data(), M, A.data(), M,
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__);
     EXPECT_TRUE(msg.empty());
 }
 
@@ -332,6 +332,6 @@ TEST_F(TestMatricesApproxEqual, fail_single_layout_delegates) {
     auto msg = matrices_approx_equal(
         blas::Layout::ColMajor, blas::Op::NoTrans,
         M, N, A.data(), M, B.data(), M,
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__);
     EXPECT_FALSE(msg.empty());
 }

--- a/test/meta/test_comparison.cc
+++ b/test/meta/test_comparison.cc
@@ -54,13 +54,13 @@ TEST_F(TestApproxEqualScalar, bool_fail_outside_tols) {
 // string-returning overload
 
 TEST_F(TestApproxEqualScalar, string_pass_returns_empty) {
-    auto msg = approx_equal(1.0, 1.0, __PRETTY_FUNCTION__, __FILE__, __LINE__);
+    auto msg = approx_equal(1.0, 1.0, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
     EXPECT_TRUE(msg.empty());
 }
 
 TEST_F(TestApproxEqualScalar, string_fail_returns_nonempty) {
     int line = __LINE__ + 1;
-    auto msg = approx_equal(1.0, 2.0, __PRETTY_FUNCTION__, __FILE__, line);
+    auto msg = approx_equal(1.0, 2.0, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, line);
     EXPECT_FALSE(msg.empty());
     // error string should reference the file and line number
     EXPECT_NE(msg.find(__FILE__), std::string::npos);
@@ -71,14 +71,14 @@ TEST_F(TestApproxEqualScalar, string_respects_custom_atol) {
     // 0.0 and 1e-4 are far apart by default tolerances but within a large atol
     double A = 0.0, B = 1e-4;
     double large_atol = 1.0;
-    auto msg = approx_equal(A, B, __PRETTY_FUNCTION__, __FILE__, __LINE__, large_atol);
+    auto msg = approx_equal(A, B, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__, large_atol);
     EXPECT_TRUE(msg.empty());
 }
 
 TEST_F(TestApproxEqualScalar, string_respects_custom_rtol) {
     double A = 1.0, B = 1.1;   // 10% relative difference
     double large_rtol = 0.5;   // 50% rtol → should pass
-    auto msg = approx_equal(A, B, __PRETTY_FUNCTION__, __FILE__, __LINE__,
+    auto msg = approx_equal(A, B, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__,
         std::numeric_limits<double>::epsilon(), large_rtol);
     EXPECT_TRUE(msg.empty());
 }
@@ -91,14 +91,14 @@ class TestBuffsApproxEqualContiguous : public ::testing::Test {};
 TEST_F(TestBuffsApproxEqualContiguous, pass_all_equal) {
     std::vector<double> a = {1.0, 2.0, 3.0, 4.0};
     auto msg = buffs_approx_equal(a.data(), a.data(), (int64_t)a.size(),
-        __PRETTY_FUNCTION__, __FILE__, __LINE__);
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
     EXPECT_TRUE(msg.empty());
 }
 
 TEST_F(TestBuffsApproxEqualContiguous, pass_empty_buffer) {
     std::vector<double> a = {};
     auto msg = buffs_approx_equal(a.data(), a.data(), (int64_t)0,
-        __PRETTY_FUNCTION__, __FILE__, __LINE__);
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
     EXPECT_TRUE(msg.empty());
 }
 
@@ -106,7 +106,7 @@ TEST_F(TestBuffsApproxEqualContiguous, fail_first_element) {
     std::vector<double> actual = {99.0, 2.0, 3.0, 4.0};
     std::vector<double> expect = { 1.0, 2.0, 3.0, 4.0};
     auto msg = buffs_approx_equal(actual.data(), expect.data(), (int64_t)actual.size(),
-        __PRETTY_FUNCTION__, __FILE__, __LINE__);
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
     EXPECT_FALSE(msg.empty());
     EXPECT_NE(msg.find("index 0"), std::string::npos);
 }
@@ -115,7 +115,7 @@ TEST_F(TestBuffsApproxEqualContiguous, fail_middle_element) {
     std::vector<double> actual = {1.0, 2.0, 99.0, 4.0};
     std::vector<double> expect = {1.0, 2.0,  3.0, 4.0};
     auto msg = buffs_approx_equal(actual.data(), expect.data(), (int64_t)actual.size(),
-        __PRETTY_FUNCTION__, __FILE__, __LINE__);
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
     EXPECT_FALSE(msg.empty());
     EXPECT_NE(msg.find("index 2"), std::string::npos);
 }
@@ -126,7 +126,7 @@ TEST_F(TestBuffsApproxEqualContiguous, pass_custom_atol) {
     std::vector<double> expect = {1.0, 1.0};
     double large_atol = 1.0;
     auto msg = buffs_approx_equal(actual.data(), expect.data(), (int64_t)actual.size(),
-        __PRETTY_FUNCTION__, __FILE__, __LINE__, large_atol);
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__, large_atol);
     EXPECT_TRUE(msg.empty());
 }
 
@@ -138,7 +138,7 @@ class TestBuffsApproxEqualStrided : public ::testing::Test {};
 TEST_F(TestBuffsApproxEqualStrided, pass_all_equal_stride1) {
     std::vector<double> a = {1.0, 2.0, 3.0};
     auto msg = buffs_approx_equal((int64_t)3, a.data(), (int64_t)1, a.data(), (int64_t)1,
-        __PRETTY_FUNCTION__, __FILE__, __LINE__);
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
     EXPECT_TRUE(msg.empty());
 }
 
@@ -149,7 +149,7 @@ TEST_F(TestBuffsApproxEqualStrided, pass_stride2_ignored_odd_elements) {
     // size=3, inc_actual=2, inc_expect=2: accesses indices 0,2,4 in each
     auto msg = buffs_approx_equal((int64_t)3,
         actual.data(), (int64_t)2, expect.data(), (int64_t)2,
-        __PRETTY_FUNCTION__, __FILE__, __LINE__);
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
     EXPECT_TRUE(msg.empty());
 }
 
@@ -159,7 +159,7 @@ TEST_F(TestBuffsApproxEqualStrided, fail_strided_element_mentions_logical_index)
     std::vector<double> expect = {1.0, 0.0, 2.0, 0.0,  3.0, 0.0};
     auto msg = buffs_approx_equal((int64_t)3,
         actual.data(), (int64_t)2, expect.data(), (int64_t)2,
-        __PRETTY_FUNCTION__, __FILE__, __LINE__);
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
     EXPECT_FALSE(msg.empty());
     EXPECT_NE(msg.find("index 2"), std::string::npos);
 }
@@ -170,7 +170,7 @@ TEST_F(TestBuffsApproxEqualStrided, fail_different_inc_actual_and_inc_expect) {
     std::vector<double> expect = {1.0, 2.0};           // logical: 1.0, 2.0
     auto msg = buffs_approx_equal((int64_t)2,
         actual.data(), (int64_t)2, expect.data(), (int64_t)1,
-        __PRETTY_FUNCTION__, __FILE__, __LINE__);
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
     EXPECT_FALSE(msg.empty());
     EXPECT_NE(msg.find("index 1"), std::string::npos);
 }
@@ -185,7 +185,7 @@ TEST_F(TestBuffsApproxEqualBounded, pass_all_within_bounds) {
     std::vector<double> expect = {1.0, 2.0, 3.0};
     std::vector<double> bounds = {0.2, 0.3, 0.4};   // all errors < bounds
     auto msg = buffs_approx_equal(actual.data(), expect.data(), bounds.data(),
-        (int64_t)actual.size(), __PRETTY_FUNCTION__, __FILE__, __LINE__);
+        (int64_t)actual.size(), RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
     EXPECT_TRUE(msg.empty());
 }
 
@@ -194,7 +194,7 @@ TEST_F(TestBuffsApproxEqualBounded, fail_at_index_1) {
     std::vector<double> expect = {1.0,  2.0, 3.0};
     std::vector<double> bounds = {0.5,  0.5, 0.5};   // index 1 error = 97, far exceeds bound
     auto msg = buffs_approx_equal(actual.data(), expect.data(), bounds.data(),
-        (int64_t)actual.size(), __PRETTY_FUNCTION__, __FILE__, __LINE__);
+        (int64_t)actual.size(), RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
     EXPECT_FALSE(msg.empty());
     EXPECT_NE(msg.find("index 1"), std::string::npos);
 }
@@ -205,7 +205,7 @@ TEST_F(TestBuffsApproxEqualBounded, pass_heterogeneous_bounds) {
     std::vector<double> expect = {1.0,  2.0,   3.0};
     std::vector<double> bounds = {0.02, 0.002, 0.0002};
     auto msg = buffs_approx_equal(actual.data(), expect.data(), bounds.data(),
-        (int64_t)actual.size(), __PRETTY_FUNCTION__, __FILE__, __LINE__);
+        (int64_t)actual.size(), RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
     EXPECT_TRUE(msg.empty());
 }
 
@@ -236,7 +236,7 @@ TEST_F(TestMatricesApproxEqual, pass_colmajor_notrans) {
     auto msg = matrices_approx_equal(
         blas::Layout::ColMajor, blas::Op::NoTrans,
         M, N, A.data(), M, A.data(), M,
-        __PRETTY_FUNCTION__, __FILE__, __LINE__);
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
     EXPECT_TRUE(msg.empty());
 }
 
@@ -245,7 +245,7 @@ TEST_F(TestMatricesApproxEqual, pass_rowmajor_notrans) {
     auto msg = matrices_approx_equal(
         blas::Layout::RowMajor, blas::Op::NoTrans,
         M, N, A.data(), N, A.data(), N,
-        __PRETTY_FUNCTION__, __FILE__, __LINE__);
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
     EXPECT_TRUE(msg.empty());
 }
 
@@ -257,7 +257,7 @@ TEST_F(TestMatricesApproxEqual, fail_colmajor_notrans_mentions_index) {
     auto msg = matrices_approx_equal(
         blas::Layout::ColMajor, blas::Op::NoTrans,
         M, N, A.data(), M, B.data(), M,
-        __PRETTY_FUNCTION__, __FILE__, __LINE__);
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
     EXPECT_FALSE(msg.empty());
     EXPECT_NE(msg.find("(1, 2)"), std::string::npos);
 }
@@ -271,7 +271,7 @@ TEST_F(TestMatricesApproxEqual, pass_colmajor_trans) {
     auto msg = matrices_approx_equal(
         blas::Layout::ColMajor, blas::Op::Trans,
         M, N, A.data(), M, B.data(), N,
-        __PRETTY_FUNCTION__, __FILE__, __LINE__);
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
     EXPECT_TRUE(msg.empty());
 }
 
@@ -286,7 +286,7 @@ TEST_F(TestMatricesApproxEqual, fail_colmajor_trans) {
     auto msg = matrices_approx_equal(
         blas::Layout::ColMajor, blas::Op::Trans,
         M, N, A.data(), M, B.data(), N,
-        __PRETTY_FUNCTION__, __FILE__, __LINE__);
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
     EXPECT_FALSE(msg.empty());
 }
 
@@ -298,7 +298,7 @@ TEST_F(TestMatricesApproxEqual, pass_mixed_layouts) {
         blas::Layout::ColMajor, blas::Layout::RowMajor,
         blas::Op::NoTrans,
         M, N, A.data(), M, B.data(), N,
-        __PRETTY_FUNCTION__, __FILE__, __LINE__);
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
     EXPECT_TRUE(msg.empty());
 }
 
@@ -311,7 +311,7 @@ TEST_F(TestMatricesApproxEqual, fail_mixed_layouts) {
         blas::Layout::ColMajor, blas::Layout::RowMajor,
         blas::Op::NoTrans,
         M, N, A.data(), M, B.data(), N,
-        __PRETTY_FUNCTION__, __FILE__, __LINE__);
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
     EXPECT_FALSE(msg.empty());
 }
 
@@ -321,7 +321,7 @@ TEST_F(TestMatricesApproxEqual, pass_single_layout_delegates) {
     auto msg = matrices_approx_equal(
         blas::Layout::ColMajor, blas::Op::NoTrans,
         M, N, A.data(), M, A.data(), M,
-        __PRETTY_FUNCTION__, __FILE__, __LINE__);
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
     EXPECT_TRUE(msg.empty());
 }
 
@@ -332,6 +332,6 @@ TEST_F(TestMatricesApproxEqual, fail_single_layout_delegates) {
     auto msg = matrices_approx_equal(
         blas::Layout::ColMajor, blas::Op::NoTrans,
         M, N, A.data(), M, B.data(), M,
-        __PRETTY_FUNCTION__, __FILE__, __LINE__);
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
     EXPECT_FALSE(msg.empty());
 }

--- a/test/meta/test_lapack_like.cc
+++ b/test/meta/test_lapack_like.cc
@@ -49,7 +49,7 @@ class TestHandrolledCholesky : public ::testing::Test {
         RandBLAS::symmetrize(layout, blas::Uplo::Upper, n, A.data(), n);
 
         auto msg = RandBLAS::testing::matrices_approx_equal(layout, blas::Op::NoTrans, n, n, B.data(), n, A.data(), n,
-            __PRETTY_FUNCTION__, __FILE__, __LINE__
+            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -83,7 +83,7 @@ class TestHandrolledCholesky : public ::testing::Test {
         }
         RandBLAS::testing::potrf_upper(n, A.data(), n, b);
         auto msg = RandBLAS::testing::matrices_approx_equal(layout, blas::Op::NoTrans, n, n, B.data(), n, A.data(), n,
-            __PRETTY_FUNCTION__, __FILE__, __LINE__
+            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -157,7 +157,7 @@ void verify_product(int64_t m, int64_t n, int64_t k, const T* A, const T* B, con
     vector<T> E(m*n, 0.0);
     T err_alpha = 2 * k * std::numeric_limits<T>::epsilon();
     blas::gemm(blas::Layout::ColMajor, blas::Op::NoTrans, blas::Op::NoTrans, m, n, k, err_alpha, A_copy.data(), lda, B_copy.data(), ldb, (T)0.0, E.data(), m);
-    auto msg = RandBLAS::testing::buffs_approx_equal(C_work.data(), C, E.data(), m*n, __PRETTY_FUNCTION__, __FILE__, __LINE__);
+    auto msg = RandBLAS::testing::buffs_approx_equal(C_work.data(), C, E.data(), m*n, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
     if (msg.size() > 0) {
         FAIL() << msg;
     }
@@ -173,7 +173,7 @@ void verify_orthonormal_componentwise(int m, int n, T* Q, T max_cond = 10) {
     T tol = max_cond * std::sqrt(m) * std::numeric_limits<T>::epsilon();
     blas::gemm(blas::Layout::ColMajor, blas::Op::Trans, blas::Op::NoTrans, n, n, m, (T) 1.0, Q, m, Q, m, (T) 0.0, QtQ.data(), n);
     auto msg = RandBLAS::testing::matrices_approx_equal(blas::Layout::ColMajor, blas::Op::NoTrans, n, n, QtQ.data(), n, I.data(), n,
-        __PRETTY_FUNCTION__, __FILE__, __LINE__, tol, tol
+        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__, tol, tol
     );
     if (msg.size() > 0) {
         FAIL() << msg;
@@ -263,7 +263,7 @@ class TestHandrolledEigvals : public ::testing::Test {
         T tol = 1e-3;
         auto iter = RandBLAS::testing::posdef_eig_chol_iteration(n, A.data(), eigvals_actual.data(), tol, iters, b);
         ASSERT_EQ(iter, 0);
-        auto msg = RandBLAS::testing::buffs_approx_equal(eigvals_actual.data(), eigvals_expect.data(), n, __PRETTY_FUNCTION__, __FILE__, __LINE__,  tol, tol);
+        auto msg = RandBLAS::testing::buffs_approx_equal(eigvals_actual.data(), eigvals_expect.data(), n, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__,  tol, tol);
         if (msg.size() > 0) {
             FAIL() << msg;
         }
@@ -287,11 +287,11 @@ class TestHandrolledEigvals : public ::testing::Test {
         std::cout << "min_comp / min_actual " << min_eig_actual / eigvals_expect[n-1] << std::endl;
         std::cout << "max_comp / max_actual " << max_eig_actual / eigvals_expect[0] << std::endl;
         std::string msg;
-        msg = RandBLAS::testing::approx_equal(min_eig_actual, eigvals_expect[n-1], __PRETTY_FUNCTION__, __FILE__, __LINE__,  tol, tol);
+        msg = RandBLAS::testing::approx_equal(min_eig_actual, eigvals_expect[n-1], RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__,  tol, tol);
         if (msg.size() > 0) {
             FAIL() << msg;
         }
-        msg = RandBLAS::testing::approx_equal(max_eig_actual, eigvals_expect[0  ], __PRETTY_FUNCTION__, __FILE__, __LINE__,  tol, tol);
+        msg = RandBLAS::testing::approx_equal(max_eig_actual, eigvals_expect[0  ], RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__,  tol, tol);
         if (msg.size() > 0) {
             FAIL() << msg;
         }
@@ -321,11 +321,11 @@ class TestHandrolledEigvals : public ::testing::Test {
         std::cout << "min_comp / min_actual = " << lambda_min / eigvals_expect[n-1] << std::endl;
         std::cout << "max_comp / max_actual = " << lambda_max / eigvals_expect[0] << std::endl;
         std::string msg;
-        msg = RandBLAS::testing::approx_equal(lambda_min, eigvals_expect[n-1], __PRETTY_FUNCTION__, __FILE__, __LINE__,  tol, tol);
+        msg = RandBLAS::testing::approx_equal(lambda_min, eigvals_expect[n-1], RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__,  tol, tol);
         if (msg.size() > 0) {
             FAIL() << msg;
         }
-        msg = RandBLAS::testing::approx_equal(lambda_max, eigvals_expect[0  ], __PRETTY_FUNCTION__, __FILE__, __LINE__,  tol, tol);
+        msg = RandBLAS::testing::approx_equal(lambda_max, eigvals_expect[0  ], RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__,  tol, tol);
         if (msg.size() > 0) {
             FAIL() << msg;
         }

--- a/test/meta/test_lapack_like.cc
+++ b/test/meta/test_lapack_like.cc
@@ -49,7 +49,7 @@ class TestHandrolledCholesky : public ::testing::Test {
         RandBLAS::symmetrize(layout, blas::Uplo::Upper, n, A.data(), n);
 
         auto msg = RandBLAS::testing::matrices_approx_equal(layout, blas::Op::NoTrans, n, n, B.data(), n, A.data(), n,
-            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+            __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -83,7 +83,7 @@ class TestHandrolledCholesky : public ::testing::Test {
         }
         RandBLAS::testing::potrf_upper(n, A.data(), n, b);
         auto msg = RandBLAS::testing::matrices_approx_equal(layout, blas::Op::NoTrans, n, n, B.data(), n, A.data(), n,
-            RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__
+            __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__
         );
         if (msg.size() > 0) {
             FAIL() << msg;
@@ -157,7 +157,7 @@ void verify_product(int64_t m, int64_t n, int64_t k, const T* A, const T* B, con
     vector<T> E(m*n, 0.0);
     T err_alpha = 2 * k * std::numeric_limits<T>::epsilon();
     blas::gemm(blas::Layout::ColMajor, blas::Op::NoTrans, blas::Op::NoTrans, m, n, k, err_alpha, A_copy.data(), lda, B_copy.data(), ldb, (T)0.0, E.data(), m);
-    auto msg = RandBLAS::testing::buffs_approx_equal(C_work.data(), C, E.data(), m*n, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__);
+    auto msg = RandBLAS::testing::buffs_approx_equal(C_work.data(), C, E.data(), m*n, __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__);
     if (msg.size() > 0) {
         FAIL() << msg;
     }
@@ -173,7 +173,7 @@ void verify_orthonormal_componentwise(int m, int n, T* Q, T max_cond = 10) {
     T tol = max_cond * std::sqrt(m) * std::numeric_limits<T>::epsilon();
     blas::gemm(blas::Layout::ColMajor, blas::Op::Trans, blas::Op::NoTrans, n, n, m, (T) 1.0, Q, m, Q, m, (T) 0.0, QtQ.data(), n);
     auto msg = RandBLAS::testing::matrices_approx_equal(blas::Layout::ColMajor, blas::Op::NoTrans, n, n, QtQ.data(), n, I.data(), n,
-        RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__, tol, tol
+        __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__, tol, tol
     );
     if (msg.size() > 0) {
         FAIL() << msg;
@@ -263,7 +263,7 @@ class TestHandrolledEigvals : public ::testing::Test {
         T tol = 1e-3;
         auto iter = RandBLAS::testing::posdef_eig_chol_iteration(n, A.data(), eigvals_actual.data(), tol, iters, b);
         ASSERT_EQ(iter, 0);
-        auto msg = RandBLAS::testing::buffs_approx_equal(eigvals_actual.data(), eigvals_expect.data(), n, RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__,  tol, tol);
+        auto msg = RandBLAS::testing::buffs_approx_equal(eigvals_actual.data(), eigvals_expect.data(), n, __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__,  tol, tol);
         if (msg.size() > 0) {
             FAIL() << msg;
         }
@@ -287,11 +287,11 @@ class TestHandrolledEigvals : public ::testing::Test {
         std::cout << "min_comp / min_actual " << min_eig_actual / eigvals_expect[n-1] << std::endl;
         std::cout << "max_comp / max_actual " << max_eig_actual / eigvals_expect[0] << std::endl;
         std::string msg;
-        msg = RandBLAS::testing::approx_equal(min_eig_actual, eigvals_expect[n-1], RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__,  tol, tol);
+        msg = RandBLAS::testing::approx_equal(min_eig_actual, eigvals_expect[n-1], __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__,  tol, tol);
         if (msg.size() > 0) {
             FAIL() << msg;
         }
-        msg = RandBLAS::testing::approx_equal(max_eig_actual, eigvals_expect[0  ], RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__,  tol, tol);
+        msg = RandBLAS::testing::approx_equal(max_eig_actual, eigvals_expect[0  ], __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__,  tol, tol);
         if (msg.size() > 0) {
             FAIL() << msg;
         }
@@ -321,11 +321,11 @@ class TestHandrolledEigvals : public ::testing::Test {
         std::cout << "min_comp / min_actual = " << lambda_min / eigvals_expect[n-1] << std::endl;
         std::cout << "max_comp / max_actual = " << lambda_max / eigvals_expect[0] << std::endl;
         std::string msg;
-        msg = RandBLAS::testing::approx_equal(lambda_min, eigvals_expect[n-1], RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__,  tol, tol);
+        msg = RandBLAS::testing::approx_equal(lambda_min, eigvals_expect[n-1], __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__,  tol, tol);
         if (msg.size() > 0) {
             FAIL() << msg;
         }
-        msg = RandBLAS::testing::approx_equal(lambda_max, eigvals_expect[0  ], RANDBLAS_TEST_FUNCTION_SIGNATURE, __FILE__, __LINE__,  tol, tol);
+        msg = RandBLAS::testing::approx_equal(lambda_max, eigvals_expect[0  ], __RANDBLAS_PRETTY_FUNCTION__, __FILE__, __LINE__,  tol, tol);
         if (msg.size() > 0) {
             FAIL() << msg;
         }


### PR DESCRIPTION
This pull should provide basic windows (MSVC) compatibility.

I got this running on a Surface Book 3 running Windows x64, MSVC 19.51, C++20.

The exact install information how to run this on Windows is shown in the install.md file.

Several changes had to be made to make this work. An LLM-Generated summary of the work is attached below.


---

# Native Windows portability notes

This document records the issues encountered while configuring RandBLAS natively on Windows with MSVC, CMake, NMake, standalone Intel oneMKL, BLAS++, and Random123.

Last fully audited against the working native-MSVC build and Windows CI:
2026-07-24.

## Observed issues

### 1. Fixed: installed RandBLAS config embedded Windows paths incorrectly

`CMake/RandBLASConfig.cmake.in` writes dependency paths directly into generated CMake code:

```cmake
set(blaspp_DIR @blaspp_DIR@)
set(Random123_DIR @Random123_DIR@)
```

When configured with ordinary Windows backslashes, a generated value such as
`C:\Users\...` contains CMake escape sequences (`\U`) and causes downstream
`find_package(RandBLAS)` to fail with `Invalid character escape '\U'`.

The current branch normalizes both dependency directories with
`file(TO_CMAKE_PATH ...)` before substitution and quotes the generated values.
The Windows downstream-consumer job deliberately configures RandBLAS with
native-backslash dependency paths and then loads the installed package without
re-supplying them, serving as a regression test for this fix.

The fix has been verified locally end to end with MSVC: RandBLAS was configured
using native-backslash dependency paths, installed into a temporary prefix,
and consumed using only that prefix. The downstream smoke target configured,
compiled, linked, and ran successfully. The generated config contained
normalized `C:/...` values. The subsequent GitHub-hosted downstream run also
passed.

### 2. Fixed: compiler flags use toolchain guards

The original `RandBLAS/CMakeLists.txt` added `-Wall`, `-Wextra`, and
`-Wno-comment` through the header-only interface target without a compiler
check. MSVC does not use these options. The current branch keeps that warning
set (including `-Wno-comment`) for GNU/Clang and uses `/W4` for MSVC.

The `SANITIZE_ADDRESS` path is now compiler-aware as well. GNU and Clang receive
`-fsanitize=address` at compilation and linking. MSVC receives
`/fsanitize=address` and `/Zi` as compile options, plus `/DEBUG` while linking,
after CMake verifies that the complete compiler/runtime setup supports it.
Unsupported compilers, or an MSVC
installation without the optional AddressSanitizer runtime libraries, fail
during configuration with a targeted explanation.

Raphael's current MSVC installation recognizes the switch but lacks
`clang_rt.asan_dynamic_runtime_thunk-x86_64.lib`, so the capability check
correctly rejects `-DSANITIZE_ADDRESS=ON`. A normal non-sanitized build remains
unaffected.

### 3. Fixed: examples included the POSIX-only `<unistd.h>` header

The following examples included `<unistd.h>` even though the header was not
used:

* `examples/total-least-squares/tls_dense_skop.cc`
* `examples/total-least-squares/tls_sparse_skop.cc`
* `examples/sparse-low-rank-approx/qrcp_matrixmarket.cc`
* `examples/sparse-low-rank-approx/svd_rank1_plus_noise.cc`
* `examples/sparse-low-rank-approx/svd_matrixmarket.cc`

The current branch removes all five unused includes. If a POSIX API becomes
necessary later, its include should instead be guarded by platform detection.

### 4. Open design question: example CMake requires OpenMP unconditionally

`examples/CMakeLists.txt` uses `find_package(OpenMP REQUIRED)`, whereas the core
RandBLAS build supports serial operation. Native MSVC OpenMP is now validated:
the installed RandBLAS package changes the imported OpenMP target to
`/openmp:experimental`, and the examples compile and run. The remaining design
question is whether examples should share the core optional-OpenMP behavior or
explicitly document OpenMP as a requirement.

### 5. Fixed: total-least-squares examples used variable-length arrays

The TLS examples declared stack arrays whose sizes depend on runtime values:

```cpp
double target_x[n*d];
double eps[m*d];
```

Variable-length arrays are not part of standard C++ and MSVC rejects them with
error C2131. The current branch replaces these arrays with
`std::vector<double>` and passes their storage through `.data()` to RandBLAS and
BLAS++.

### 6. Partially fixed: documentation and CI were Unix-centric

`INSTALL.md` and the examples documentation use `make`, shell backticks, and
Unix path conventions. `RAPHAEL_INSTRUCTION.md` now records the validated local
NMake recipe, but the project still has no general Windows installation guide.

The current branch adds native-MSVC jobs to the core, downstream-consumer, and
examples workflows. A Windows composite action provisions oneMKL through
vcpkg, then builds the remaining dependencies. A shared PowerShell driver makes
the substantive configure, build, test, and example commands runnable both in
GitHub Actions and on a local x64 Native Tools installation. Current results
are summarized under **Validation and CI status**.

The documentation and thread-sanitizer workflows remain Unix-only
intentionally. Documentation generation is platform-independent and receives
little additional signal from duplicating it on Windows. The available
Clang/GCC thread-sanitizer setup is not a native-MSVC facility. The CMake
AddressSanitizer flags are now compiler-aware; adding a Windows
AddressSanitizer job remains optional and would require a runner/toolchain with
the MSVC AddressSanitizer runtime installed.

### 7. Fixed for RandBLAS: upstream dependency portability remains

The downstream smoke test exposed additional portability issues:

* The current Random123 `boxmuller.hpp` fallback does not enable
  `R123_NO_SINCOS` for MSVC, so `sincosf` and `sincos` are undeclared. RandBLAS
  already supplies host `sincospif`/`sincospi` shims, but the Random123 fallback
  also needs to be enabled (or equivalent MSVC-safe wrappers need to be supplied).
* Upstream BLAS++ `include/blas/symv.hh` contains an unconditional diagnostic
  using `__PRETTY_FUNCTION__`, which MSVC does not define. The selected
  `windows-portability` branch removes that diagnostic.

The same build reported parser errors in the RandBLAS `uneg11` wrapper because
MSVC's legacy `__cplusplus` value hid Random123's C++11 templates. Supplying
`/Zc:__cplusplus` through the RandBLAS target resolved those errors; they were
not an independent RandBLAS parser defect.

The current branch exports `R123_NO_SINCOS=1` as an MSVC-only `INTERFACE`
definition on the `RandBLAS` target. This provides a scoped downstream fix
without modifying the Random123 checkout. Random123 should still detect MSVC
itself upstream so direct Random123 consumers receive the same fallback.
RandBLAS's test diagnostics now use the descriptive
`__RANDBLAS_PRETTY_FUNCTION__` macro from
`RandBLAS/testing/comparison.hh`. It expands to `__FUNCSIG__` under MSVC,
`__PRETTY_FUNCTION__` under GNU/Clang, and the standard `__func__` fallback
elsewhere. This keeps the compiler extension inside the test helper and removes
the former `__PRETTY_FUNCTION__=__FUNCSIG__` definition from the exported
RandBLAS target.

### 8. Fixed: MSVC must report the selected standard in `__cplusplus`

MSVC historically reports `__cplusplus` as `199711L` even when compiling with
`/std:c++20`. Random123 uses `__cplusplus >= 201103L` to expose C++11 facilities
such as `uneg11all`. Without `/Zc:__cplusplus`, the template is hidden and
RandBLAS later fails while parsing `r123::uneg11all<T>`.

The current branch adds `/Zc:__cplusplus` and `/EHsc` as compiler-conditioned
`INTERFACE` options on the header-only `RandBLAS` CMake target. They therefore
apply both to the source-tree tests and to consumers of the installed package,
without affecting non-MSVC compilers. Together with the MSVC-only compile
definition for Random123, RandBLAS-related configure commands no
longer require custom `CMAKE_CXX_FLAGS`.

Exporting `/EHsc` from the target also preserves normal C++ exception-unwind
semantics if a caller replaces CMake's default `CMAKE_CXX_FLAGS` for unrelated
reasons.

### 9. Fixed for MSVC: `omp simd` requires experimental OpenMP mode

The full test build reaches `RandBLAS/sparse_data/csr_spmm_impl.hh`, which uses
`#pragma omp simd`. MSVC reports:

```text
error C7660: 'simd': requires '-openmp:experimental' command line option(s)
```

The current branch applies `/openmp:experimental` automatically when MSVC is
detected, both while building RandBLAS from source (`CMake/OpenMP.cmake`) and
when an installed package is loaded (`CMake/RandBLASConfig.cmake.in`). No
`OpenMP_CXX_FLAGS` command-line setting is required. Other compiler families
retain CMake's normal OpenMP discovery.

This is compiler-specific rather than a universal Windows requirement.
GCC/MinGW, Clang, and Intel compilers use different OpenMP options and runtimes.
A more general future implementation could probe support for `omp simd` and
fall back to an ordinary correctness-preserving loop when SIMD OpenMP is
unavailable, rather than selecting solely by the `MSVC` compiler ID.

### 10. Resolved configuration: full tests require ILP64 BLAS++

An LP64 BLAS++ build reaches the sparse GEMM tests and then fails when they
instantiate 64-bit (`int64_t`) sparse indices:

```text
static assertion failed: 'RandBLAS::spgemm: first sparse matrix index type must match MKL_INT size.'
```

With oneMKL LP64 (`mkl_intel_lp64_dll.lib`),
`MKL_INT` is 32-bit. RandBLAS's MKL sparse backend requires sparse index types
to have the same size as `MKL_INT`; the tests use 64-bit indices. This is a
configuration mismatch, not an MSVC parser failure.

The canonical Windows recipe therefore uses one ILP64 BLAS++ installation
(`mkl_intel_ilp64_dll.lib`, `blas_int=ilp64`) for tests, installation, smoke
validation, and examples. A separate LP64 installation is unnecessary for this
workflow, though LP64 remains valid for consumers using 32-bit BLAS indices.

MSVC also warns that the `reduction` clause on the SIMD directive is ignored
and reports that the loop was not vectorized. These are performance warnings;
the test build proceeds, but the MSVC SIMD path is not currently providing the
same optimization as GCC/Clang. Follow-up work should check compiler
vectorization reports (and, if relevant, benchmarks) on the Linux and Apple
builds as well, and ask the maintainers whether the CSR loop is expected to
vectorize there. The MSVC warning alone does not establish that the non-Windows
builds are vectorizing successfully.

### 11. Fixed: imported runtime DLLs were unavailable during test discovery

GoogleTest discovery executes each test binary immediately after linking. If
the Windows loader cannot find a dependency, the build fails with exit code
`0xc0000135` even though compilation and linking succeeded.

The Windows-only `randblas_stage_runtime_dlls` helper now copies
`$<TARGET_RUNTIME_DLLS:target>` beside every repository-owned test,
downstream-smoke, and example executable. Test targets invoke the helper before
`gtest_discover_tests`, so the DLLs are present before post-build discovery.
The transitive CMake target data selects the configured BLAS++ and LAPACK++
DLLs without hardcoded filenames or installation paths.

`TARGET_RUNTIME_DLLS` requires CMake 3.21, so native Windows configurations now
reject older CMake releases with a clear diagnostic. The local recipe uses
`cmake --fresh`, which separately requires CMake 3.24; the validated machine
has CMake 3.29.2. Non-Windows builds retain the project's earlier minimum.

oneMKL remains separate: BLAS++ exports MKL as raw `.lib` paths rather than
imported shared-library targets, so CMake cannot infer the corresponding MKL
DLLs. Continue activating the installer-provided oneMKL environment before
configuring, building, or running. No additional RandBLAS runtime `PATH`
wrapper is required. The helper serves repository-owned build-tree executables;
it does not deploy dependencies for arbitrary installed-package consumers.

## Selected dependency revisions

The Windows jobs use vcpkg's `intel-mkl:x64-windows` port and build shared,
sequential, ILP64 BLAS++ against its raw oneMKL libraries. Random123 remains a
header-only dependency. Until the corresponding changes are upstream, CI uses:

* `RaphaelArkadyMeyerNYU/blaspp`, branch `windows-portability`;
* `RaphaelArkadyMeyerNYU/lapackpp`, branch `msvc-compatibility`.

These branches contain the BLAS++ diagnostic removal and LAPACK++ direct-include
fixes. The Actions setup performs ordinary clone, configure, build, and install
steps; it does not rewrite dependency sources or inject compatibility macros.

## Validation and CI status

The Windows workflow coverage is:

* `core.yml`: MSVC/oneMKL ILP64 Release builds with OpenMP enabled and
  disabled, plus a serial AddressSanitizer build. The OpenMP job runs the suite
  with one and four threads; the sanitizer job configures through
  `-DSANITIZE_ADDRESS=ON` and runs the full serial suite under MSVC ASan.
* `downstream-consumer.yml`: installs RandBLAS, then configures, builds, and
  runs the smoke consumer without re-supplying `blaspp_DIR` or
  `Random123_DIR`.
* `examples.yml`: builds LAPACK++, RandBLAS, and all seven examples. Like the
  Linux examples job, it does not execute them.

The previously hosted core, examples, and downstream jobs pass, including clean
vcpkg provisioning. The first Windows AddressSanitizer run reached the link
step and exposed an MSVC STL-annotation mismatch: RandBLAS was instrumented,
but the cached GoogleTest libraries were not. The dependency action now gives
the sanitizer job a separately instrumented and separately cached GoogleTest
installation; that correction is pending its hosted run. The downstream job
permanently exercises native-backslash configure/install/consume behavior and
runs `smoke.exe`.

Additional local validation includes 459/459 OpenMP tests, 455/455 serial tests
(the other four are OpenMP-specific), and manual execution of all seven
examples. The file-based examples used a temporary 80-by-80 Matrix Market
input. The Actions workflows intentionally stop after building the examples.

The composite dependency action is
`.github/actions/setup-randblas-deps-windows/action.yml`; its shared local and
hosted driver is `.github/scripts/windows/run-ci.ps1`. The workflows pass
`actionlint`, YAML parsing, and PowerShell parsing locally.

## Appendix: GitHub Issues

The following drafts capture the remaining upstream work and the RandBLAS
memory-safety fix. They are intentionally self-contained so they can be filed
with minimal editing; historical reproduction flags in an issue body are not
part of the current RandBLAS build recipe.

### A. Random123: MSVC host compilation fails in `boxmuller.hpp`

**Title:** MSVC compilation fails because `boxmuller.hpp` does not enable the `sincos` fallback

**Body:**

When Random123 is included in a native Windows/MSVC C++20 project, compiling
`Random123/boxmuller.hpp` fails with:

```text
error C3861: 'sincosf': identifier not found
error C3861: 'sincos': identifier not found
```

The header provides fallback definitions guarded by `R123_NO_SINCOS`, but the
macro is enabled automatically only for `__APPLE__`. MSVC does not provide the
POSIX `sincos`/`sincosf` functions, so the fallback is also needed there.

Suggested fix: enable `R123_NO_SINCOS` for MSVC (or for host compilers known not
to provide these functions), or use a portable compiler-specific wrapper based
on `std::sin` and `std::cos`. A minimal downstream workaround is to compile
with `R123_NO_SINCOS=1`.

Environment tested: Windows x64, MSVC 19.51, C++20, Random123 headers from the
current repository, standalone Intel oneMKL/BLAS++ consumer.

### B. BLAS++: MSVC compilation fails on `__PRETTY_FUNCTION__`

**Title:** `blas/symv.hh` uses the nonportable `__PRETTY_FUNCTION__` macro on MSVC

**Body:**

Native MSVC compilation of a downstream BLAS++ consumer fails in
`include/blas/symv.hh`:

```text
error C3861: '__PRETTY_FUNCTION__': identifier not found
error C2065: '__PRETTY_FUNCTION__': undeclared identifier
```

The function currently contains:

```cpp
printf("%s: %s\n", __func__, __PRETTY_FUNCTION__);
```

`__PRETTY_FUNCTION__` is a GCC/Clang extension. MSVC provides `__FUNCSIG__` as
its closest equivalent. Since this appears to be an unconditional diagnostic
print in a public header, the preferred fix may simply be to remove the debug
print. Otherwise, BLAS++ should define a portable function-signature macro and
map it to `__FUNCSIG__` on MSVC.

Environment tested: Windows x64, MSVC 19.51, C++20, BLAS++ built with NMake,
standalone Intel oneMKL, downstream RandBLAS smoke test.

### C. LAPACK++: missing direct includes break the native MSVC build

**Title:** MSVC build fails because `config.h` and `lartg.cc` rely on transitive standard-library includes

**Body:**

Building LAPACK++ natively with MSVC fails in the ILP64 configuration with
diagnostics beginning with:

```text
include/lapack/config.h(20): error C4430: missing type specifier
include/lapack/config.h(20): error C2146: missing ';' before identifier 'lapack_int'
include/lapack/fortran.h(35): error C2065: 'LAPACK_S_SELECT2': undeclared identifier
src/lartg.cc(36): error C2039: 'complex': is not a member of 'std'
```

There appear to be two independent missing direct includes:

1. `include/lapack/config.h` uses global `int64_t` when `LAPACK_ILP64` is
   enabled, but does not include `<stdint.h>`. Some Unix standard-library
   headers expose this type transitively; MSVC's `<stdlib.h>` does not.
2. `src/lartg.cc` uses `std::complex` but does not include `<complex>`. Under
   MSVC, the `_MSC_VER` branch in `lapack/config.h` defines C-compatible complex
   structs and does not include the C++ `<complex>` header.

The `LAPACK_S_SELECT2` and related callback errors appear to cascade from the
failed `lapack_int` typedef. The minimal source fixes are:

```cpp
// include/lapack/config.h
#include <stdint.h>
```

```cpp
// src/lartg.cc
#include <complex>
```

These headers should be included directly rather than relying on transitive
implementation details of a particular C or C++ standard library.

Environment tested: Windows x64, MSVC 19.51, C++17, LAPACK++ version
2025.05.28 (commit `8b32767`), NMake generator, BLAS++/oneMKL ILP64 sequential
configuration.

### D. RandBLAS: off-by-`k` workspace offset corrupts the heap in sparse SVD examples

**Title:** Sparse SVD examples write past the `qb_to_svd` workspace allocation

**Body:**

Running the synthetic sparse low-rank approximation example can terminate with
heap corruption during the conversion of a QB factorization to an SVD. A
native Windows/MSVC reproduction is:

```text
slra_svd_synthetic.exe 200 100 4
16
13333
13338
Exit code 0xc0000374
```

The `qb_to_svd` implementations in both
`examples/sparse-low-rank-approx/svd_rank1_plus_noise.cc` and
`examples/sparse-low-rank-approx/svd_matrixmarket.cc` divide a caller-provided
workspace into two regions. The first `k*k` elements hold `U`, and the next
`m*k` elements hold a temporary copy of `Q`. The available second-region size
is correspondingly calculated as:

```cpp
int64_t extra_work_size = lwork - k*k;
```

However, the second region begins at `work + k*(k+1)`. When the caller supplies
the documented/expected `k*k + m*k` elements, only `m*k - k` elements remain
at that address, and `lapack::lacpy` writes `k` elements beyond the allocation.
For the reproduction above, this is an overrun of four doubles.

The offset should be:

```cpp
T* more_work = work + k*k;
```

The same correction is needed in both example files. After applying it and
rebuilding, the synthetic example completes normally and reports small angles
between the recovered and reference singular vectors.

Although Windows heap validation exposed the error as status `0xc0000374`, the
out-of-bounds write is cross-platform and may silently corrupt memory on other
systems.

Environment tested: Windows x64, MSVC 19.51, C++20, NMake generator,
LAPACK++/BLAS++ with standalone Intel oneMKL ILP64 sequential libraries.
